### PR TITLE
fix: batch 1 — validation consistency across entry points

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projectbluefin/knuckle/internal/probe"
 	"github.com/projectbluefin/knuckle/internal/runner"
 	"github.com/projectbluefin/knuckle/internal/tui"
+	"github.com/projectbluefin/knuckle/internal/validate"
 	"github.com/projectbluefin/knuckle/internal/wizard"
 )
 
@@ -34,7 +35,7 @@ func main() {
 	)
 	flag.BoolVar(&dryRun, "dry-run", false, "simulate installation without writing to disk")
 	flag.StringVar(&logFile, "log-file", "/tmp/knuckle.log", "path to log file")
-	flag.StringVar(&channel, "channel", "stable", "Flatcar release channel (stable, beta, alpha, edge)")
+	flag.StringVar(&channel, "channel", "stable", "Flatcar release channel (stable, beta, alpha, lts, edge)")
 	flag.BoolVar(&showVer, "version", false, "print version and exit")
 	flag.StringVar(&configFile, "config", "", "path to JSON config file for headless install")
 	flag.BoolVar(&headlessMode, "headless", false, "run without TUI (requires --config)")
@@ -58,9 +59,8 @@ func main() {
 	}
 
 	// Validate channel flag
-	validChannels := map[string]bool{"stable": true, "beta": true, "alpha": true, "edge": true}
-	if !validChannels[channel] {
-		fmt.Fprintf(os.Stderr, "Error: invalid channel %q (must be stable, beta, alpha, or edge)\n", channel)
+	if err := validate.Channel(channel); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/projectbluefin/knuckle/internal/validate"
 )
 
 // KeyFetcher fetches SSH public keys for a user.
@@ -34,6 +36,9 @@ func NewClient() *Client {
 func (c *Client) FetchKeys(ctx context.Context, username string) ([]string, error) {
 	if username == "" {
 		return nil, fmt.Errorf("empty GitHub username")
+	}
+	if err := validate.GitHubUsername(username); err != nil {
+		return nil, err
 	}
 
 	url := fmt.Sprintf("%s/%s.keys", c.BaseURL, username)

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -188,6 +188,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Version
+	if err := validate.FlatcarVersion(c.Version); err != nil {
+		return fmt.Errorf("version: %w", err)
+	}
+
 	// Hostname
 	if c.Hostname != "" {
 		if err := validate.Hostname(c.Hostname); err != nil {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -12,11 +12,13 @@ import (
 
 // Compiled regex patterns — evaluated once at init to catch malformed patterns early.
 var (
-	reHostname      = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
-	reUsername      = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	reTimezone      = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_/+-]*$`)
-	reGroupName     = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
-	reInterfaceName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	reHostname       = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`)
+	reUsername       = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	reTimezone       = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_/+-]*$`)
+	reGroupName      = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+	reInterfaceName  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	reGitHubUsername = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
+	reFlatcarVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 )
 
 // Hostname validates a Linux hostname (RFC 1123).
@@ -259,6 +261,37 @@ func CheckConsistency(cfg *model.InstallConfig) error {
 		}
 	}
 
+	return nil
+}
+
+// GitHubUsername validates a GitHub username.
+// GitHub rules: 1-39 chars, alphanumeric and hyphens, no consecutive hyphens,
+// cannot start or end with a hyphen.
+func GitHubUsername(s string) error {
+	if s == "" {
+		return fmt.Errorf("GitHub username cannot be empty")
+	}
+	if len(s) > 39 {
+		return fmt.Errorf("GitHub username too long (max 39 characters)")
+	}
+	if !reGitHubUsername.MatchString(s) {
+		return fmt.Errorf("invalid GitHub username %q: must be alphanumeric with hyphens, cannot start or end with a hyphen", s)
+	}
+	if strings.Contains(s, "--") {
+		return fmt.Errorf("invalid GitHub username %q: consecutive hyphens not allowed", s)
+	}
+	return nil
+}
+
+// FlatcarVersion validates a pinned Flatcar version string.
+// Must be empty (latest) or in MAJOR.MINOR.PATCH format.
+func FlatcarVersion(s string) error {
+	if s == "" {
+		return nil // empty = use latest
+	}
+	if !reFlatcarVersion.MatchString(s) {
+		return fmt.Errorf("invalid Flatcar version %q: must be MAJOR.MINOR.PATCH (e.g. 3510.2.8)", s)
+	}
 	return nil
 }
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -519,3 +519,60 @@ func TestCheckConsistency(t *testing.T) {
 		})
 	}
 }
+
+func TestGitHubUsername(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid simple", "torvalds", false},
+		{"valid with hyphen", "john-doe", false},
+		{"valid with numbers", "user123", false},
+		{"valid single char", "a", false},
+		{"valid max length 39", strings.Repeat("a", 39), false},
+		{"empty", "", true},
+		{"too long 40", strings.Repeat("a", 40), true},
+		{"leading hyphen", "-user", true},
+		{"trailing hyphen", "user-", true},
+		{"consecutive hyphens", "john--doe", true},
+		{"contains underscore", "user_name", true},
+		{"contains dot", "user.name", true},
+		{"contains space", "user name", true},
+		{"contains slash", "user/name", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GitHubUsername(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitHubUsername(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFlatcarVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty is latest", "", false},
+		{"valid semver", "3510.2.8", false},
+		{"valid zeros", "0.0.0", false},
+		{"valid large", "9999.99.99", false},
+		{"missing patch", "3510.2", true},
+		{"with v prefix", "v3510.2.8", true},
+		{"alpha string", "latest", true},
+		{"extra segment", "3510.2.8.1", true},
+		{"leading dot", ".3510.2.8", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FlatcarVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FlatcarVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -160,7 +160,7 @@ func (w *Wizard) validateWelcome() error {
 		return err
 	}
 	if w.State.Config.IgnitionURL != "" {
-		if err := validate.URL(w.State.Config.IgnitionURL); err != nil {
+		if err := validate.IgnitionURL(w.State.Config.IgnitionURL); err != nil {
 			return fmt.Errorf("ignition URL: %w", err)
 		}
 	}

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -9,7 +9,7 @@
 #   Ubuntu:  sudo apt-get install -y xorriso mtools cpio systemd-boot-efi
 #   Fedora:  sudo dnf install -y xorriso mtools cpio systemd-boot-unsigned
 #
-# Usage: ./scripts/build-iso.sh [--channel stable|beta|alpha|lts] [--arch amd64|arm64] [--binary /path/to/knuckle]
+# Usage: ./scripts/build-iso.sh [--channel stable|beta|alpha|lts|edge] [--arch amd64|arm64] [--binary /path/to/knuckle]
 set -euo pipefail
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
         --arch)      ARCH="$2"; shift 2 ;;
         --binary=*)  BINARY_OVERRIDE="${1#--binary=}"; shift ;;
         --binary)    BINARY_OVERRIDE="$2"; shift 2 ;;
-        stable|beta|alpha|lts) CHANNEL="$1"; shift ;;
+        stable|beta|alpha|lts|edge) CHANNEL="$1"; shift ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;
     esac
 done
@@ -34,6 +34,10 @@ done
 if [[ "$ARCH" != "amd64" && "$ARCH" != "arm64" ]]; then
     echo "error: --arch must be amd64 or arm64 (got '$ARCH')" >&2; exit 1
 fi
+case "$CHANNEL" in
+    stable|beta|alpha|lts|edge) ;;
+    *) echo "error: --channel must be stable, beta, alpha, lts, or edge (got '$CHANNEL')" >&2; exit 1 ;;
+esac
 if [[ "$ARCH" == "arm64" && "$CHANNEL" == "lts" ]]; then
     echo "error: LTS channel is not available for arm64" >&2; exit 1
 fi


### PR DESCRIPTION
Five low-effort fixes closing five security/correctness findings:

- wizard.go: use validate.IgnitionURL() instead of validate.URL() so http:// Ignition URLs are rejected in the TUI path, matching the headless path (closes #129)

- cmd/knuckle/main.go: delegate --channel flag validation to validate.Channel() — the hardcoded map omitted 'lts', causing 'knuckle --channel=lts' to fail with a misleading error (closes #144)

- internal/validate: add GitHubUsername() (GitHub name rules: 1-39 chars, alphanumeric + hyphens, no leading/trailing/consecutive hyphens) and FlatcarVersion() (empty = latest, otherwise N.N.N)

- internal/github: call validate.GitHubUsername() before constructing the keys URL — prevents path traversal via crafted usernames (closes #135)

- internal/headless: call validate.FlatcarVersion() in Validate() — rejects non-semver version strings before they are interpolated into download URLs (closes #140)

- scripts/build-iso.sh: add case statement to reject unknown --channel values passed via the flag path; the positional-arg path already had this check (closes #142)

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified validation logic for channels, GitHub usernames, Flatcar versions, and ignition URLs across the application with improved consistency and clearer error feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->