### PR TITLE
feat: add Flatcar Discord links in dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 # Go
 vendor/
 
-# IDE
+# IDE / Claude
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ internal/wizard/     → step state machine, navigation, validation gates
 - **Security** (`security.yml`) — CodeQL (Go), OSSF Scorecard, dependency-review
 - **Release** (`release.yml`) — triggered on `v*` tags; builds amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`; produces binaries + installer ISOs + cosign bundles
 
+## Community
+
+- [Flatcar on Discord](https://flatcar.org/discord) — chat with the Flatcar community
+- [Flatcar docs](https://www.flatcar.org/docs/) — official documentation
+- [knuckle issues](https://github.com/projectbluefin/knuckle/issues) — file bugs and ideas
+
 ## License
 
 Apache 2.0

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -451,10 +451,13 @@ func (m *Model) viewChannelCards() string {
 		b.WriteString("\n")
 	}
 
-	// Show advanced hint
+	// Show advanced hint + community link
 	b.WriteString("\n")
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
-		"  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1245,6 +1245,13 @@ func (m *Model) viewDone() string {
 		b.WriteString(dimStyle.Render("    docker run --rm --gpus all nvidia/cuda:12.6.3-base-ubuntu22.04 nvidia-smi") + "\n")
 	}
 
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("Community & help:") + "\n")
+	b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
+	b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+
 	b.WriteString("\n")
 	if cfg.DryRun {
 		b.WriteString("Press q to exit.\n")


### PR DESCRIPTION
Closes #117

## Summary
- Adds Flatcar community Discord link to the welcome screen, install-done screen, and README
- Also adds `.claude/` to `.gitignore` so local agent settings don't leak into commits

## Test plan
- [ ] `just ci` passes
- [ ] Discord link appears at first launch and after successful install