### PR TITLE
fix: kind/* label taxonomy in release.yml and issue templates (#164 #165)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something in knuckle is broken — install fails, TUI freezes, ISO won't boot, etc.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in as much as you can — installer
+        bugs are very environment-specific (firmware, disk model, channel), and
+        we cannot reproduce what we cannot see.
+
+        **For contributors using AI agents (Claude Code, Copilot, Cursor, pi):**
+        `AGENTS.md` at the repo root is the authoritative agent context for
+        this project. Point your agent at it before asking it to triage or
+        fix this issue. The hive workflow expects agents to read
+        `AGENTS.md` → run `just ci` → respect the safety invariants
+        documented there.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what went wrong.
+      placeholder: "Install fails on a SATA SSD with `flatcar-install` returning exit code 1 — stderr lost."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Smallest sequence that reliably reproduces the bug. Include the headless JSON config if you have one.
+      placeholder: |
+        1. Boot installer ISO on bare metal (Lenovo M75q-1)
+        2. Pick `stable` channel
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Install completes and the system reboots into Flatcar."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste TUI output, `flatcar-install` stderr, and any kernel messages. Use code fences.
+    validations:
+      required: true
+
+  - type: input
+    id: knuckle-version
+    attributes:
+      label: knuckle version
+      description: Output of `knuckle --version`, or the ISO filename.
+      placeholder: "v0.6.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Architecture
+      options:
+        - x86_64
+        - arm64
+    validations:
+      required: true
+
+  - type: dropdown
+    id: env
+    attributes:
+      label: Where did you run knuckle?
+      options:
+        - Bare metal
+        - QEMU/KVM
+        - Other VM (Proxmox, VMware, Hyper-V, etc.)
+        - Cloud VM
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware / VM details
+      description: CPU, disk model+size, NIC, firmware mode (UEFI/BIOS). For VMs, the launch command if you have it.
+      placeholder: |
+        Lenovo M75q-1, AMD Ryzen 5 PRO 3400GE
+        500GB Samsung 870 EVO (SATA AHCI)
+        Realtek RTL8111H
+        UEFI
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / config / dmesg
+      description: |
+        Attach any of: installer log (`/var/log/knuckle-install.log` if present),
+        rendered Ignition JSON from the Review screen, `dmesg | tail -200`, or a
+        screen capture of the failure. Redact any tokens or passwords.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something in knuckle is broken — install fails, TUI freezes, ISO won't boot, etc.
-labels: ["bug"]
+labels: ["kind/bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Flatcar Discord
+    url: https://flatcar.org/discord
+    about: General Flatcar questions and chat — not knuckle-specific.
+  - name: Flatcar documentation
+    url: https://www.flatcar.org/docs/
+    about: Upstream Flatcar setup, Ignition, and bare-metal install docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a new feature, wizard step, or sysext integration.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new features (e.g. "add Tailscale step", "support LUKS").
+        For bugs use the bug report template.
+
+        **Contributors using AI agents:** read `AGENTS.md` first. This file is
+        the authoritative agent context for the project — it lists package
+        boundaries, the runner abstraction, safety invariants, and the
+        `just ci` gate every change must pass. The hive workflow expects
+        agents to consult it before writing code.
+
+        Small features that already match an existing pattern (NVIDIA, sysexts,
+        update strategy) are great candidates for the `copilot-ready` label.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who asks for it?
+      placeholder: "Tailscale is the most common first thing people set up on a new Flatcar node..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed design
+      description: How should this look in the wizard / headless config / Ignition output?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope check
+      description: |
+        knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64. Does this
+        feature stay inside that scope, or does it expand it?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature, wizard step, or sysext integration.
-labels: ["enhancement"]
+labels: ["kind/feature", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for sending a PR to knuckle.
+
+Contributors using AI agents (Claude Code, Copilot, Cursor, pi):
+AGENTS.md at the repo root is the authoritative agent context for
+this project. Read it before writing code, and have the agent
+verify it ran `just ci` locally before opening the PR. The hive
+workflow assumes agents have respected the package boundaries and
+safety invariants documented there.
+-->
+
+## What
+<!-- One or two sentences. What does this change? -->
+
+## Why
+<!-- Link the issue this closes (Closes #123) or describe the motivation. -->
+
+## How tested
+<!-- Check at least one. -->
+- [ ] `just ci` is green locally
+- [ ] `just vm-e2e` passes (end-to-end install + boot)
+- [ ] `just headless-test` passes (for headless-mode changes)
+- [ ] Tested on real hardware — describe below
+- [ ] Doc / template / CI change only — no install path touched
+
+## Scope check
+<!-- knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64.
+     Does this PR stay inside that scope? If it expands it, call out why. -->
+
+## Notes for reviewers
+<!-- Anything reviewers should know — risky areas, follow-ups, screenshots, etc. -->
+
+---
+
+<!-- For agents: mention what command you ran to verify, e.g.
+     `just ci` exit 0, `just headless-test` exit 0. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,42 @@
+# GitHub auto-generated release notes config.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Groups merged PRs by label into sections in the release body.
+# Keep this list short and aligned with the labels used on issues.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+    authors:
+      - dependabot
+      - renovate-bot
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Security
+      labels:
+        - security
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: Refactors
+      labels:
+        - refactor
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI & infrastructure
+      labels:
+        - ci
+        - infra
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,25 +18,25 @@ changelog:
         - breaking-change
     - title: Security
       labels:
-        - security
+        - kind/security
     - title: Features
       labels:
-        - enhancement
-        - feature
+        - kind/feature
     - title: Bug fixes
       labels:
-        - bug
-        - fix
-    - title: Refactors
+        - kind/bug
+    - title: Refactors & cleanup
       labels:
-        - refactor
+        - kind/cleanup
+    - title: Tests
+      labels:
+        - kind/test
     - title: Documentation
       labels:
         - documentation
     - title: CI & infrastructure
       labels:
-        - ci
-        - infra
+        - domain:ci
     - title: Other changes
       labels:
         - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to knuckle are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each
+release also has a GitHub Release with auto-generated PR-level notes — this
+file is the curated, human-readable history.
+
+## [Unreleased]
+
+### Added
+- Flatcar Discord community links on the welcome and install-done screens
+  (#117).
+- `.github/release.yml` to group auto-generated release notes by label
+  (Features, Bug fixes, Security, etc.) (#116).
+
+## [0.6.2] - 2026-05-19
+
+### Fixed
+- `Shift+Tab` now goes back a wizard step instead of incorrectly moving the
+  cursor up.
+
+## [0.6.1] - 2026-05-18
+
+### Fixed
+- Use `/dev/console` in the installer systemd unit so the TUI renders correctly
+  when booting over serial.
+
+### Added
+- Tests for GitHub SSH key-fetch error handling and no-auth guard on
+  `StepUser`.
+
+## [0.6.0] - 2026-05-17
+
+### Fixed
+- Password-only auth in headless mode now propagates to `InstallConfig`.
+
+## [0.5.1] - 2026-05-16
+
+### Added
+- CNCF supply-chain stack: Syft SBOMs, cosign keyless signing, ORAS push to
+  GHCR, SLSA build provenance attestations.
+
+## [0.5.0] - 2026-05-15
+
+### Fixed
+- External Ignition URL path bypasses auth/channel consistency checks.
+
+## [0.4.0] - 2026-05-14
+
+### Fixed
+- CI: use the correct arm64 runner label (`ubuntu-24.04-arm`).
+
+## [0.3.0] - 2026-05-13
+
+### Fixed
+- `justfile`: escape Go template braces in the `vm-e2e` docker check.
+
+## [0.2.1] - 2026-05-12
+
+### Fixed
+- ISO: inject `knuckle` into `usr.squashfs` for reliable live boot.
+
+## [0.2.0] - 2026-05-11
+
+### Security
+- Real Flatcar GPG verification via ProtonMail/go-crypto (security baseline
+  B1).
+
+## [0.1.0] - 2026-05-10
+
+### Added
+- First working ISO build with GRUB and `boot-iso` justfile recipes.
+
+[Unreleased]: https://github.com/projectbluefin/knuckle/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/projectbluefin/knuckle/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/projectbluefin/knuckle/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/projectbluefin/knuckle/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/projectbluefin/knuckle/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/projectbluefin/knuckle/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/projectbluefin/knuckle/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/projectbluefin/knuckle/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/projectbluefin/knuckle/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/projectbluefin/knuckle/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/projectbluefin/knuckle/releases/tag/v0.1.0


### PR DESCRIPTION
Fixes the label taxonomy issues flagged in reviews of #164 and #165.

## Changes

`.github/release.yml` — update categories to match `kind/*` taxonomy:
- `kind/bug`, `kind/feature`, `kind/security`, `kind/cleanup`, `kind/test`, `domain:ci`

`.github/ISSUE_TEMPLATE/bug_report.yml` — `labels: ["kind/bug", "needs-triage"]`

`.github/ISSUE_TEMPLATE/feature_request.yml` — `labels: ["kind/feature", "needs-triage"]`

Closes #165 (supersedes hanthor's PR with the label fix applied)
Closes #164 (supersedes hanthor's PR with the label fix applied)

Assisted-by: claude-sonnet-4-5 via pi