### PR TITLE
feat: Tailscale integration step (conditional, like NVIDIA)

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -20,21 +20,31 @@ import (
 // Config is the JSON schema for headless install configuration.
 // It maps closely to model.InstallConfig but uses simpler types for JSON.
 type Config struct {
-	Arch                string        `json:"arch,omitempty"` // "amd64" or "arm64"; defaults to "amd64"
-	Channel             string        `json:"channel"`
-	Version             string        `json:"version,omitempty"`
-	Hostname            string        `json:"hostname"`
-	Timezone            string        `json:"timezone,omitempty"`
-	Network             NetworkConfig `json:"network"`
-	Users               []UserConfig  `json:"users"`
-	Disk                string        `json:"disk"`
-	Sysexts             []string      `json:"sysexts,omitempty"`
-	NvidiaDriverVersion string        `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
-	Swap                *SwapConfig   `json:"swap,omitempty"`                  // nil = default-on (4 GiB); pass {"enabled":false} to disable
-	UpdateStrategy      string        `json:"update_strategy"`
-	IgnitionURL         string        `json:"ignition_url,omitempty"`
-	Reboot              bool          `json:"reboot"`
-	DryRun              bool          `json:"dry_run,omitempty"`
+	Arch                string          `json:"arch,omitempty"` // "amd64" or "arm64"; defaults to "amd64"
+	Channel             string          `json:"channel"`
+	Version             string          `json:"version,omitempty"`
+	Hostname            string          `json:"hostname"`
+	Timezone            string          `json:"timezone,omitempty"`
+	Network             NetworkConfig   `json:"network"`
+	Users               []UserConfig    `json:"users"`
+	Disk                string          `json:"disk"`
+	Sysexts             []string        `json:"sysexts,omitempty"`
+	NvidiaDriverVersion string          `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
+	Swap                *SwapConfig     `json:"swap,omitempty"`                  // nil = default-on (4 GiB); pass {"enabled":false} to disable
+	Tailscale           TailscaleConfig `json:"tailscale,omitempty"`
+	UpdateStrategy      string          `json:"update_strategy"`
+	IgnitionURL         string          `json:"ignition_url,omitempty"`
+	Reboot              bool            `json:"reboot"`
+	DryRun              bool            `json:"dry_run,omitempty"`
+}
+
+// TailscaleConfig for JSON input. Empty AuthKey skips the integration.
+type TailscaleConfig struct {
+	AuthKey string `json:"auth_key,omitempty"`
+	// Mode: "connect" (default), "exit-node", or "subnet-router".
+	Mode string `json:"mode,omitempty"`
+	// Routes: comma-separated CIDRs, only used when mode == "subnet-router".
+	Routes string `json:"routes,omitempty"`
 }
 
 // SwapConfig for JSON input. Default (nil) ⇒ enabled with default size.
@@ -131,6 +141,19 @@ func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
 		cfg.Swap = model.SwapConfig{Enabled: true, SizeMB: 0}
 	} else {
 		cfg.Swap = model.SwapConfig{Enabled: c.Swap.Enabled, SizeMB: c.Swap.SizeMB}
+	}
+
+	// Tailscale (empty AuthKey skips provisioning)
+	if c.Tailscale.AuthKey != "" {
+		mode := c.Tailscale.Mode
+		if mode == "" {
+			mode = model.TailscaleModeConnect
+		}
+		cfg.Tailscale = model.TailscaleConfig{
+			AuthKey: c.Tailscale.AuthKey,
+			Mode:    mode,
+			Routes:  c.Tailscale.Routes,
+		}
 	}
 
 	// Users
@@ -296,6 +319,25 @@ func (c *Config) Validate() error {
 	// Swap size must be non-negative if explicit
 	if c.Swap != nil && c.Swap.SizeMB < 0 {
 		return fmt.Errorf("swap.size_mb: must be ≥ 0 (got %d)", c.Swap.SizeMB)
+	}
+
+	// Tailscale
+	if c.Tailscale.AuthKey != "" {
+		if err := validate.TailscaleAuthKey(c.Tailscale.AuthKey); err != nil {
+			return fmt.Errorf("tailscale auth_key: %w", err)
+		}
+		switch c.Tailscale.Mode {
+		case "", model.TailscaleModeConnect, model.TailscaleModeExitNode, model.TailscaleModeSubnetRouter:
+			// ok
+		default:
+			return fmt.Errorf("tailscale mode: must be %q, %q, or %q (got %q)",
+				model.TailscaleModeConnect, model.TailscaleModeExitNode, model.TailscaleModeSubnetRouter, c.Tailscale.Mode)
+		}
+		if c.Tailscale.Mode == model.TailscaleModeSubnetRouter {
+			if err := validate.TailscaleRoutes(c.Tailscale.Routes); err != nil {
+				return fmt.Errorf("tailscale routes: %w", err)
+			}
+		}
 	}
 
 	// NVIDIA driver version must be a known series

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -100,6 +100,10 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		NvidiaDriverVersion: cfg.NvidiaDriverVersion,
 		SwapEnabled:         cfg.Swap.Enabled,
 		SwapSizeMB:          swapSize,
+		Tailscale:           cfg.Tailscale,
+		TailscaleEnabled:    cfg.Tailscale.AuthKey != "",
+		TailscaleForwarding: cfg.Tailscale.AuthKey != "" && (cfg.Tailscale.Mode == model.TailscaleModeExitNode || cfg.Tailscale.Mode == model.TailscaleModeSubnetRouter),
+		TailscaleExtraArgs:  tailscaleExtraArgs(cfg.Tailscale),
 	}
 
 	var buf bytes.Buffer
@@ -123,6 +127,27 @@ type templateData struct {
 	NvidiaDriverVersion string // e.g. "570-open"; empty = no NVIDIA kernel driver setup
 	SwapEnabled         bool
 	SwapSizeMB          int // effective swap size in MiB when SwapEnabled
+	Tailscale           model.TailscaleConfig
+	TailscaleEnabled    bool   // AuthKey is set, i.e. user filled the step
+	TailscaleForwarding bool   // exit-node or subnet-router → need sysctl ip_forward=1
+	TailscaleExtraArgs  string // value of TS_EXTRA_ARGS in tailscale.env
+}
+
+// tailscaleExtraArgs builds the TS_EXTRA_ARGS value for /etc/tailscale/tailscale.env
+// based on the selected mode.
+func tailscaleExtraArgs(ts model.TailscaleConfig) string {
+	switch ts.Mode {
+	case model.TailscaleModeExitNode:
+		return "--advertise-exit-node"
+	case model.TailscaleModeSubnetRouter:
+		routes := strings.ReplaceAll(strings.TrimSpace(ts.Routes), " ", "")
+		if routes == "" {
+			return ""
+		}
+		return "--advertise-routes=" + routes
+	default:
+		return ""
+	}
 }
 
 func filterSelected(sysexts []model.SysextEntry) []model.SysextEntry {
@@ -197,6 +222,27 @@ storage:
       contents:
         source: "data:,"
 {{- end}}
+{{- if .TailscaleEnabled}}
+    - path: /etc/tailscale/tailscale.env
+      mode: 0600
+      overwrite: true
+      contents:
+        inline: |
+          TS_AUTHKEY={{.Tailscale.AuthKey | yamlEscape}}
+          TS_AUTH_ONCE=true
+{{- if .TailscaleExtraArgs}}
+          TS_EXTRA_ARGS={{.TailscaleExtraArgs | yamlEscape}}
+{{- end}}
+{{- if .TailscaleForwarding}}
+    - path: /etc/sysctl.d/99-tailscale.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          net.ipv4.ip_forward = 1
+          net.ipv6.conf.all.forwarding = 1
+{{- end}}
+{{- end}}
 {{- if .Timezone}}
   links:
     - path: /etc/localtime
@@ -240,6 +286,29 @@ systemd:
 
         [Swap]
         What=/var/swapfile
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end}}
+{{- if .TailscaleEnabled}}
+    - name: tailscaled.service
+      enabled: true
+    - name: knuckle-tailscale-up.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Bring up Tailscale with the auth key provisioned by knuckle
+        Requires=tailscaled.service network-online.target
+        After=tailscaled.service network-online.target
+        ConditionPathExists=/etc/tailscale/tailscale.env
+        ConditionPathExists=!/var/lib/tailscale/.knuckle-up-done
+
+        [Service]
+        Type=oneshot
+        EnvironmentFile=/etc/tailscale/tailscale.env
+        ExecStart=/usr/bin/tailscale up --auth-key=$${TS_AUTHKEY} $${TS_EXTRA_ARGS}
+        ExecStartPost=/bin/sh -c 'install -m 0600 /dev/null /var/lib/tailscale/.knuckle-up-done'
+        RemainAfterExit=yes
 
         [Install]
         WantedBy=multi-user.target

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -784,3 +784,112 @@ func TestGenerateButaneSwapDisabled(t *testing.T) {
 		t.Error("swap unit must not appear when Swap.Enabled = false")
 	}
 }
+
+func TestGenerateButaneTailscaleAuthKey(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-node",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeConnect,
+		},
+	}
+
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "/etc/tailscale/tailscale.env") {
+		t.Error("expected /etc/tailscale/tailscale.env in Butane output")
+	}
+	if !strings.Contains(out, "TS_AUTHKEY=tskey-auth-") {
+		t.Error("expected TS_AUTHKEY in tailscale.env contents")
+	}
+	if !strings.Contains(out, "TS_AUTH_ONCE=true") {
+		t.Error("expected TS_AUTH_ONCE=true in tailscale.env")
+	}
+	if !strings.Contains(out, "tailscaled.service") {
+		t.Error("expected tailscaled.service enabled")
+	}
+	if !strings.Contains(out, "knuckle-tailscale-up.service") {
+		t.Error("expected knuckle-tailscale-up.service in systemd units")
+	}
+	if strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("connect mode should not enable IP forwarding")
+	}
+	// The unit body references $${TS_EXTRA_ARGS} as an env var; the env file
+	// itself should not define TS_EXTRA_ARGS= in connect mode (empty → expands
+	// to an empty string).
+	if strings.Contains(out, "TS_EXTRA_ARGS=") {
+		t.Error("connect mode should not set TS_EXTRA_ARGS= in tailscale.env")
+	}
+}
+
+func TestGenerateButaneTailscaleExitNode(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-exit",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeExitNode,
+		},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "--advertise-exit-node") {
+		t.Error("expected --advertise-exit-node in TS_EXTRA_ARGS")
+	}
+	if !strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("expected IP forwarding sysctl for exit node")
+	}
+}
+
+func TestGenerateButaneTailscaleSubnetRouter(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-subnet",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeSubnetRouter,
+			Routes:  "10.0.0.0/24,192.168.1.0/24",
+		},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "--advertise-routes=10.0.0.0/24,192.168.1.0/24") {
+		t.Errorf("expected --advertise-routes in TS_EXTRA_ARGS, got:\n%s", out)
+	}
+	if !strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("expected IP forwarding sysctl for subnet router")
+	}
+}
+
+func TestGenerateButaneTailscaleSkippedWhenNoAuthKey(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname:  "ts-skip",
+		Network:   model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:     []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{}, // no auth key
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "tailscale.env") {
+		t.Error("tailscale.env should not appear when AuthKey is empty")
+	}
+	if strings.Contains(out, "tailscaled.service") {
+		t.Error("tailscaled.service should not be force-enabled when AuthKey is empty")
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,7 +11,8 @@ const (
 	StepStorage
 	StepUser
 	StepSysext
-	StepNvidia // conditional: only visited when nvidia-runtime sysext is selected
+	StepNvidia    // conditional: only visited when nvidia-runtime sysext is selected
+	StepTailscale // conditional: only visited when tailscale sysext is selected
 	StepUpdate
 	StepReview
 	StepInstall
@@ -33,6 +34,8 @@ func (s WizardStep) String() string {
 		return "Sysext"
 	case StepNvidia:
 		return "GPU Setup"
+	case StepTailscale:
+		return "Tailscale"
 	case StepUpdate:
 		return "Update Strategy"
 	case StepReview:
@@ -62,6 +65,7 @@ type InstallConfig struct {
 	IgnitionURL         string // external ignition URL (mutually exclusive with local gen)
 	NvidiaDriverVersion string // Flatcar NVIDIA kernel driver series, e.g. "570-open". Empty = none.
 	Swap                SwapConfig
+	Tailscale           TailscaleConfig
 	DryRun              bool
 }
 
@@ -77,6 +81,29 @@ type SwapConfig struct {
 // Swap.SizeMB = 0. 4 GiB is the upstream Flatcar example and a reasonable cap
 // for home-server workloads; explicit SizeMB always overrides.
 const DefaultSwapSizeMB = 4096
+
+// TailscaleConfig holds optional Tailscale provisioning for the installed system.
+// Populated only when the tailscale sysext is selected. AuthKey is written to
+// /etc/tailscale/tailscale.env (mode 0600) and consumed by a oneshot systemd
+// unit that runs `tailscale up` at first boot.
+type TailscaleConfig struct {
+	// AuthKey is the Tailscale auth/preauth key (tskey-auth-…). Empty = step skipped.
+	AuthKey string
+	// Mode controls how the node advertises itself:
+	//   "connect"      — plain client (default)
+	//   "exit-node"    — advertise as exit node (--advertise-exit-node)
+	//   "subnet-router" — advertise routes via --advertise-routes
+	Mode string
+	// Routes is the comma-separated CIDR list advertised when Mode == "subnet-router".
+	Routes string
+}
+
+// Tailscale mode constants.
+const (
+	TailscaleModeConnect      = "connect"
+	TailscaleModeExitNode     = "exit-node"
+	TailscaleModeSubnetRouter = "subnet-router"
+)
 
 // UpdateStrategy holds OS update and reboot settings for Flatcar.
 type UpdateStrategy struct {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -12,6 +12,8 @@ func TestWizardStepString(t *testing.T) {
 		{StepStorage, "Storage"},
 		{StepUser, "User"},
 		{StepSysext, "Sysext"},
+		{StepNvidia, "GPU Setup"},
+		{StepTailscale, "Tailscale"},
 		{StepUpdate, "Update Strategy"},
 		{StepReview, "Review"},
 		{StepInstall, "Install"},

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -38,6 +38,14 @@ func (m *Model) initForm() {
 			m.Wizard.State.Config.Timezone = "UTC"
 		}
 		m.activeForm = m.buildUserForm()
+	case model.StepTailscale:
+		m.tailscaleAuthKeyIn = m.Wizard.State.Config.Tailscale.AuthKey
+		m.tailscaleModeIn = m.Wizard.State.Config.Tailscale.Mode
+		if m.tailscaleModeIn == "" {
+			m.tailscaleModeIn = model.TailscaleModeConnect
+		}
+		m.tailscaleRoutesIn = m.Wizard.State.Config.Tailscale.Routes
+		m.activeForm = m.buildTailscaleForm()
 	case model.StepReview:
 		m.activeForm = m.buildReviewForm()
 	default:
@@ -99,6 +107,22 @@ func (m *Model) onFormComplete() tea.Cmd {
 				keys, err := github.FetchKeys(username)
 				return fetchKeysMsg{keys: keys, err: err}
 			}
+		}
+
+	case model.StepTailscale:
+		cfg.Tailscale.AuthKey = strings.TrimSpace(m.tailscaleAuthKeyIn)
+		cfg.Tailscale.Mode = m.tailscaleModeIn
+		if cfg.Tailscale.Mode == "" {
+			cfg.Tailscale.Mode = model.TailscaleModeConnect
+		}
+		cfg.Tailscale.Routes = strings.TrimSpace(m.tailscaleRoutesIn)
+		if err := m.Wizard.ValidateCurrentStep(); err != nil {
+			m.err = err
+			m.initForm()
+			if m.activeForm != nil {
+				return m.activeForm.Init()
+			}
+			return nil
 		}
 
 	case model.StepReview:

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -152,6 +152,45 @@ func (m *Model) localKeysSummary() string {
 	return fmt.Sprintf("🔑 %d local key(s) from ~/.ssh/ will be included automatically", len(keys))
 }
 
+// buildTailscaleForm creates the huh form for the Tailscale step.
+// Shown only when the tailscale sysext is selected.
+func (m *Model) buildTailscaleForm() *huh.Form {
+	modeOptions := []huh.Option[string]{
+		huh.NewOption("Just connect — plain client", model.TailscaleModeConnect),
+		huh.NewOption("Exit node — advertise as exit node", model.TailscaleModeExitNode),
+		huh.NewOption("Subnet router — advertise routes", model.TailscaleModeSubnetRouter),
+	}
+
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Tailscale").
+				Description("Optional. Paste a tailnet auth key to provision Tailscale at first boot.\nLeave the auth key blank to skip — tailscale binaries will still be installed."),
+			huh.NewInput().
+				Title("Auth Key").
+				Description("From https://login.tailscale.com/admin/settings/keys — preauth is recommended").
+				Placeholder("tskey-auth-...").
+				EchoMode(huh.EchoModePassword).
+				Value(&m.tailscaleAuthKeyIn).
+				Validate(func(s string) error {
+					if s == "" {
+						return nil
+					}
+					return validate.TailscaleAuthKey(s)
+				}),
+			huh.NewSelect[string]().
+				Title("Mode").
+				Options(modeOptions...).
+				Value(&m.tailscaleModeIn),
+			huh.NewInput().
+				Title("Advertised routes").
+				Description("Only used in Subnet router mode. Comma-separated CIDRs (e.g. 10.0.0.0/24,192.168.1.0/24)").
+				Placeholder("10.0.0.0/24").
+				Value(&m.tailscaleRoutesIn),
+		),
+	).WithTheme(huh.ThemeDracula()).WithShowHelp(true).WithWidth(80)
+}
+
 // buildReviewForm creates the huh confirm for the Review step.
 func (m *Model) buildReviewForm() *huh.Form {
 	return huh.NewForm(
@@ -203,6 +242,16 @@ func (m *Model) reviewSummary() string {
 		fmt.Fprintf(&b, "\nSwap: %d MiB (/var/swapfile)", size)
 	} else {
 		b.WriteString("\nSwap: disabled")
+	}
+	if cfg.Tailscale.AuthKey != "" {
+		mode := cfg.Tailscale.Mode
+		if mode == "" {
+			mode = model.TailscaleModeConnect
+		}
+		fmt.Fprintf(&b, "\nTailscale: auth key set, mode=%s", mode)
+		if mode == model.TailscaleModeSubnetRouter && cfg.Tailscale.Routes != "" {
+			fmt.Fprintf(&b, " routes=%s", cfg.Tailscale.Routes)
+		}
 	}
 	return b.String()
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -57,14 +57,17 @@ type Model struct {
 	fieldIdx      int
 
 	// huh form state
-	activeForm       *huh.Form
-	dnsInput         string
-	networkModeInput string
-	usernameInput    string
-	passwordInput    string
-	githubUserInput  string
-	sshKeyInput      string
-	showAdvanced     bool
+	activeForm         *huh.Form
+	dnsInput           string
+	networkModeInput   string
+	usernameInput      string
+	passwordInput      string
+	githubUserInput    string
+	sshKeyInput        string
+	tailscaleAuthKeyIn string
+	tailscaleModeIn    string
+	tailscaleRoutesIn  string
+	showAdvanced       bool
 
 	// Sysext list (bubbles/list)
 	sysextList      list.Model

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -19,6 +19,9 @@ var (
 	reInterfaceName  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 	reGitHubUsername = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 	reFlatcarVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	// Tailscale auth keys: tskey-auth-<id12>-<secret32+>; tskey-client- variant also accepted.
+	// See https://tailscale.com/kb/1085/auth-keys for the format.
+	reTailscaleAuthKey = regexp.MustCompile(`^tskey-(auth|client)-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}$`)
 )
 
 // Hostname validates a Linux hostname (RFC 1123).
@@ -283,6 +286,19 @@ func GitHubUsername(s string) error {
 	return nil
 }
 
+// TailscaleAuthKey validates a Tailscale auth key (tskey-auth-… or tskey-client-…).
+// Rejects obviously malformed input early — the real check is Tailscale's API at
+// `tailscale up` time, but failing here gives the user immediate feedback in the TUI.
+func TailscaleAuthKey(s string) error {
+	if s == "" {
+		return fmt.Errorf("auth key cannot be empty")
+	}
+	if !reTailscaleAuthKey.MatchString(s) {
+		return fmt.Errorf("auth key must start with %q or %q and contain an id and secret", "tskey-auth-", "tskey-client-")
+	}
+	return nil
+}
+
 // FlatcarVersion validates a pinned Flatcar version string.
 // Must be empty (latest) or in MAJOR.MINOR.PATCH format.
 func FlatcarVersion(s string) error {
@@ -291,6 +307,23 @@ func FlatcarVersion(s string) error {
 	}
 	if !reFlatcarVersion.MatchString(s) {
 		return fmt.Errorf("invalid Flatcar version %q: must be MAJOR.MINOR.PATCH (e.g. 3510.2.8)", s)
+	}
+	return nil
+}
+
+// TailscaleRoutes validates a comma-separated list of CIDRs for --advertise-routes.
+func TailscaleRoutes(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("at least one route is required for subnet router mode")
+	}
+	for _, raw := range strings.Split(s, ",") {
+		r := strings.TrimSpace(raw)
+		if r == "" {
+			continue
+		}
+		if err := CIDR(r); err != nil {
+			return fmt.Errorf("route %q: %w", r, err)
+		}
 	}
 	return nil
 }

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -96,6 +96,10 @@ func (w *Wizard) Next() error {
 		if w.State.CurrentStep == model.StepNvidia && !w.isNvidiaSelected() {
 			w.State.CurrentStep++
 		}
+		// StepTailscale is conditional — only visit it when tailscale is selected.
+		if w.State.CurrentStep == model.StepTailscale && !w.isTailscaleSelected() {
+			w.State.CurrentStep++
+		}
 	}
 	return nil
 }
@@ -104,6 +108,10 @@ func (w *Wizard) Next() error {
 func (w *Wizard) Previous() {
 	if w.State.CurrentStep > model.StepWelcome {
 		w.State.CurrentStep--
+		// StepTailscale is conditional — skip back over it when tailscale is not selected.
+		if w.State.CurrentStep == model.StepTailscale && !w.isTailscaleSelected() {
+			w.State.CurrentStep--
+		}
 		// StepNvidia is conditional — skip back over it when nvidia-runtime is not selected.
 		if w.State.CurrentStep == model.StepNvidia && !w.isNvidiaSelected() {
 			w.State.CurrentStep--
@@ -121,11 +129,25 @@ func (w *Wizard) isNvidiaSelected() bool {
 	return false
 }
 
+// isTailscaleSelected returns true when the tailscale sysext is toggled on.
+func (w *Wizard) isTailscaleSelected() bool {
+	for _, s := range w.State.Sysexts {
+		if s.Name == "tailscale" && s.Selected {
+			return true
+		}
+	}
+	return false
+}
+
 // GoToStep jumps to a specific step (for review screen navigation)
 func (w *Wizard) GoToStep(step model.WizardStep) {
 	if step >= model.StepWelcome && step <= model.StepDone {
 		// StepNvidia is conditional — refuse jump when nvidia-runtime not selected.
 		if step == model.StepNvidia && !w.isNvidiaSelected() {
+			return
+		}
+		// StepTailscale is conditional — refuse jump when tailscale not selected.
+		if step == model.StepTailscale && !w.isTailscaleSelected() {
 			return
 		}
 		w.State.CurrentStep = step
@@ -147,6 +169,8 @@ func (w *Wizard) ValidateCurrentStep() error {
 		return nil // sysext selection is optional
 	case model.StepNvidia:
 		return nil // driver series has a safe default; no validation needed
+	case model.StepTailscale:
+		return w.validateTailscale()
 	case model.StepUpdate:
 		return nil // update strategy selection is optional (defaults to "reboot")
 	case model.StepReview:
@@ -201,6 +225,23 @@ func (w *Wizard) validateStorage() error {
 		}
 	}
 	return validate.DiskPath(w.State.Config.Disk.DevPath)
+}
+
+func (w *Wizard) validateTailscale() error {
+	ts := w.State.Config.Tailscale
+	if ts.AuthKey == "" {
+		// Empty auth key is allowed: user skips the step, no provisioning.
+		return nil
+	}
+	if err := validate.TailscaleAuthKey(ts.AuthKey); err != nil {
+		return fmt.Errorf("tailscale auth key: %w", err)
+	}
+	if ts.Mode == model.TailscaleModeSubnetRouter {
+		if err := validate.TailscaleRoutes(ts.Routes); err != nil {
+			return fmt.Errorf("tailscale routes: %w", err)
+		}
+	}
+	return nil
 }
 
 func (w *Wizard) validateUser() error {

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -386,8 +386,8 @@ func TestIsFirstAndLastStep(t *testing.T) {
 
 func TestStepCount(t *testing.T) {
 	count := StepCount()
-	if count != 10 {
-		t.Errorf("expected 10 steps (added StepNvidia), got %d", count)
+	if count != 11 {
+		t.Errorf("expected 11 steps (added StepTailscale), got %d", count)
 	}
 }
 


### PR DESCRIPTION
Closes #94

## Summary
- New conditional wizard step `StepTailscale` between StepNvidia and StepUpdate
- Visible only when the tailscale bakery sysext is selected
- Validates auth key format (`tskey-auth-`/`tskey-client-` prefix); subnet-router mode requires routes
- Adds `model.TailscaleConfig{AuthKey, Mode, Routes}` to `InstallConfig`
- Ignition provisions Tailscale systemd units at first boot

## Test plan
- [ ] `just ci` passes
- [ ] Select tailscale sysext in TUI — step appears; deselect — step skips
- [ ] Headless path with `tailscale.auth_key` set provisions correctly