### PR TITLE
fix: remove dead DryRunner butane stub and add channel HTTP client pool

### DIFF
--- a/internal/bakery/channels.go
+++ b/internal/bakery/channels.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+var channelHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // ChannelInfo holds version details for a Flatcar release channel.
 type ChannelInfo struct {
 	Channel    string // stable, beta, alpha
@@ -180,8 +182,7 @@ func httpGet(ctx context.Context, url string) (string, error) {
 	}
 	req.Header.Set("User-Agent", "knuckle/1.0")
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := channelHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/bakery/channels.go
+++ b/internal/bakery/channels.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+// channelHTTPClient is the shared HTTP client used for fetching Flatcar channel information,
+// enabling connection reuse across parallel requests.
 var channelHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 // ChannelInfo holds version details for a Flatcar release channel.
@@ -142,6 +144,7 @@ func FetchAllChannelsArch(ctx context.Context, arch string) ([]ChannelInfo, erro
 	}, channels...)
 }
 
+// fetchAllChannelsWithURLFn is a helper for parallel channel fetching with custom URLs.
 func fetchAllChannelsWithURLFn(ctx context.Context, urlFn func(string) (string, string), channels ...string) ([]ChannelInfo, error) {
 	if len(channels) == 0 {
 		channels = []string{"stable", "beta", "alpha", "lts"}
@@ -175,6 +178,7 @@ func fetchAllChannelsWithURLFn(ctx context.Context, urlFn func(string) (string, 
 	return results, nil
 }
 
+// httpGet performs a GET request with the shared client and returns the body as a string.
 func httpGet(ctx context.Context, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -200,7 +204,7 @@ func httpGet(ctx context.Context, url string) (string, error) {
 	return string(body), nil
 }
 
-// parseVersionTxt parses key=value lines from version.txt.
+// parseVersionTxt parses key=value lines from version.txt into the ChannelInfo.
 func parseVersionTxt(body string, info *ChannelInfo) {
 	for _, line := range strings.Split(body, "\n") {
 		line = strings.TrimSpace(line)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -125,11 +125,6 @@ func (r *DryRunner) Run(ctx context.Context, name string, args ...string) (*Resu
 func (r *DryRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*Result, error) {
 	r.Logger.Info("dry-run with input", "cmd", name, "args", args)
 	result := &Result{Command: name, Args: args, ExitCode: 0}
-	// When butane is invoked in dry-run, return a minimal valid Ignition JSON
-	// so downstream steps can proceed without error.
-	if name == "butane" {
-		result.Stdout = `{"ignition":{"version":"3.4.0"}}`
-	}
 	r.History = append(r.History, *result)
 	return result, nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -38,6 +38,7 @@ func NewRealRunner(logger *slog.Logger) *RealRunner {
 	return &RealRunner{Logger: logger}
 }
 
+// Run executes a command and returns its result.
 func (r *RealRunner) Run(ctx context.Context, name string, args ...string) (*Result, error) {
 	r.Logger.Debug("executing command", "cmd", name, "args", args)
 
@@ -70,6 +71,7 @@ func (r *RealRunner) Run(ctx context.Context, name string, args ...string) (*Res
 	return result, nil
 }
 
+// RunWithInput executes a command with the given string as standard input.
 func (r *RealRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*Result, error) {
 	r.Logger.Debug("executing command with input", "cmd", name, "args", args)
 
@@ -115,6 +117,7 @@ func NewDryRunner(logger *slog.Logger) *DryRunner {
 	return &DryRunner{Logger: logger}
 }
 
+// Run records the command and returns a success result without executing it.
 func (r *DryRunner) Run(ctx context.Context, name string, args ...string) (*Result, error) {
 	r.Logger.Info("dry-run", "cmd", name, "args", args)
 	result := &Result{Command: name, Args: args, ExitCode: 0}
@@ -122,6 +125,7 @@ func (r *DryRunner) Run(ctx context.Context, name string, args ...string) (*Resu
 	return result, nil
 }
 
+// RunWithInput records the command and input, and returns a success result without executing it.
 func (r *DryRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*Result, error) {
 	r.Logger.Info("dry-run with input", "cmd", name, "args", args)
 	result := &Result{Command: name, Args: args, ExitCode: 0}
@@ -162,6 +166,7 @@ func (r *SpyRunner) StubError(command string, err error) {
 	r.Errors[command] = err
 }
 
+// Run records the call and returns a stubbed response or error if configured.
 func (r *SpyRunner) Run(ctx context.Context, name string, args ...string) (*Result, error) {
 	r.Calls = append(r.Calls, SpyCall{Name: name, Args: args})
 
@@ -180,6 +185,7 @@ func (r *SpyRunner) Run(ctx context.Context, name string, args ...string) (*Resu
 	return &Result{Command: name, Args: args, ExitCode: 0}, nil
 }
 
+// RunWithInput records the call and input, and returns a stubbed response or error.
 func (r *SpyRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*Result, error) {
 	r.Calls = append(r.Calls, SpyCall{Name: name, Args: args, Input: input})
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -38,28 +38,23 @@ func TestDryRunnerRecordsHistory(t *testing.T) {
 	}
 }
 
-func TestDryRunnerButaneReturnsIgnitionJSON(t *testing.T) {
+func TestDryRunnerRunWithInputReturnsEmptyStdout(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	dr := NewDryRunner(logger)
 	ctx := context.Background()
 
-	result, err := dr.RunWithInput(ctx, "some butane yaml", "butane", "--strict")
+	result, err := dr.RunWithInput(ctx, "input", "cat")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	expected := `{"ignition":{"version":"3.4.0"}}`
-	if result.Stdout != expected {
-		t.Errorf("expected butane stub output %q, got %q", expected, result.Stdout)
+	if result.Stdout != "" {
+		t.Errorf("expected empty stdout, got %q", result.Stdout)
 	}
-
-	// Non-butane commands should still return empty stdout
-	result2, err := dr.RunWithInput(ctx, "input", "cat")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if len(dr.History) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(dr.History))
 	}
-	if result2.Stdout != "" {
-		t.Errorf("expected empty stdout for non-butane command, got %q", result2.Stdout)
+	if dr.History[0].Command != "cat" {
+		t.Errorf("expected command 'cat', got %q", dr.History[0].Command)
 	}
 }
 


### PR DESCRIPTION
Closes #154
Closes #155

## Summary
- **#154**: Removes the dead `if name == "butane"` block in `DryRunner.RunWithInput` that pre-dates in-process butane compilation (`ignition.CompileToIgnition`). The butane CLI is never invoked via the runner anymore, so this stub was misleading dead code. Updates the test to assert the correct (empty-stdout) behavior.
- **#155**: Replaces the per-call `&http.Client{Timeout: 30 * time.Second}` allocation in `channels.go httpGet` with a package-level `channelHTTPClient`, consistent with the pattern in `bakery.go` and `github.go`. Enables TCP connection reuse across the ~24 parallel requests made at TUI startup.

## Test plan
- [x] `go test ./internal/runner/... ./internal/bakery/...` passes
- [x] `just ci` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified dry-run execution to consistently return empty standard output for all command types, removing special command-specific response formatting
  * Optimized internal HTTP request handling through improved client resource management and connection efficiency

* **Tests**
  * Updated test suite to verify new dry-run output behavior and confirm proper command execution logging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->