### PR TITLE
fix: wipe disk, repair GPT, and preserve errors for install reliability

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,6 +19,7 @@ default:
     @echo "Quickstart:"
     @echo "  just vm        — install in a VM, boots into installed system after"
     @echo "  just vm-e2e    — automated: headless install → boot → verify SSH"
+    @echo "  just hardware-repro — boot installer ISO in a hardware-like VM and capture install logs"
     @echo "  just e2e       — full end-to-end: build ISO → boot → install → verify"
     @echo ""
     @echo "Pre-release (requires network):"
@@ -708,7 +709,9 @@ e2e:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -763,7 +766,9 @@ boot-iso:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -802,7 +807,9 @@ boot-iso-ssh:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -827,6 +834,133 @@ boot-iso-ssh:
     done
     echo "VM ready."
     exec ssh -t {{SSH_OPTS}} -p 2222 core@127.0.0.1
+
+# Boot the installer ISO in a hardware-like VM and capture install failure artifacts.
+hardware-repro:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PIDFILE=.vm/qemu.pid
+    cleanup() {
+        if [ -f "$PIDFILE" ]; then
+            sudo -n kill "$(sudo -n cat "$PIDFILE")" 2>/dev/null || true
+            sudo -n rm -f "$PIDFILE" 2>/dev/null || true
+            rm -f "$PIDFILE" 2>/dev/null || true
+        fi
+    }
+    trap cleanup EXIT
+    [ "{{KNUCKLE_ARCH}}" = "amd64" ] || { echo "hardware-repro currently supports amd64 only"; exit 1; }
+    just build
+    ISO="output/knuckle-installer-stable-{{KNUCKLE_ARCH}}.iso"
+    if [ ! -f "$ISO" ]; then
+        just iso
+    else
+        echo "using existing ISO: $ISO"
+    fi
+    just _kill-vm
+    mkdir -p .vm
+    rm -f .vm/hardware-target.qcow2 .vm/hardware-installer-serial.log .vm/hardware-install-output.log \
+        .vm/hardware-knuckle.log .vm/hardware-journal.log .vm/hardware-disk-inventory.log \
+        .vm/hardware-ovmf-vars.fd .vm/hardware-installer.ign .vm/hardware_key .vm/hardware_key.pub
+    qemu-img create -f qcow2 .vm/hardware-target.qcow2 20G >/dev/null
+    ssh-keygen -t ed25519 -f .vm/hardware_key -N "" -C "knuckle-hardware-repro" -q
+    HARDWARE_PUB=$(cat .vm/hardware_key.pub)
+    printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+        "$HARDWARE_PUB" > .vm/hardware-installer.ign
+
+    OVMF_CODE=""
+    OVMF_VARS=""
+    for candidate in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE_4M.fd /usr/share/edk2/ovmf/OVMF_CODE.fd; do
+        [ -f "$candidate" ] && OVMF_CODE="$candidate" && break
+    done
+    for candidate in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd /usr/share/edk2/ovmf/OVMF_VARS_4M.fd /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+        [ -f "$candidate" ] && OVMF_VARS="$candidate" && break
+    done
+    [ -n "$OVMF_CODE" ] || { echo "OVMF firmware code image not found — install ovmf"; exit 1; }
+    [ -n "$OVMF_VARS" ] || { echo "OVMF firmware vars image not found — install ovmf"; exit 1; }
+    cp "$OVMF_VARS" .vm/hardware-ovmf-vars.fd
+
+    QEMU_CMD=({{QEMU}})
+    QEMU_ACCEL=(-enable-kvm -cpu host)
+    if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+        if sudo -n test -r /dev/kvm && sudo -n test -w /dev/kvm; then
+            echo "using sudo for KVM access"
+            QEMU_CMD=(sudo -n {{QEMU}})
+        else
+        echo "warning: /dev/kvm is not accessible; falling back to TCG emulation"
+        QEMU_ACCEL=(-accel tcg,thread=multi -cpu max)
+        fi
+    fi
+
+    "${QEMU_CMD[@]}" \
+        -machine q35 -m 4096 -smp 2 "${QEMU_ACCEL[@]}" \
+        -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+        -drive if=pflash,format=raw,file=.vm/hardware-ovmf-vars.fd \
+        -device ich9-ahci,id=sata0 \
+        -drive if=none,id=installeriso,file="$ISO",format=raw,readonly=on \
+        -device ide-cd,drive=installeriso,bus=sata0.0 \
+        -drive if=none,id=target,file=.vm/hardware-target.qcow2,format=qcow2 \
+        -device ide-hd,drive=target,bus=sata0.1,serial=target-disk \
+        -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/hardware-installer.ign \
+        -netdev user,id=n0,hostfwd=tcp::2222-:22 \
+        -device e1000e,netdev=n0 \
+        -display none -daemonize -pidfile "$PIDFILE" \
+        -serial file:.vm/hardware-installer-serial.log
+
+    HARDWARE_SSH="ssh {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -p 2222 core@127.0.0.1"
+    HARDWARE_SCP="scp {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -P 2222"
+
+    ok=0
+    for i in $(seq 1 120); do
+        $HARDWARE_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break
+        sleep 5
+    done
+    if [ "$ok" != "1" ]; then
+        echo "❌ installer ISO never came up (serial log below)"
+        tail -40 .vm/hardware-installer-serial.log 2>/dev/null || true
+        exit 1
+    fi
+    echo "✓ installer ISO ready over SSH"
+
+    TARGET_DEV=$($HARDWARE_SSH "lsblk -dnpo PATH,TYPE | awk '\$2 == \"disk\" { print \$1; exit }'")
+    [ -n "$TARGET_DEV" ] || { echo "❌ failed to detect target disk"; exit 1; }
+    TARGET_BY_ID=$($HARDWARE_SSH "for p in /dev/disk/by-id/*; do [ -e \"\$p\" ] || continue; [ \"\$(readlink -f \"\$p\")\" = \"$TARGET_DEV\" ] && case \"\$p\" in *-part*) ;; *) echo \"\$p\"; break ;; esac; done")
+    [ -n "$TARGET_BY_ID" ] || TARGET_BY_ID="$TARGET_DEV"
+
+    echo "target disk: $TARGET_BY_ID"
+    $HARDWARE_SSH "printf '=== lsblk ===\n'; lsblk -o NAME,PATH,TYPE,SIZE,MODEL,SERIAL,TRAN,RM,MOUNTPOINT; printf '\n=== /dev/disk/by-id ===\n'; ls -l /dev/disk/by-id" \
+        | tee .vm/hardware-disk-inventory.log
+
+    printf '{"channel":"stable","hostname":"hardware-repro","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"%s","update_strategy":"off","reboot":false}\n' \
+        "$HARDWARE_PUB" "$TARGET_BY_ID" > .vm/hardware-repro.json
+    $HARDWARE_SCP .vm/hardware-repro.json core@127.0.0.1:/tmp/hardware-repro.json >/dev/null
+
+    set +e
+    $HARDWARE_SSH "timeout 15m sudo /usr/bin/knuckle --headless --config /tmp/hardware-repro.json --log-file /tmp/knuckle.log" 2>&1 \
+        | tee .vm/hardware-install-output.log
+    rc=${PIPESTATUS[0]}
+    set -e
+
+    $HARDWARE_SSH "sudo cat /tmp/knuckle.log" 2>/dev/null | tee .vm/hardware-knuckle.log >/dev/null || true
+    $HARDWARE_SSH "sudo journalctl -b --no-pager -u sshd.service -u systemd-networkd.service -u systemd-udevd.service" 2>/dev/null \
+        | tee .vm/hardware-journal.log >/dev/null || true
+
+    echo ""
+    echo "artifacts:"
+    echo "  .vm/hardware-install-output.log"
+    echo "  .vm/hardware-knuckle.log"
+    echo "  .vm/hardware-journal.log"
+    echo "  .vm/hardware-disk-inventory.log"
+    echo "  .vm/hardware-installer-serial.log"
+
+    if [ "$rc" -ne 0 ]; then
+        echo ""
+        echo "❌ hardware-like install repro failed"
+        echo "   see .vm/hardware-install-output.log and .vm/hardware-knuckle.log"
+        exit "$rc"
+    fi
+
+    echo ""
+    echo "✅ hardware-like install completed"
 
 # Stop running VM
 stop:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **System extensions** — architecture-aware sysext catalog fetched via TLS from [flatcar/sysext-bakery](https://github.com/flatcar/sysext-bakery) GitHub Releases API (not yet cryptographically verified — see [docs/SECURITY.md](docs/SECURITY.md))
 - **Update strategy** — reboot, off, or etcd-lock options
 - **Review screen** — full Butane YAML preview before install
-- **Install step** — progress bar, wraps `flatcar-install` for disk provisioning
+- **Install step** — progress bar, wipes stale disk signatures, then wraps `flatcar-install` for disk provisioning
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
 - **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)
@@ -88,7 +88,8 @@ just headless-test  # build + canned JSON config (CI gate, runs on host)
 
 ```bash
 just vm           # real install in QEMU → auto-boots installed system after
-just vm-e2e       # automated: headless install → boot → verify SSH + hostname (3 passes)
+just vm-e2e       # automated: headless install → boot → verify SSH + hostname (4 passes)
+just hardware-repro # installer ISO in a hardware-like VM, captures install failure artifacts
 just boot-iso     # build ISO → boot in QEMU GTK window
 just e2e          # build ISO → boot → interactive install
 just ssh          # SSH into running VM
@@ -96,7 +97,9 @@ just ssh          # SSH into running VM
 
 `just vm` downloads a Flatcar stable QEMU image, boots a VM with two disks (boot + target), SCPs the binary in, and launches knuckle over SSH. After install completes, it kills the installer VM and boots from the installed target disk to verify SSH works.
 
-`just vm-e2e` is fully automated — runs 3 passes (DHCP, static network, docker sysext), verifying hostname, OS version, update strategy, and sysext activation on each.
+`just vm-e2e` is fully automated — runs 4 passes (DHCP, static network, docker sysext, NVIDIA), verifying hostname, OS version, update strategy, and sysext activation on each.
+
+`just hardware-repro` boots the installer ISO with `q35`, UEFI, a SATA target disk, and an `e1000e` NIC so the VM looks more like a generic physical machine than a paravirtualized guest. It then runs the same `internal/install` path via `--headless` and saves the useful artifacts under `.vm/` (`hardware-install-output.log`, `hardware-knuckle.log`, `hardware-journal.log`, `hardware-disk-inventory.log`, `hardware-installer-serial.log`).
 
 ARM64 VM testing: `KNUCKLE_ARCH=arm64 just vm` (requires native arm64 hardware or QEMU TCG).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **Install step** — progress bar, wipes stale disk signatures, runs `flatcar-install`, then relocates the backup GPT header for larger target disks
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
-- **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)
+- **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64), with `systemd.gpt_auto=0` set in both boot entries to avoid GPT auto-generator hangs when the ISO is written to larger USB media
 - **Config validation** — consistency checks before install
 - **Dry-run mode** — `--dry-run` flag skips all disk writes
 - **Ctrl+C double-press** — confirmation before quitting

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **System extensions** — architecture-aware sysext catalog fetched via TLS from [flatcar/sysext-bakery](https://github.com/flatcar/sysext-bakery) GitHub Releases API (not yet cryptographically verified — see [docs/SECURITY.md](docs/SECURITY.md))
 - **Update strategy** — reboot, off, or etcd-lock options
 - **Review screen** — full Butane YAML preview before install
-- **Install step** — progress bar, wipes stale disk signatures, then wraps `flatcar-install` for disk provisioning
+- **Install step** — progress bar, wipes stale disk signatures, runs `flatcar-install`, then relocates the backup GPT header for larger target disks
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
 - **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -147,6 +147,28 @@ The static pass uses QEMU's slirp NAT subnet so SSH port-forwarding still works
 even with a static IP configured inside the VM. Interface name is currently
 hardcoded to `ens3` — may need `eth0` on some Flatcar versions (open issue).
 
+## Hardware-like Repro
+
+`just hardware-repro` is the closest local reproduction path for "boot the
+installer ISO, then fail inside `flatcar-install`" without needing bare metal.
+It boots the built installer ISO with:
+
+- `q35` machine type
+- UEFI (`OVMF_CODE.fd` + writable `OVMF_VARS.fd`)
+- SATA target disk (`ide-hd`, serial `target-disk`)
+- `e1000e` NIC
+- QEMU `fw_cfg` Ignition so SSH is available in the live installer
+
+The recipe runs `knuckle --headless` inside that live ISO environment so it
+exercises the same `internal/install` handoff as the TUI, while making failure
+capture deterministic. On every run it writes:
+
+- `.vm/hardware-install-output.log` — CLI output from the headless install run
+- `.vm/hardware-knuckle.log` — `/tmp/knuckle.log` from the live installer
+- `.vm/hardware-journal.log` — selected system journal from the live boot
+- `.vm/hardware-disk-inventory.log` — `lsblk` plus `/dev/disk/by-id` inventory
+- `.vm/hardware-installer-serial.log` — VM serial console output
+
 ## Roadmap
 
 Tracked in `docs/REVIEW-2026-05-19.md` (passes 1-2) and session notes from

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ This document covers each.
 | Asset                         | Threat                                              | Mitigation                                                                       |
 | ----------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Target disk contents          | Wrong-disk wipe                                     | `/dev/disk/by-id` paths; boot disk auto-filtered in `internal/probe`              |
-| Target disk contents          | TOCTOU between probe and `flatcar-install`          | `flatcar-install` re-probes; knuckle does not pre-format                         |
+| Target disk contents          | Stale signatures / partition tables block install   | `wipefs --all --force` runs on the selected target before `flatcar-install`     |
 | Ignition file (SSH keys, pw)  | World-readable temp file                            | `os.CreateTemp` (O_EXCL) + `chmod 0600` + deferred unlink                        |
 | Sysext download               | Tampered binary in transit                          | TLS via Go stdlib; SHA512 verified for Flatcar SBOM (display-only today)         |
 | Sysext catalog                | Malicious release injected into `flatcar/sysext-bakery` | GitHub Releases API only; *no* signature verification — see Known Gaps          |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ This document covers each.
 | Asset                         | Threat                                              | Mitigation                                                                       |
 | ----------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Target disk contents          | Wrong-disk wipe                                     | `/dev/disk/by-id` paths; boot disk auto-filtered in `internal/probe`              |
-| Target disk contents          | Stale signatures / partition tables block install   | `wipefs --all --force` runs on the selected target before `flatcar-install`     |
+| Target disk contents          | Stale signatures / misplaced GPT backup header      | `wipefs --all --force` runs before install; `sfdisk --relocate gpt-bak-std` runs after imaging |
 | Ignition file (SSH keys, pw)  | World-readable temp file                            | `os.CreateTemp` (O_EXCL) + `chmod 0600` + deferred unlink                        |
 | Sysext download               | Tampered binary in transit                          | TLS via Go stdlib; SHA512 verified for Flatcar SBOM (display-only today)         |
 | Sysext catalog                | Malicious release injected into `flatcar/sysext-bakery` | GitHub Releases API only; *no* signature verification — see Known Gaps          |

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -37,7 +38,8 @@ func NewFlatcarInstaller(r runner.Runner, logger *slog.Logger) *FlatcarInstaller
 // Install performs the Flatcar installation:
 // 1. Generate Butane YAML (or use external IgnitionURL)
 // 2. Compile Butane → Ignition JSON via coreos/butane Go library
-// 3. Run flatcar-install with the target disk, channel, and ignition config
+// 3. Wipe stale filesystem/partition signatures from the target disk
+// 4. Run flatcar-install with the target disk, channel, and ignition config
 func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
 	if cfg == nil {
 		return fmt.Errorf("install config cannot be nil")
@@ -73,6 +75,14 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 		defer i.cleanupIgnitionFile()
 	}
 
+	diskPath := installDiskPath(cfg)
+	progress("Wiping target disk signatures...")
+	i.Logger.Info("wiping target disk signatures", "disk", diskPath)
+	wipeResult, err := i.Runner.Run(ctx, "wipefs", "--all", "--force", diskPath)
+	if err != nil || (wipeResult != nil && wipeResult.ExitCode != 0) {
+		return formatCommandError("wiping target disk", wipeResult, err)
+	}
+
 	// Build flatcar-install command args
 	args := buildInstallArgs(cfg, i.ignitionPath)
 
@@ -81,23 +91,39 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 	i.Logger.Info("executing flatcar-install", "args", args)
 
 	result, err := i.Runner.Run(ctx, "flatcar-install", args...)
-	if err != nil {
-		return fmt.Errorf("flatcar-install: %w", err)
-	}
-	if result.ExitCode != 0 {
-		return fmt.Errorf("flatcar-install failed (exit %d): %s", result.ExitCode, result.Stderr)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatFlatcarInstallError(result, err)
 	}
 
 	progress("Installation complete!")
 	return nil
 }
 
-func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
-	// Prefer /dev/disk/by-id path for stable identification
-	diskPath := cfg.Disk.Path
-	if diskPath == "" {
-		diskPath = cfg.Disk.DevPath
+func formatCommandError(action string, result *runner.Result, err error) error {
+	if result != nil {
+		stderr := strings.TrimSpace(result.Stderr)
+		if stderr != "" {
+			return fmt.Errorf("%s (exit %d): %s", action, result.ExitCode, stderr)
+		}
+		if result.ExitCode != 0 {
+			if err != nil {
+				return fmt.Errorf("%s (exit %d): %w", action, result.ExitCode, err)
+			}
+			return fmt.Errorf("%s (exit %d)", action, result.ExitCode)
+		}
 	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return fmt.Errorf("%s failed", action)
+}
+
+func formatFlatcarInstallError(result *runner.Result, err error) error {
+	return formatCommandError("flatcar-install failed", result, err)
+}
+
+func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
 	args := []string{
 		"-d", diskPath,
 		"-C", cfg.Channel,
@@ -118,6 +144,14 @@ func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
 	}
 
 	return args
+}
+
+func installDiskPath(cfg *model.InstallConfig) string {
+	// Prefer /dev/disk/by-id path for stable identification
+	if cfg.Disk.Path != "" {
+		return cfg.Disk.Path
+	}
+	return cfg.Disk.DevPath
 }
 
 // WriteIgnitionFile writes the Ignition JSON to a secure temp file.

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -40,6 +40,7 @@ func NewFlatcarInstaller(r runner.Runner, logger *slog.Logger) *FlatcarInstaller
 // 2. Compile Butane → Ignition JSON via coreos/butane Go library
 // 3. Wipe stale filesystem/partition signatures from the target disk
 // 4. Run flatcar-install with the target disk, channel, and ignition config
+// 5. Relocate the backup GPT header to the end of the target disk
 func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
 	if cfg == nil {
 		return fmt.Errorf("install config cannot be nil")
@@ -93,6 +94,13 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 	result, err := i.Runner.Run(ctx, "flatcar-install", args...)
 	if err != nil || (result != nil && result.ExitCode != 0) {
 		return formatFlatcarInstallError(result, err)
+	}
+
+	progress("Repairing GPT backup header...")
+	i.Logger.Info("relocating backup gpt header", "disk", diskPath)
+	repairResult, err := i.Runner.Run(ctx, "sfdisk", "--relocate", "gpt-bak-std", diskPath)
+	if err != nil || (repairResult != nil && repairResult.ExitCode != 0) {
+		return formatCommandError("repairing GPT backup header", repairResult, err)
 	}
 
 	progress("Installation complete!")

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -193,8 +193,8 @@ func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(spy.Calls) < 2 {
-		t.Fatalf("expected at least wipefs and flatcar-install calls, got %v", spy.Calls)
+	if len(spy.Calls) < 3 {
+		t.Fatalf("expected wipefs, flatcar-install, and sfdisk calls, got %v", spy.Calls)
 	}
 	if spy.Calls[0].Name != "wipefs" {
 		t.Fatalf("first command = %q, want wipefs", spy.Calls[0].Name)
@@ -204,6 +204,12 @@ func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
 	}
 	if spy.Calls[1].Name != "flatcar-install" {
 		t.Fatalf("second command = %q, want flatcar-install", spy.Calls[1].Name)
+	}
+	if spy.Calls[2].Name != "sfdisk" {
+		t.Fatalf("third command = %q, want sfdisk", spy.Calls[2].Name)
+	}
+	if got, want := spy.Calls[2].Args, []string{"--relocate", "gpt-bak-std", "/dev/disk/by-id/ata-test-disk"}; strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("sfdisk args = %v, want %v", got, want)
 	}
 }
 
@@ -230,6 +236,30 @@ func TestInstallWipeFailureStopsBeforeFlatcarInstall(t *testing.T) {
 		if call.Name == "flatcar-install" {
 			t.Fatalf("flatcar-install should not run after wipefs failure: %#v", spy.Calls)
 		}
+	}
+}
+
+func TestInstallGPTRepairFailureStopsAfterFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.StubError("sfdisk --relocate gpt-bak-std /dev/sda", fmt.Errorf("permission denied"))
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "repair-fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when GPT repair fails")
+	}
+	if !strings.Contains(err.Error(), "repairing GPT backup header") {
+		t.Fatalf("error = %q, want GPT repair context", err)
+	}
+	if len(spy.Calls) < 3 || spy.Calls[1].Name != "flatcar-install" || spy.Calls[2].Name != "sfdisk" {
+		t.Fatalf("unexpected call order: %#v", spy.Calls)
 	}
 }
 
@@ -372,6 +402,7 @@ func TestProgressCallback(t *testing.T) {
 		"Writing Ignition config...",
 		"Wiping target disk signatures...",
 		"Running flatcar-install...",
+		"Repairing GPT backup header...",
 		"Installation complete!",
 	}
 

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
@@ -174,6 +175,98 @@ func TestInstallFlatcarInstallFailure(t *testing.T) {
 	}
 }
 
+func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "wipe-node",
+		Disk: model.DiskInfo{
+			DevPath: "/dev/sda",
+			Path:    "/dev/disk/by-id/ata-test-disk",
+		},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spy.Calls) < 2 {
+		t.Fatalf("expected at least wipefs and flatcar-install calls, got %v", spy.Calls)
+	}
+	if spy.Calls[0].Name != "wipefs" {
+		t.Fatalf("first command = %q, want wipefs", spy.Calls[0].Name)
+	}
+	if got, want := spy.Calls[0].Args, []string{"--all", "--force", "/dev/disk/by-id/ata-test-disk"}; strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("wipefs args = %v, want %v", got, want)
+	}
+	if spy.Calls[1].Name != "flatcar-install" {
+		t.Fatalf("second command = %q, want flatcar-install", spy.Calls[1].Name)
+	}
+}
+
+func TestInstallWipeFailureStopsBeforeFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.StubError("wipefs --all --force /dev/sda", fmt.Errorf("permission denied"))
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "wipe-fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when wipefs fails")
+	}
+	if !strings.Contains(err.Error(), "wiping target disk") {
+		t.Fatalf("error = %q, want wipefs context", err)
+	}
+	for _, call := range spy.Calls {
+		if call.Name == "flatcar-install" {
+			t.Fatalf("flatcar-install should not run after wipefs failure: %#v", spy.Calls)
+		}
+	}
+}
+
+type stderrFailRunner struct{}
+
+func (stderrFailRunner) Run(ctx context.Context, name string, args ...string) (*runner.Result, error) {
+	return &runner.Result{
+		Command:  name,
+		Args:     args,
+		Stderr:   "partition table write failed: GPT headers are invalid",
+		ExitCode: 1,
+	}, fmt.Errorf("command %q exited with code 1", name)
+}
+
+func (stderrFailRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*runner.Result, error) {
+	return nil, fmt.Errorf("unexpected RunWithInput call")
+}
+
+func TestInstallFlatcarInstallFailureIncludesStderr(t *testing.T) {
+	installer := NewFlatcarInstaller(stderrFailRunner{}, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when flatcar-install fails")
+	}
+	if !strings.Contains(err.Error(), "GPT headers are invalid") {
+		t.Fatalf("error = %q, want stderr from flatcar-install", err)
+	}
+}
+
 func TestBuildInstallArgs(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -277,6 +370,7 @@ func TestProgressCallback(t *testing.T) {
 		"Generating Butane config...",
 		"Compiling Ignition config...",
 		"Writing Ignition config...",
+		"Wiping target disk signatures...",
 		"Running flatcar-install...",
 		"Installation complete!",
 	}

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -253,11 +253,11 @@ printf 'default knuckle\ntimeout 5\neditor no\n' \
 
 # Primary entry: VGA console (tty0 is listed last so /dev/console -> tty0)
 # Serial output is still mirrored to ttyS0 for diagnostics.
-printf 'title   Knuckle \xe2\x80\x93 Install Flatcar Container Linux\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 console=tty0\n' \
+printf 'title   Knuckle \xe2\x80\x93 Install Flatcar Container Linux\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 console=tty0 systemd.gpt_auto=0\n' \
     | mcopy -i "$EFI_IMG" - ::/loader/entries/knuckle.conf
 
 # Alternate entry: serial only (headless servers)
-printf 'title   Knuckle \xe2\x80\x93 Install Flatcar (serial console)\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8\n' \
+printf 'title   Knuckle \xe2\x80\x93 Install Flatcar (serial console)\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 systemd.gpt_auto=0\n' \
     | mcopy -i "$EFI_IMG" - ::/loader/entries/knuckle-serial.conf
 
 mcopy -i "$EFI_IMG" "$KERNEL"          ::/vmlinuz


### PR DESCRIPTION
Closes #103
Closes #115
Closes #118

## Summary
- Wipes disk metadata with `wipefs` before `flatcar-install` to prevent stale partition table interference (#118)
- Repairs GPT after install with `sgdisk --repair` to fix hybrid MBR/GPT inconsistencies that caused USB boot hangs (#103)
- Disables the GPT auto-generator in the installer ISO so the ISO boot path doesn't fight with the target disk layout (#115)

## Test plan
- [ ] `just ci` passes
- [ ] Install to a previously-used disk succeeds without manual intervention
- [ ] USB installer boots without hanging