### PR TITLE
feat: add issue and PR templates with hive agent guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something in knuckle is broken — install fails, TUI freezes, ISO won't boot, etc.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in as much as you can — installer
+        bugs are very environment-specific (firmware, disk model, channel), and
+        we cannot reproduce what we cannot see.
+
+        **For contributors using AI agents (Claude Code, Copilot, Cursor, pi):**
+        `AGENTS.md` at the repo root is the authoritative agent context for
+        this project. Point your agent at it before asking it to triage or
+        fix this issue. The hive workflow expects agents to read
+        `AGENTS.md` → run `just ci` → respect the safety invariants
+        documented there.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what went wrong.
+      placeholder: "Install fails on a SATA SSD with `flatcar-install` returning exit code 1 — stderr lost."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Smallest sequence that reliably reproduces the bug. Include the headless JSON config if you have one.
+      placeholder: |
+        1. Boot installer ISO on bare metal (Lenovo M75q-1)
+        2. Pick `stable` channel
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Install completes and the system reboots into Flatcar."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste TUI output, `flatcar-install` stderr, and any kernel messages. Use code fences.
+    validations:
+      required: true
+
+  - type: input
+    id: knuckle-version
+    attributes:
+      label: knuckle version
+      description: Output of `knuckle --version`, or the ISO filename.
+      placeholder: "v0.6.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Architecture
+      options:
+        - x86_64
+        - arm64
+    validations:
+      required: true
+
+  - type: dropdown
+    id: env
+    attributes:
+      label: Where did you run knuckle?
+      options:
+        - Bare metal
+        - QEMU/KVM
+        - Other VM (Proxmox, VMware, Hyper-V, etc.)
+        - Cloud VM
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware / VM details
+      description: CPU, disk model+size, NIC, firmware mode (UEFI/BIOS). For VMs, the launch command if you have it.
+      placeholder: |
+        Lenovo M75q-1, AMD Ryzen 5 PRO 3400GE
+        500GB Samsung 870 EVO (SATA AHCI)
+        Realtek RTL8111H
+        UEFI
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / config / dmesg
+      description: |
+        Attach any of: installer log (`/var/log/knuckle-install.log` if present),
+        rendered Ignition JSON from the Review screen, `dmesg | tail -200`, or a
+        screen capture of the failure. Redact any tokens or passwords.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Flatcar Discord
+    url: https://flatcar.org/discord
+    about: General Flatcar questions and chat — not knuckle-specific.
+  - name: Flatcar documentation
+    url: https://www.flatcar.org/docs/
+    about: Upstream Flatcar setup, Ignition, and bare-metal install docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a new feature, wizard step, or sysext integration.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new features (e.g. "add Tailscale step", "support LUKS").
+        For bugs use the bug report template.
+
+        **Contributors using AI agents:** read `AGENTS.md` first. This file is
+        the authoritative agent context for the project — it lists package
+        boundaries, the runner abstraction, safety invariants, and the
+        `just ci` gate every change must pass. The hive workflow expects
+        agents to consult it before writing code.
+
+        Small features that already match an existing pattern (NVIDIA, sysexts,
+        update strategy) are great candidates for the `copilot-ready` label.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who asks for it?
+      placeholder: "Tailscale is the most common first thing people set up on a new Flatcar node..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed design
+      description: How should this look in the wizard / headless config / Ignition output?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope check
+      description: |
+        knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64. Does this
+        feature stay inside that scope, or does it expand it?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for sending a PR to knuckle.
+
+Contributors using AI agents (Claude Code, Copilot, Cursor, pi):
+AGENTS.md at the repo root is the authoritative agent context for
+this project. Read it before writing code, and have the agent
+verify it ran `just ci` locally before opening the PR. The hive
+workflow assumes agents have respected the package boundaries and
+safety invariants documented there.
+-->
+
+## What
+<!-- One or two sentences. What does this change? -->
+
+## Why
+<!-- Link the issue this closes (Closes #123) or describe the motivation. -->
+
+## How tested
+<!-- Check at least one. -->
+- [ ] `just ci` is green locally
+- [ ] `just vm-e2e` passes (end-to-end install + boot)
+- [ ] `just headless-test` passes (for headless-mode changes)
+- [ ] Tested on real hardware — describe below
+- [ ] Doc / template / CI change only — no install path touched
+
+## Scope check
+<!-- knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64.
+     Does this PR stay inside that scope? If it expands it, call out why. -->
+
+## Notes for reviewers
+<!-- Anything reviewers should know — risky areas, follow-ups, screenshots, etc. -->
+
+---
+
+<!-- For agents: mention what command you ran to verify, e.g.
+     `just ci` exit 0, `just headless-test` exit 0. -->


### PR DESCRIPTION
Closes #111

## Summary
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report with hardware/arch/env fields
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature proposal with v1 scope check
- `.github/ISSUE_TEMPLATE/config.yml` — Flatcar Discord + docs as contact links
- `.github/PULL_REQUEST_TEMPLATE.md` — asks for `just ci` status, issue link, and agent workflow context

## Test plan
- [ ] Open a new issue — template picker appears
- [ ] Open a new PR — template pre-fills