### PR TITLE
feat(#126): add Codecov upload to CI and coverage badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
           path: cover.out
           retention-days: 14
 
+      - name: upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./cover.out
+          fail_ci_if_error: false
+
   headless-e2e:
     name: headless e2e (dry-run)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Knuckle
 
+[![codecov](https://codecov.io/gh/projectbluefin/knuckle/graph/badge.svg)](https://codecov.io/gh/projectbluefin/knuckle)
+
 A modern, interactive TUI "installer" for [Flatcar Container Linux](https://www.flatcar.org/), designed for bare-metal deployments. Not a real installer because making one would be dumb. There's no reason to make a "Bluefin Server" if Bluefin just gives you a nice tool to use Flatcar. 
 
 Knuckle is a charm.sh form that makes a valid ignition file and passes it to the Flatcat installer. We're just making users not have to use ignition, with an ubuntu-server style install UX. 


### PR DESCRIPTION
## Summary

Closes #126.

Two minimal changes, both based directly on `upstream/main` (`1895c29`):

### 1. Codecov upload in CI (`.github/workflows/ci.yml`)

Adds a `codecov/codecov-action@v5` step to the existing `coverage` job, immediately after the aggregate `cover.out` is generated:

```yaml
- name: upload coverage to Codecov
  uses: codecov/codecov-action@v5
  with:
    files: ./cover.out
    fail_ci_if_error: false
```

`fail_ci_if_error: false` ensures Codecov outages never block merges.

Once a maintainer connects the repo on [codecov.io](https://codecov.io), every PR will automatically get:
- A coverage diff comment showing which lines a PR adds without tests
- Historical trend graphs

### 2. Coverage badge in `README.md`

```md
[![codecov](https://codecov.io/gh/projectbluefin/knuckle/graph/badge.svg)](https://codecov.io/gh/projectbluefin/knuckle)
```

The badge will show 'unknown' until the first CI run uploads data, then display the live percentage.

## No functional changes

No production code, test logic, or gates are modified.

---
*Filed by Antigravity agent on behalf of hanthor*