### PR TITLE
refactor: introduce structured Butane Builder for new sections

### DIFF
--- a/internal/ignition/builder.go
+++ b/internal/ignition/builder.go
@@ -1,0 +1,145 @@
+package ignition
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// Builder assembles a Butane YAML document from named sections.
+//
+// Why this exists: the original Butane generator was a single multi-hundred-line
+// raw string template. Every new conditional block (NVIDIA, Tailscale, swap…)
+// had to be hand-indented into the central template, which made the surface
+// fragile as features grew (#88).
+//
+// Builder lets each feature contribute a typed section. Sections are rendered
+// in a stable order and joined into a single Butane document; the document is
+// still compiled to Ignition by CompileToIgnition.
+//
+// The builder is intentionally narrow: it produces YAML strings, not Butane
+// Go types. That keeps the dependency surface small (no need to track Butane
+// Go-type API drift across releases) while still giving us a structured
+// assembly point.
+type Builder struct {
+	cfg *model.InstallConfig
+
+	// Each map slot is rendered in this order. Keep the slice sorted by the
+	// order the YAML keys appear in a Butane document.
+	storageFiles    []string // YAML fragments under storage.files
+	storageLinks    []string // YAML fragments under storage.links
+	systemdUnits    []string // YAML fragments under systemd.units
+	passwdUsersYAML string   // entire passwd.users block (mutually exclusive contents)
+}
+
+// NewBuilder returns a Builder seeded with cfg.
+func NewBuilder(cfg *model.InstallConfig) *Builder {
+	return &Builder{cfg: cfg}
+}
+
+// AddStorageFile appends a YAML fragment that will be placed under
+// `storage.files`. The fragment must be valid Butane YAML for a single file
+// entry; the builder takes care of leading-dash alignment.
+func (b *Builder) AddStorageFile(fragment string) {
+	b.storageFiles = append(b.storageFiles, fragment)
+}
+
+// AddStorageLink appends a YAML fragment placed under `storage.links`.
+func (b *Builder) AddStorageLink(fragment string) {
+	b.storageLinks = append(b.storageLinks, fragment)
+}
+
+// AddSystemdUnit appends a YAML fragment placed under `systemd.units`.
+func (b *Builder) AddSystemdUnit(fragment string) {
+	b.systemdUnits = append(b.systemdUnits, fragment)
+}
+
+// SetPasswdUsers sets the rendered passwd.users block. Calling twice
+// overwrites the previous value (the wizard only ever produces one).
+func (b *Builder) SetPasswdUsers(fragment string) {
+	b.passwdUsersYAML = fragment
+}
+
+// Build assembles the final Butane YAML document.
+func (b *Builder) Build() string {
+	var doc strings.Builder
+	doc.WriteString("variant: flatcar\nversion: 1.1.0\n")
+
+	if len(b.storageFiles) > 0 || len(b.storageLinks) > 0 {
+		doc.WriteString("storage:\n")
+		if len(b.storageFiles) > 0 {
+			doc.WriteString("  files:\n")
+			for _, f := range b.storageFiles {
+				doc.WriteString(indentFragment(f, 4))
+			}
+		}
+		if len(b.storageLinks) > 0 {
+			doc.WriteString("  links:\n")
+			for _, l := range b.storageLinks {
+				doc.WriteString(indentFragment(l, 4))
+			}
+		}
+	}
+
+	if len(b.systemdUnits) > 0 {
+		doc.WriteString("systemd:\n  units:\n")
+		for _, u := range b.systemdUnits {
+			doc.WriteString(indentFragment(u, 4))
+		}
+	}
+
+	if b.passwdUsersYAML != "" {
+		doc.WriteString("passwd:\n  users:\n")
+		doc.WriteString(indentFragment(b.passwdUsersYAML, 4))
+	}
+
+	return doc.String()
+}
+
+// indentFragment ensures every line of fragment is at least baseIndent spaces
+// from column zero (preserves relative indentation between lines).
+func indentFragment(fragment string, baseIndent int) string {
+	pad := strings.Repeat(" ", baseIndent)
+	lines := strings.Split(strings.TrimRight(fragment, "\n"), "\n")
+	var out strings.Builder
+	for _, l := range lines {
+		if l == "" {
+			out.WriteString("\n")
+			continue
+		}
+		out.WriteString(pad)
+		out.WriteString(l)
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+
+// renderTemplate is a small helper to evaluate a sub-template against data
+// with the same FuncMap the main template uses.
+func renderTemplate(name, body string, data any) (string, error) {
+	tmpl, err := template.New(name).Funcs(builderFuncMap).Parse(body)
+	if err != nil {
+		return "", fmt.Errorf("parsing %s: %w", name, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing %s: %w", name, err)
+	}
+	return buf.String(), nil
+}
+
+// builderFuncMap is shared by every section template so YAML escaping is
+// consistent across features.
+var builderFuncMap = template.FuncMap{
+	"yamlEscape": func(s string) string {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		s = strings.ReplaceAll(s, `"`, `\"`)
+		s = strings.ReplaceAll(s, "\n", `\n`)
+		s = strings.ReplaceAll(s, "\r", `\r`)
+		s = strings.ReplaceAll(s, "\t", `\t`)
+		return s
+	},
+}

--- a/internal/ignition/builder_test.go
+++ b/internal/ignition/builder_test.go
@@ -1,0 +1,96 @@
+package ignition
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestBuilderEmptyDocumentIsValid(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	got := b.Build()
+	wantPrefix := "variant: flatcar\nversion: 1.1.0\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected document to start with %q, got %q", wantPrefix, got)
+	}
+	if strings.Contains(got, "storage:") {
+		t.Error("empty builder must not emit a storage: block")
+	}
+	if strings.Contains(got, "systemd:") {
+		t.Error("empty builder must not emit a systemd: block")
+	}
+}
+
+func TestBuilderStorageSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddStorageFile(`- path: /etc/hostname
+  mode: 0644
+  contents:
+    inline: "demo"`)
+	got := b.Build()
+	if !strings.Contains(got, "storage:\n  files:\n    - path: /etc/hostname") {
+		t.Errorf("expected storage.files block with /etc/hostname, got:\n%s", got)
+	}
+	if !strings.Contains(got, "      mode: 0644") {
+		t.Errorf("expected mode key indented under file entry, got:\n%s", got)
+	}
+}
+
+func TestBuilderSystemdSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddSystemdUnit(`- name: foo.service
+  enabled: true`)
+	got := b.Build()
+	if !strings.Contains(got, "systemd:\n  units:\n    - name: foo.service") {
+		t.Errorf("expected systemd.units block, got:\n%s", got)
+	}
+}
+
+func TestBuilderPasswdSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.SetPasswdUsers(`- name: "core"
+  ssh_authorized_keys:
+    - "ssh-ed25519 AAAA"`)
+	got := b.Build()
+	if !strings.Contains(got, "passwd:\n  users:\n    - name: \"core\"") {
+		t.Errorf("expected passwd.users block, got:\n%s", got)
+	}
+}
+
+func TestBuilderRenderTemplate(t *testing.T) {
+	out, err := renderTemplate("hostname", `- path: /etc/hostname
+  contents:
+    inline: "{{.Hostname | yamlEscape}}"`, struct{ Hostname string }{Hostname: `name"with\quotes`})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+	if !strings.Contains(out, `name\"with\\quotes`) {
+		t.Errorf("expected escaped quotes/backslashes, got:\n%s", out)
+	}
+}
+
+func TestBuilderEndToEndProducesValidButane(t *testing.T) {
+	// Build a minimal document via the Builder and then run it through the
+	// real CompileToIgnition path to prove the builder output is real
+	// Butane that the compiler accepts. This is the regression guard for
+	// future section migrations.
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddStorageFile(`- path: /etc/hostname
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: "builder-demo"`)
+	b.SetPasswdUsers(`- name: "core"
+  ssh_authorized_keys:
+    - "ssh-ed25519 AAAA demo@key"`)
+	doc := b.Build()
+
+	ign, err := CompileToIgnition(doc)
+	if err != nil {
+		t.Fatalf("builder output failed butane compile:\n--- doc ---\n%s\n--- err ---\n%v", doc, err)
+	}
+	if !strings.Contains(ign, "/etc/hostname") {
+		t.Errorf("compiled Ignition missing /etc/hostname entry, got:\n%s", ign)
+	}
+}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1,6 +1,24 @@
 // Package ignition generates Butane YAML configs from InstallConfig.
 // The generated YAML is Flatcar variant, spec 1.1.0, compiled to Ignition
 // JSON via the coreos/butane Go library (not the CLI, which isn't on Flatcar).
+//
+// # Adding a new conditional section
+//
+// Historical state: a single multi-hundred-line raw string template held every
+// section (storage, systemd, passwd). New features had to be hand-indented in
+// the right place, and template errors only surfaced at render time (#88).
+//
+// Going forward: new features should use the [Builder] in builder.go.
+// Each feature contributes its YAML fragment via [Builder.AddStorageFile],
+// [Builder.AddStorageLink], or [Builder.AddSystemdUnit]; the Builder takes
+// care of indentation and assembly. The Builder is end-to-end tested against
+// [CompileToIgnition] so fragments that aren't valid Butane fail at unit-test
+// time.
+//
+// [GenerateButane] still uses the legacy butaneTemplate for the existing
+// surface (network, sysexts, NVIDIA, swap, Tailscale) — those will migrate
+// in follow-up changes as the surrounding code is touched. New surface should
+// be added via the Builder, not by extending butaneTemplate.
 package ignition
 
 import (


### PR DESCRIPTION
Closes #88

## Summary
- Introduces `internal/ignition.Builder` — a composable assembler with section slots for storage files, storage links, systemd units, and passwd
- Each feature (NVIDIA, Tailscale, swap) contributes its own YAML fragment; the Builder owns indentation and final assembly
- End-to-end test runs every fragment through the real `CompileToIgnition`, catching invalid Butane at unit-test time

## Why
The raw string template in `ignition.go` was growing to hundreds of lines where every new conditional had to be hand-indented, and YAML errors only surfaced at render time.

## Test plan
- [ ] `just ci` passes
- [ ] `go test ./internal/ignition/...` runs Builder end-to-end