### PR TITLE
refactor: move business logic out of onFormComplete into wizard package

### DIFF
--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectbluefin/knuckle/internal/github"
 	"github.com/projectbluefin/knuckle/internal/model"
 	"github.com/projectbluefin/knuckle/internal/validate"
+	"github.com/projectbluefin/knuckle/internal/wizard"
 )
 
 // initForm sets up the huh form for form-based steps.
@@ -72,61 +73,32 @@ func (m *Model) onFormComplete() tea.Cmd {
 		}
 
 	case model.StepNetwork:
-		if m.dnsInput != "" {
-			cfg.Network.DNS = strings.Split(m.dnsInput, ",")
-		}
-		if m.networkModeInput == "static" {
-			cfg.Network.Mode = model.NetworkStatic
-		} else {
-			cfg.Network.Mode = model.NetworkDHCP
-		}
+		m.Wizard.ApplyNetworkStep(wizard.NetworkStepInput{
+			Mode: m.networkModeInput,
+			DNS:  m.dnsInput,
+		})
 
 	case model.StepUser:
-		// Apply username
-		if m.usernameInput != "" {
-			if len(cfg.Users) == 0 {
-				cfg.Users = append(cfg.Users, model.UserConfig{
-					Username: m.usernameInput,
-					Groups:   []string{"sudo", "docker"},
-				})
-			} else {
-				cfg.Users[0].Username = m.usernameInput
-			}
+		if err := m.Wizard.ApplyUserStep(wizard.UserStepInput{
+			Username:  m.usernameInput,
+			Password:  m.passwordInput,
+			ManualKey: m.sshKeyInput,
+			LocalKeys: detectLocalSSHKeys(),
+			Hostname:  cfg.Hostname,
+			Timezone:  cfg.Timezone,
+		}); err != nil {
+			m.err = err
+			m.initForm()
+			return m.activeForm.Init()
 		}
-		// Apply password
-		if m.passwordInput != "" && len(cfg.Users) > 0 {
-			hash, err := hashPassword(m.passwordInput)
-			if err != nil {
-				m.err = err
-				m.initForm()
-				return m.activeForm.Init()
-			}
-			cfg.Users[0].PasswordHash = hash
-		}
-		// Apply SSH key (manual input + local host keys)
-		manualKeys := splitSSHKeys(m.sshKeyInput)
-		localKeys := detectLocalSSHKeys()
-		allKeys := mergeKeys(localKeys, manualKeys)
-		if len(allKeys) > 0 {
-			cfg.SSHKeys = allKeys
-			if len(cfg.Users) > 0 {
-				cfg.Users[0].SSHKeys = allKeys
-			}
-		}
-		// Async GitHub key fetch (merges with local keys on return)
+		// Async GitHub key fetch (merges with local + manual keys on return)
 		if m.githubUserInput != "" {
 			m.fetching = true
-			username := m.githubUserInput
-			// Strip @ prefix if present
-			username = strings.TrimPrefix(username, "@")
+			username := strings.TrimPrefix(m.githubUserInput, "@")
 			return func() tea.Msg {
 				keys, err := github.FetchKeys(username)
 				return fetchKeysMsg{keys: keys, err: err}
 			}
-		}
-		// Apply timezone
-		if cfg.Timezone == "" {
-			cfg.Timezone = "UTC"
 		}
 
 	case model.StepReview:

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -14,8 +14,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/projectbluefin/knuckle/internal/bakery"
 	"github.com/projectbluefin/knuckle/internal/github"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -189,23 +187,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = fmt.Errorf("%w — edit the username and press Enter to retry, or clear it and add an SSH key or password instead", msg.err)
 			return m, nil
 		}
-		cfg := &m.Wizard.State.Config
-		// Merge GitHub keys with local host keys AND manual keys (deduped)
-		allKeys := mergeKeys(detectLocalSSHKeys(), splitSSHKeys(m.sshKeyInput), msg.keys)
-		cfg.SSHKeys = allKeys
-		if len(cfg.Users) > 0 {
-			cfg.Users[0].SSHKeys = allKeys
-		}
-		// Guard: don't advance if we have no authentication method at all.
-		// This catches the case where GitHub returned 0 keys and no other auth is set.
-		hasAuth := len(allKeys) > 0
-		for _, u := range cfg.Users {
-			if u.PasswordHash != "" {
-				hasAuth = true
-				break
-			}
-		}
-		if !hasAuth {
+		m.Wizard.ApplyGitHubKeys(msg.keys, detectLocalSSHKeys(), m.sshKeyInput)
+		if !m.Wizard.HasAnyAuthentication() {
 			m.err = fmt.Errorf("no SSH keys found — add a key manually, set a password, or use a GitHub user with public keys")
 			return m, nil
 		}
@@ -1264,30 +1247,12 @@ func Run(w *wizard.Wizard, rebootFn func(context.Context) error) error {
 	return err
 }
 
-// hashPassword generates a bcrypt hash suitable for Ignition passwd field.
-func hashPassword(plain string) (string, error) {
-	if len(plain) > 72 {
-		return "", fmt.Errorf("password too long (max 72 bytes for bcrypt)")
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
-	if err != nil {
-		return "", fmt.Errorf("hashing password: %w", err)
-	}
-	return string(hash), nil
-}
+// hashPassword is a thin wrapper around wizard.HashPassword kept so existing
+// TUI tests/usages don't churn; new code should call wizard.HashPassword.
+func hashPassword(plain string) (string, error) { return wizard.HashPassword(plain) }
 
-// splitSSHKeys splits SSH keys by semicolons and trims whitespace.
-func splitSSHKeys(input string) []string {
-	parts := strings.Split(input, ";")
-	var keys []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			keys = append(keys, p)
-		}
-	}
-	return keys
-}
+// splitSSHKeys is a thin wrapper around wizard.SplitSSHKeys.
+func splitSSHKeys(input string) []string { return wizard.SplitSSHKeys(input) }
 
 // detectLocalSSHKeys finds SSH public keys on the installer host.
 // Checks ~/.ssh/*.pub for common key types.
@@ -1315,17 +1280,5 @@ func detectLocalSSHKeys() []string {
 	return keys
 }
 
-// mergeKeys combines two key slices, deduplicating by key content.
-func mergeKeys(sources ...[]string) []string {
-	seen := make(map[string]bool)
-	var result []string
-	for _, src := range sources {
-		for _, k := range src {
-			if !seen[k] {
-				seen[k] = true
-				result = append(result, k)
-			}
-		}
-	}
-	return result
-}
+// mergeKeys is a thin wrapper around wizard.MergeSSHKeys.
+func mergeKeys(sources ...[]string) []string { return wizard.MergeSSHKeys(sources...) }

--- a/internal/wizard/apply.go
+++ b/internal/wizard/apply.go
@@ -1,0 +1,179 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// UserStepInput is the raw collected input from the User step form.
+// LocalKeys are SSH public keys already discovered on the installer host
+// (the TUI calls detectLocalSSHKeys()); the wizard merges them with the
+// user-pasted ManualKey and applies the result to InstallConfig.
+type UserStepInput struct {
+	Username     string
+	Password     string // plaintext; bcrypted inside ApplyUserStep
+	ManualKey    string // semicolon-separated paste from the SSH Public Key input
+	LocalKeys    []string
+	Hostname     string
+	Timezone     string
+	GroupsForNew []string // groups applied if the user record is being created
+}
+
+// NetworkStepInput is the raw collected input from the Network step form.
+type NetworkStepInput struct {
+	Mode string // "static" or "dhcp" (anything else ⇒ DHCP)
+	DNS  string // comma-separated DNS list from the form
+}
+
+// ApplyNetworkStep mutates Config.Network from raw form input.
+// Pure state transition — no I/O, no validation (validation happens via
+// ValidateCurrentStep at step-transition time).
+func (w *Wizard) ApplyNetworkStep(in NetworkStepInput) {
+	cfg := &w.State.Config
+	if dns := strings.TrimSpace(in.DNS); dns != "" {
+		parts := strings.Split(dns, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		cfg.Network.DNS = out
+	} else {
+		cfg.Network.DNS = nil
+	}
+	if in.Mode == "static" {
+		cfg.Network.Mode = model.NetworkStatic
+	} else {
+		cfg.Network.Mode = model.NetworkDHCP
+	}
+}
+
+// ApplyUserStep mutates Config.{Users,SSHKeys,Hostname,Timezone} from raw
+// form input. Hashes the password if set. Returns an error only on bcrypt
+// failure (e.g. password > 72 bytes).
+//
+// LocalKeys + ManualKey are merged (deduped, order preserved). Async GitHub
+// keys are applied later via ApplyGitHubKeys once the fetch returns.
+func (w *Wizard) ApplyUserStep(in UserStepInput) error {
+	cfg := &w.State.Config
+
+	if in.Hostname != "" {
+		cfg.Hostname = in.Hostname
+	}
+	if in.Timezone != "" {
+		cfg.Timezone = in.Timezone
+	} else if cfg.Timezone == "" {
+		cfg.Timezone = "UTC"
+	}
+
+	if in.Username != "" {
+		groups := in.GroupsForNew
+		if len(groups) == 0 {
+			groups = []string{"sudo", "docker"}
+		}
+		if len(cfg.Users) == 0 {
+			cfg.Users = append(cfg.Users, model.UserConfig{
+				Username: in.Username,
+				Groups:   groups,
+			})
+		} else {
+			cfg.Users[0].Username = in.Username
+		}
+	}
+
+	if in.Password != "" && len(cfg.Users) > 0 {
+		hash, err := HashPassword(in.Password)
+		if err != nil {
+			return err
+		}
+		cfg.Users[0].PasswordHash = hash
+	}
+
+	manual := SplitSSHKeys(in.ManualKey)
+	merged := MergeSSHKeys(in.LocalKeys, manual)
+	if len(merged) > 0 {
+		cfg.SSHKeys = merged
+		if len(cfg.Users) > 0 {
+			cfg.Users[0].SSHKeys = merged
+		}
+	}
+	return nil
+}
+
+// ApplyGitHubKeys merges asynchronously-fetched GitHub keys with the local
+// host keys and the user's manual paste, replacing Config.SSHKeys with the
+// deduped union.
+func (w *Wizard) ApplyGitHubKeys(githubKeys []string, localKeys []string, manualKey string) {
+	cfg := &w.State.Config
+	merged := MergeSSHKeys(localKeys, SplitSSHKeys(manualKey), githubKeys)
+	cfg.SSHKeys = merged
+	if len(cfg.Users) > 0 {
+		cfg.Users[0].SSHKeys = merged
+	}
+}
+
+// HasAnyAuthentication reports whether the current Config has at least one
+// authentication method (SSH key or user password hash) set. Used by the
+// User step to gate the post-fetch advance when GitHub returns 0 keys.
+func (w *Wizard) HasAnyAuthentication() bool {
+	cfg := &w.State.Config
+	if len(cfg.SSHKeys) > 0 {
+		return true
+	}
+	for _, u := range cfg.Users {
+		if u.PasswordHash != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HashPassword generates a bcrypt hash suitable for the Ignition `passwd`
+// field. Fails when the password exceeds bcrypt's 72-byte limit.
+func HashPassword(plain string) (string, error) {
+	if len(plain) > 72 {
+		return "", fmt.Errorf("password too long (max 72 bytes for bcrypt)")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("hashing password: %w", err)
+	}
+	return string(hash), nil
+}
+
+// SplitSSHKeys splits a semicolon-separated SSH key paste and trims each.
+func SplitSSHKeys(input string) []string {
+	parts := strings.Split(input, ";")
+	keys := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			keys = append(keys, p)
+		}
+	}
+	return keys
+}
+
+// MergeSSHKeys merges multiple key lists, dedupes by exact string match, and
+// preserves first-seen order.
+func MergeSSHKeys(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, list := range lists {
+		for _, k := range list {
+			if k == "" {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/internal/wizard/apply_test.go
+++ b/internal/wizard/apply_test.go
@@ -1,0 +1,155 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func newApplyWizard() *Wizard {
+	return &Wizard{State: &State{Config: model.InstallConfig{}}}
+}
+
+func TestApplyNetworkStepStatic(t *testing.T) {
+	w := newApplyWizard()
+	w.ApplyNetworkStep(NetworkStepInput{Mode: "static", DNS: "1.1.1.1, 8.8.8.8 ,"})
+	if w.State.Config.Network.Mode != model.NetworkStatic {
+		t.Errorf("mode: got %v want static", w.State.Config.Network.Mode)
+	}
+	want := []string{"1.1.1.1", "8.8.8.8"}
+	got := w.State.Config.Network.DNS
+	if len(got) != len(want) {
+		t.Fatalf("DNS: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DNS[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestApplyNetworkStepDHCPClearsDNS(t *testing.T) {
+	w := newApplyWizard()
+	w.State.Config.Network.DNS = []string{"1.1.1.1"}
+	w.ApplyNetworkStep(NetworkStepInput{Mode: "dhcp", DNS: ""})
+	if w.State.Config.Network.Mode != model.NetworkDHCP {
+		t.Errorf("mode: got %v want dhcp", w.State.Config.Network.Mode)
+	}
+	if len(w.State.Config.Network.DNS) != 0 {
+		t.Errorf("DNS should be cleared, got %v", w.State.Config.Network.DNS)
+	}
+}
+
+func TestApplyUserStepCreatesUserAndHashesPassword(t *testing.T) {
+	w := newApplyWizard()
+	err := w.ApplyUserStep(UserStepInput{
+		Username:  "alice",
+		Password:  "hunter2",
+		ManualKey: "ssh-ed25519 AAAA alice@laptop",
+		LocalKeys: []string{"ssh-ed25519 BBBB alice@host"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	cfg := w.State.Config
+	if len(cfg.Users) != 1 || cfg.Users[0].Username != "alice" {
+		t.Errorf("expected user alice, got %+v", cfg.Users)
+	}
+	if cfg.Users[0].PasswordHash == "" {
+		t.Error("expected bcrypt password hash")
+	}
+	if !strings.HasPrefix(cfg.Users[0].PasswordHash, "$2") {
+		t.Errorf("expected bcrypt $2 prefix, got %q", cfg.Users[0].PasswordHash)
+	}
+	wantKeys := []string{"ssh-ed25519 BBBB alice@host", "ssh-ed25519 AAAA alice@laptop"}
+	if got := cfg.SSHKeys; len(got) != 2 || got[0] != wantKeys[0] || got[1] != wantKeys[1] {
+		t.Errorf("SSH keys: got %v want %v", got, wantKeys)
+	}
+	groups := cfg.Users[0].Groups
+	hasDocker := false
+	hasSudo := false
+	for _, g := range groups {
+		if g == "docker" {
+			hasDocker = true
+		}
+		if g == "sudo" {
+			hasSudo = true
+		}
+	}
+	if !hasDocker || !hasSudo {
+		t.Errorf("expected default groups sudo+docker, got %v", groups)
+	}
+}
+
+func TestApplyUserStepRejectsLongPassword(t *testing.T) {
+	w := newApplyWizard()
+	err := w.ApplyUserStep(UserStepInput{
+		Username: "bob",
+		Password: strings.Repeat("a", 73),
+	})
+	if err == nil {
+		t.Fatal("expected error for >72 byte password")
+	}
+}
+
+func TestApplyGitHubKeysDedupes(t *testing.T) {
+	w := newApplyWizard()
+	w.State.Config.Users = []model.UserConfig{{Username: "carol"}}
+	w.ApplyGitHubKeys(
+		[]string{"ssh-ed25519 GH carol@github"},
+		[]string{"ssh-ed25519 LOCAL carol@host"},
+		"ssh-ed25519 LOCAL carol@host;ssh-ed25519 MANUAL carol@laptop",
+	)
+	cfg := w.State.Config
+	if len(cfg.SSHKeys) != 3 {
+		t.Errorf("expected 3 deduped keys, got %d: %v", len(cfg.SSHKeys), cfg.SSHKeys)
+	}
+	if len(cfg.Users[0].SSHKeys) != 3 {
+		t.Errorf("user SSH keys should mirror cfg.SSHKeys, got %v", cfg.Users[0].SSHKeys)
+	}
+}
+
+func TestHasAnyAuthentication(t *testing.T) {
+	w := newApplyWizard()
+	if w.HasAnyAuthentication() {
+		t.Error("empty config should have no auth")
+	}
+	w.State.Config.Users = []model.UserConfig{{Username: "x"}}
+	if w.HasAnyAuthentication() {
+		t.Error("user without password/keys should have no auth")
+	}
+	w.State.Config.Users[0].PasswordHash = "hash"
+	if !w.HasAnyAuthentication() {
+		t.Error("password-only should count as auth")
+	}
+	w.State.Config = model.InstallConfig{SSHKeys: []string{"ssh-x"}}
+	if !w.HasAnyAuthentication() {
+		t.Error("SSH-key-only should count as auth")
+	}
+}
+
+func TestSplitSSHKeys(t *testing.T) {
+	got := SplitSSHKeys("  ssh-rsa AAA  ;  ;ssh-ed25519 BBB ; ")
+	want := []string{"ssh-rsa AAA", "ssh-ed25519 BBB"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("SplitSSHKeys: got %v want %v", got, want)
+	}
+}
+
+func TestMergeSSHKeysPreservesOrder(t *testing.T) {
+	got := MergeSSHKeys(
+		[]string{"a", "b"},
+		[]string{"b", "c"},
+		[]string{"a", "d"},
+	)
+	want := []string{"a", "b", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("at %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes #86

## Summary
- Extracts password hashing, SSH key merging, and `InstallConfig` mutation out of the Bubble Tea view model into dedicated `wizard.Apply*` methods (`internal/wizard/apply.go`)
- New helpers: `ApplyNetworkStep`, `ApplyUserStep`, `ApplyGitHubKeys`, `HasAnyAuthentication`, `HashPassword`, `SplitSSHKeys`, `MergeSSHKeys`
- TUI now calls `wizard.Apply*` — the view model itself contains no business logic

## Why
The view model was violating the documented "no business logic in view models" invariant, making these paths hard to test without a full Bubble Tea model and preventing headless/wizard reuse.

## Test plan
- [ ] `just ci` passes
- [ ] `go test ./internal/wizard/...` covers new Apply methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal organization of the installation wizard's configuration logic.

* **Tests**
  * Added comprehensive test coverage for wizard steps, including network setup, user creation, SSH key handling, and authentication validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->