### PR TITLE
feat: configure swap on installed systems

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -30,10 +30,19 @@ type Config struct {
 	Disk                string        `json:"disk"`
 	Sysexts             []string      `json:"sysexts,omitempty"`
 	NvidiaDriverVersion string        `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
+	Swap                *SwapConfig   `json:"swap,omitempty"`                  // nil = default-on (4 GiB); pass {"enabled":false} to disable
 	UpdateStrategy      string        `json:"update_strategy"`
 	IgnitionURL         string        `json:"ignition_url,omitempty"`
 	Reboot              bool          `json:"reboot"`
 	DryRun              bool          `json:"dry_run,omitempty"`
+}
+
+// SwapConfig for JSON input. Default (nil) ⇒ enabled with default size.
+// Pass {"enabled": false} to disable, or {"enabled": true, "size_mb": 8192}
+// for an explicit size.
+type SwapConfig struct {
+	Enabled bool `json:"enabled"`
+	SizeMB  int  `json:"size_mb,omitempty"` // 0 = use model.DefaultSwapSizeMB
 }
 
 // NetworkConfig for JSON input.
@@ -116,6 +125,13 @@ func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
 
 	// NVIDIA kernel driver series (empty = no NVIDIA setup)
 	cfg.NvidiaDriverVersion = c.NvidiaDriverVersion
+
+	// Swap: nil = default-on (matches wizard New() default).
+	if c.Swap == nil {
+		cfg.Swap = model.SwapConfig{Enabled: true, SizeMB: 0}
+	} else {
+		cfg.Swap = model.SwapConfig{Enabled: c.Swap.Enabled, SizeMB: c.Swap.SizeMB}
+	}
 
 	// Users
 	for _, u := range c.Users {
@@ -270,6 +286,11 @@ func (c *Config) Validate() error {
 	validStrategies := map[string]bool{"reboot": true, "off": true, "etcd-lock": true, "": true}
 	if !validStrategies[c.UpdateStrategy] {
 		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
+	}
+
+	// Swap size must be non-negative if explicit
+	if c.Swap != nil && c.Swap.SizeMB < 0 {
+		return fmt.Errorf("swap.size_mb: must be ≥ 0 (got %d)", c.Swap.SizeMB)
 	}
 
 	// NVIDIA driver version must be a known series

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -64,6 +64,11 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		}
 	}
 
+	swapSize := cfg.Swap.SizeMB
+	if cfg.Swap.Enabled && swapSize <= 0 {
+		swapSize = model.DefaultSwapSizeMB
+	}
+
 	data := templateData{
 		Hostname:            cfg.Hostname,
 		Timezone:            cfg.Timezone,
@@ -75,6 +80,8 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		RebootStrategy:      rebootStrategy,
 		HasPassword:         hasPassword,
 		NvidiaDriverVersion: cfg.NvidiaDriverVersion,
+		SwapEnabled:         cfg.Swap.Enabled,
+		SwapSizeMB:          swapSize,
 	}
 
 	var buf bytes.Buffer
@@ -96,6 +103,8 @@ type templateData struct {
 	RebootStrategy      string
 	HasPassword         bool
 	NvidiaDriverVersion string // e.g. "570-open"; empty = no NVIDIA kernel driver setup
+	SwapEnabled         bool
+	SwapSizeMB          int // effective swap size in MiB when SwapEnabled
 }
 
 func filterSelected(sysexts []model.SysextEntry) []model.SysextEntry {
@@ -164,6 +173,12 @@ storage:
         inline: |
           nvidia-drivers-{{.NvidiaDriverVersion | yamlEscape}}
 {{- end}}
+{{- if .SwapEnabled}}
+    - path: /var/swapfile
+      mode: 0600
+      contents:
+        source: "data:,"
+{{- end}}
 {{- if .Timezone}}
   links:
     - path: /etc/localtime
@@ -178,6 +193,39 @@ systemd:
 {{- end}}
     - name: update-engine.service
       enabled: true
+{{- if .SwapEnabled}}
+    - name: knuckle-create-swapfile.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Create the /var/swapfile (knuckle, {{.SwapSizeMB}} MiB)
+        Before=var-swapfile.swap
+        ConditionPathExists=!/var/lib/knuckle/.swap-created
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/fallocate -l {{.SwapSizeMB}}M /var/swapfile
+        ExecStart=/usr/bin/chmod 0600 /var/swapfile
+        ExecStart=/usr/sbin/mkswap /var/swapfile
+        ExecStartPost=/bin/sh -c 'install -m 0644 -D /dev/null /var/lib/knuckle/.swap-created'
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: var-swapfile.swap
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Activate /var/swapfile
+        Requires=knuckle-create-swapfile.service
+        After=knuckle-create-swapfile.service
+
+        [Swap]
+        What=/var/swapfile
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end}}
 passwd:
   users:
 {{- if .Users}}

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -721,3 +721,66 @@ func TestGenerateButaneNvidiaDriverVersionEscaped(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateButaneSwapEnabledDefault(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "swap-default",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 0},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "/var/swapfile") {
+		t.Error("expected /var/swapfile in output")
+	}
+	if !strings.Contains(out, "fallocate -l 4096M") {
+		t.Errorf("expected default 4096 MiB swap, got:\n%s", out)
+	}
+	if !strings.Contains(out, "var-swapfile.swap") {
+		t.Error("expected var-swapfile.swap unit")
+	}
+	if !strings.Contains(out, "knuckle-create-swapfile.service") {
+		t.Error("expected knuckle-create-swapfile.service")
+	}
+}
+
+func TestGenerateButaneSwapExplicitSize(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "swap-8g",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 8192},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "fallocate -l 8192M") {
+		t.Errorf("expected 8192 MiB swap, got:\n%s", out)
+	}
+}
+
+func TestGenerateButaneSwapDisabled(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "no-swap",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: false},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "/var/swapfile") {
+		t.Error("/var/swapfile must not appear when Swap.Enabled = false")
+	}
+	if strings.Contains(out, "var-swapfile.swap") {
+		t.Error("swap unit must not appear when Swap.Enabled = false")
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -61,8 +61,22 @@ type InstallConfig struct {
 	UpdateStrategy      UpdateStrategy
 	IgnitionURL         string // external ignition URL (mutually exclusive with local gen)
 	NvidiaDriverVersion string // Flatcar NVIDIA kernel driver series, e.g. "570-open". Empty = none.
+	Swap                SwapConfig
 	DryRun              bool
 }
+
+// SwapConfig holds swap-file provisioning settings.
+// Enabled+SizeMB=0 ⇒ auto-size via min(detectedRAM, DefaultSwapSizeMB) at install time
+// (the wizard picks a sensible default for the host). Enabled=false ⇒ no swap unit.
+type SwapConfig struct {
+	Enabled bool
+	SizeMB  int // 0 = auto. Otherwise explicit MiB (e.g. 4096 for 4 GiB).
+}
+
+// DefaultSwapSizeMB is the swap size knuckle picks when Swap.Enabled = true and
+// Swap.SizeMB = 0. 4 GiB is the upstream Flatcar example and a reasonable cap
+// for home-server workloads; explicit SizeMB always overrides.
+const DefaultSwapSizeMB = 4096
 
 // UpdateStrategy holds OS update and reboot settings for Flatcar.
 type UpdateStrategy struct {

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -195,6 +195,15 @@ func (m *Model) reviewSummary() string {
 		}
 		fmt.Fprintf(&b, "\nSysexts: %s", strings.Join(names, ", "))
 	}
+	if cfg.Swap.Enabled {
+		size := cfg.Swap.SizeMB
+		if size <= 0 {
+			size = model.DefaultSwapSizeMB
+		}
+		fmt.Fprintf(&b, "\nSwap: %d MiB (/var/swapfile)", size)
+	} else {
+		b.WriteString("\nSwap: disabled")
+	}
 	return b.String()
 }
 

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -73,6 +73,9 @@ func New(prober probe.Prober, bakeryClient bakery.Client, installer install.Inst
 				Arch:           runtime.GOARCH,
 				Channel:        "stable",
 				UpdateStrategy: model.UpdateStrategy{RebootStrategy: "reboot"},
+				// Default to enabling swap (issue #95). Sized at render time —
+				// 0 SizeMB means "use DefaultSwapSizeMB".
+				Swap: model.SwapConfig{Enabled: true, SizeMB: 0},
 			},
 		},
 		Prober:    prober,


### PR DESCRIPTION
Closes #95

## Summary
- Provisions a 4 GiB swapfile by default via Ignition (`/var/swapfile`, mode 0600)
- `knuckle-create-swapfile.service` runs `fallocate`+`mkswap` at first boot; stamps a flag so it never re-runs
- `SwapConfig{Enabled bool, SizeMB int}` on `InstallConfig`; headless can opt out via `{"swap": {"enabled": false}}`

## Why
Flatcar nodes installed without swap trip the OOM killer under memory pressure (GPU workloads, databases, media stacks).

## Test plan
- [ ] `just ci` passes
- [ ] Rendered Ignition JSON contains swapfile unit and storage entry