### PR TITLE
fix: five bakery/download security hardening fixes

### DIFF
--- a/internal/bakery/bakery.go
+++ b/internal/bakery/bakery.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
 )
+
+var reSHA256 = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 const (
 	// DefaultCatalogURL is the GitHub Releases API for the sysext-bakery repo.
@@ -166,6 +170,9 @@ func (c *HTTPClient) FetchCatalogArch(ctx context.Context, arch string) ([]model
 		if downloadURL == "" {
 			continue
 		}
+		if validate.SysextName(name) != nil {
+			continue
+		}
 
 		seen[name] = true
 
@@ -276,7 +283,11 @@ func (c *HTTPClient) fetchSHA256ForAsset(ctx context.Context, sha256sumsURL, raw
 			baseName = baseName[idx+1:]
 		}
 		if baseName == rawFilename {
-			return fields[0], nil
+			hash := fields[0]
+			if !reSHA256.MatchString(hash) {
+				return "", fmt.Errorf("malformed SHA256 hash %q for %s", hash, rawFilename)
+			}
+			return hash, nil
 		}
 	}
 	return "", nil // file found but hash for this asset not listed

--- a/internal/bakery/channels.go
+++ b/internal/bakery/channels.go
@@ -91,7 +91,8 @@ func fetchChannelInfoFromURLs(ctx context.Context, channel, versionURL, pkgURL s
 	if sbomUsed && sbomBody != "" {
 		digestURL := sbomURL + ".DIGESTS"
 		if digestBody, err := httpGet(ctx, digestURL); err == nil {
-			info.DigestVerified = verifySHA512(sbomBody, digestBody)
+			sbomFilename := sbomURL[strings.LastIndex(sbomURL, "/")+1:]
+			info.DigestVerified = verifySHA512(sbomBody, digestBody, sbomFilename)
 			// Cryptographic GPG verification against the embedded Flatcar key.
 			ascURL := digestURL + ".asc"
 			if ascBody, err := httpGet(ctx, ascURL); err == nil {
@@ -303,9 +304,10 @@ func extractVersionBeforeColons(line, prefix string) string {
 	return after
 }
 
-// verifySHA512 checks if the SHA512 hash of content matches the digest file.
-// The digest file format is: "<hash>  <filename>\n" per line.
-func verifySHA512(content, digestBody string) bool {
+// verifySHA512 checks if the SHA512 hash of content matches the digest file
+// for the expected filename. Both the hash and the filename field must match
+// to prevent hash-swap attacks within the same DIGESTS file.
+func verifySHA512(content, digestBody, expectedFilename string) bool {
 	hash := sha512.Sum512([]byte(content))
 	computed := hex.EncodeToString(hash[:])
 
@@ -324,7 +326,7 @@ func verifySHA512(content, digestBody string) bool {
 		if inSHA512 && line != "" {
 			// Format: "<hash>  <filename>"
 			parts := strings.Fields(line)
-			if len(parts) >= 1 && parts[0] == computed {
+			if len(parts) >= 2 && parts[0] == computed && parts[1] == expectedFilename {
 				return true
 			}
 		}

--- a/internal/bakery/channels_test.go
+++ b/internal/bakery/channels_test.go
@@ -233,16 +233,21 @@ func TestVerifySHA512(t *testing.T) {
 	// Pre-computed SHA512 of "hello world"
 	digest := "# SHA512 HASH\n309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f  test.txt\n"
 
-	if !verifySHA512(content, digest) {
-		t.Error("expected SHA512 verification to pass for known hash")
+	if !verifySHA512(content, digest, "test.txt") {
+		t.Error("expected SHA512 verification to pass for known hash+filename")
 	}
 
-	if verifySHA512("wrong content", digest) {
+	if verifySHA512("wrong content", digest, "test.txt") {
 		t.Error("expected SHA512 verification to fail for wrong content")
 	}
 
-	if verifySHA512(content, "# SHA512 HASH\ndeadbeef  test.txt\n") {
+	if verifySHA512(content, "# SHA512 HASH\ndeadbeef  test.txt\n", "test.txt") {
 		t.Error("expected SHA512 verification to fail for wrong hash")
+	}
+
+	// filename mismatch must fail even if hash matches
+	if verifySHA512(content, digest, "other.txt") {
+		t.Error("expected SHA512 verification to fail for wrong filename")
 	}
 }
 

--- a/internal/bakery/security_test.go
+++ b/internal/bakery/security_test.go
@@ -145,18 +145,12 @@ func TestSHA256Injection_CraftedCatalogURL(t *testing.T) {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
 
-	// FINDING: The evil URL is accepted and placed into the entry — no domain
-	// validation or HTTPS enforcement on download URLs from the catalog.
+	// The catalog layer stores the URL as-is; HTTPS enforcement happens in
+	// ignition.GenerateButane() when the URL is embedded into the Ignition config.
 	if entries[0].URL != "http://evil.attacker.example.com/backdoor.raw" {
-		t.Errorf("expected evil URL to pass through, got %q", entries[0].URL)
+		t.Errorf("expected evil URL to pass through catalog fetch, got %q", entries[0].URL)
 	}
-	// NOTE: SHA256 will be empty because the SHA256SUMS URL points to the evil
-	// server which is unreachable from the test. The key finding is that the
-	// download URL itself is accepted without domain validation.
-	// In a real attack where the attacker controls the SHA256SUMS server too,
-	// they'd provide a matching hash — making verification useless.
-	// The entry proceeds regardless (soft fail on SHA256 fetch).
-	_ = entries[0].Sha256 // may be empty (unreachable) or attacker-controlled
+	_ = entries[0].Sha256 // may be empty (unreachable evil server)
 }
 
 // TestSHA256_ValidHashExtracted verifies the happy path: hash is correctly
@@ -232,7 +226,7 @@ func TestSHA256_PrefixedFilename(t *testing.T) {
 // TestVerifySHA512_EmptyDigestFile documents that an empty .DIGESTS file
 // results in verification failure (returns false).
 func TestVerifySHA512_EmptyDigestFile(t *testing.T) {
-	if verifySHA512("any content", "") {
+	if verifySHA512("any content", "", "test.txt") {
 		t.Error("verifySHA512 should return false for empty digest body")
 	}
 }
@@ -242,7 +236,7 @@ func TestVerifySHA512_EmptyDigestFile(t *testing.T) {
 func TestVerifySHA512_MissingHashSection(t *testing.T) {
 	// No "# SHA512 HASH" marker — all lines are ignored
 	digest := "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f  test.txt\n"
-	if verifySHA512("hello world", digest) {
+	if verifySHA512("hello world", digest, "test.txt") {
 		t.Error("should fail when # SHA512 HASH header is missing")
 	}
 }
@@ -319,9 +313,10 @@ func TestGPGSignature_MissingAscFile(t *testing.T) {
 	}
 }
 
-// TestNoSHA256HashValidation documents that the SHA256 hash format is never
-// validated — any string is accepted as a hash (no length/hex check).
-func TestNoSHA256HashValidation(t *testing.T) {
+// TestSHA256HashValidation verifies that malformed SHA256 hashes are rejected.
+// fetchSHA256ForAsset returns ("", err) for non-hex-64 strings; the entry
+// is still included in the catalog but with an empty Sha256 (soft fail).
+func TestSHA256HashValidation(t *testing.T) {
 	payload := `[{"tag_name":"docker-v24.0.7","body":"Docker","assets":[
 		{"name":"docker-24.0.7-x86-64.raw","browser_download_url":"https://BASEURL/docker-24.0.7-x86-64.raw"},
 		{"name":"SHA256SUMS","browser_download_url":"https://BASEURL/SHA256SUMS"}
@@ -348,10 +343,8 @@ func TestNoSHA256HashValidation(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-	// FINDING: Invalid hash format accepted without validation.
-	// Ignition will reject it at install time (butane validation catches it),
-	// but the catalog layer doesn't guard against it.
-	if entries[0].Sha256 != "not-a-valid-hash!!!" {
-		t.Errorf("expected invalid hash to be stored as-is, got %q", entries[0].Sha256)
+	// Invalid hash is rejected; entry is still present but Sha256 is empty (soft fail).
+	if entries[0].Sha256 != "" {
+		t.Errorf("expected empty Sha256 for invalid hash, got %q", entries[0].Sha256)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -67,11 +67,15 @@ func (c *Client) FetchKeys(ctx context.Context, username string) ([]string, erro
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
+	const maxKeys = 50
 	var keys []string
 	for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			keys = append(keys, line)
+		}
+		if len(keys) >= maxKeys {
+			break
 		}
 	}
 

--- a/internal/github/github_security_test.go
+++ b/internal/github/github_security_test.go
@@ -109,10 +109,10 @@ func TestFetchKeys_MaliciousKeyContent(t *testing.T) {
 			desc:     "Windows-style line endings may leave \\r in keys",
 		},
 		{
-			name:     "many keys (1000)",
+			name:     "many keys (1000) capped at 50",
 			response: strings.Repeat("ssh-ed25519 AAAA user@host\n", 1000),
-			wantKeys: 1000,
-			desc:     "no limit on number of keys returned",
+			wantKeys: 50,
+			desc:     "key count capped at maxKeys (50) to prevent resource exhaustion",
 		},
 	}
 

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -74,6 +74,13 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		rebootStrategy = "reboot"
 	}
 
+	// Enforce HTTPS for sysext download URLs before embedding in Ignition config.
+	for _, s := range filterSelected(cfg.Sysexts) {
+		if !strings.HasPrefix(s.URL, "https://") {
+			return "", fmt.Errorf("sysext %q has non-HTTPS download URL %q", s.Name, s.URL)
+		}
+	}
+
 	hasPassword := false
 	for _, u := range cfg.Users {
 		if u.PasswordHash != "" {

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -784,3 +784,19 @@ func TestGenerateButaneSwapDisabled(t *testing.T) {
 		t.Error("swap unit must not appear when Swap.Enabled = false")
 	}
 }
+
+func TestGenerateButane_SysextHTTPURLRejected(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "node01",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA key"}}},
+		Sysexts: []model.SysextEntry{
+			{Name: "docker", URL: "http://evil.example.com/docker.raw", Selected: true},
+		},
+	}
+	_, err := g.GenerateButane(cfg)
+	if err == nil {
+		t.Error("expected error for non-HTTPS sysext URL, got nil")
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -18,8 +18,8 @@ var (
 	reGroupName      = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 	reInterfaceName  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 	reGitHubUsername = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
-	reFlatcarVersion   = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
-	reSysextName       = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+	reFlatcarVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	reSysextName     = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 	// Tailscale auth keys: tskey-auth-<id12>-<secret32+>; tskey-client- variant also accepted.
 	// See https://tailscale.com/kb/1085/auth-keys for the format.
 	reTailscaleAuthKey = regexp.MustCompile(`^tskey-(auth|client)-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}$`)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -19,6 +19,7 @@ var (
 	reInterfaceName  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 	reGitHubUsername = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`)
 	reFlatcarVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	reSysextName     = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 )
 
 // Hostname validates a Linux hostname (RFC 1123).
@@ -291,6 +292,18 @@ func FlatcarVersion(s string) error {
 	}
 	if !reFlatcarVersion.MatchString(s) {
 		return fmt.Errorf("invalid Flatcar version %q: must be MAJOR.MINOR.PATCH (e.g. 3510.2.8)", s)
+	}
+	return nil
+}
+
+// SysextName validates a sysext extension name used in Butane/Ignition paths.
+// Allows alphanumeric, hyphens, and underscores — no dots, slashes, or path traversal.
+func SysextName(s string) error {
+	if s == "" {
+		return fmt.Errorf("sysext name cannot be empty")
+	}
+	if !reSysextName.MatchString(s) {
+		return fmt.Errorf("invalid sysext name %q: must contain only alphanumeric, hyphens, or underscores", s)
 	}
 	return nil
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -576,3 +576,68 @@ func TestFlatcarVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestSysextName(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"docker", false},
+		{"nvidia-runtime", false},
+		{"my_ext", false},
+		{"", true},
+		{"bad/name", true},
+		{"bad.name", true},
+		{"bad name", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			err := SysextName(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SysextName(%q) error=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGateway(t *testing.T) {
+	if err := Gateway("192.168.1.1"); err != nil {
+		t.Errorf("expected valid gateway, got %v", err)
+	}
+	if err := Gateway("notanip"); err == nil {
+		t.Error("expected error for invalid gateway")
+	}
+}
+
+func TestDNSServer(t *testing.T) {
+	if err := DNSServer("8.8.8.8"); err != nil {
+		t.Errorf("expected valid DNS, got %v", err)
+	}
+	if err := DNSServer("notanip"); err == nil {
+		t.Error("expected error for invalid DNS")
+	}
+}
+
+func TestTailscaleAuthKey(t *testing.T) {
+	if err := TailscaleAuthKey("tskey-auth-abcdef1234-secretsecretsecretsecret12"); err != nil {
+		t.Errorf("expected valid key, got %v", err)
+	}
+	if err := TailscaleAuthKey("plaintext"); err == nil {
+		t.Error("expected error for invalid key")
+	}
+	if err := TailscaleAuthKey(""); err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
+func TestTailscaleRoutes(t *testing.T) {
+	if err := TailscaleRoutes("10.0.0.0/24,192.168.1.0/24"); err != nil {
+		t.Errorf("expected valid routes, got %v", err)
+	}
+	if err := TailscaleRoutes(""); err == nil {
+		t.Error("expected error for empty routes")
+	}
+	if err := TailscaleRoutes("notacidr"); err == nil {
+		t.Error("expected error for invalid CIDR")
+	}
+}


### PR DESCRIPTION
Closes #131
Closes #136
Closes #137
Closes #138
Closes #139

## Summary

Five security hardening fixes for the sysext catalog and download pipeline:

- **#131 `verifySHA512`**: Now requires both hash *and* filename to match in the DIGESTS file. Previously only the hash was checked, allowing a hash-swap attack where the hash of artifact A listed under artifact B's filename would be accepted.
- **#136 `FetchKeys` key cap**: Limits accepted SSH keys from GitHub to 50 (`maxKeys`). Previously there was no limit, allowing up to ~12,500 keys that could exhaust resources during Butane/Ignition generation.
- **#137 HTTPS enforcement**: `ignition.GenerateButane()` now rejects sysext download URLs that are not `https://`, preventing non-HTTPS URLs from being embedded in the generated Ignition config.
- **#138 SHA256 format validation**: `fetchSHA256ForAsset` validates the returned hash is a 64-char lowercase hex string before storing it. Malformed hashes are silently discarded (soft fail — entry still included, Sha256 left empty).
- **#139 `validate.SysextName`**: New validator allows only alphanumeric, hyphens, and underscores in sysext names. `FetchCatalogArch` silently skips entries whose names fail this check, preventing path traversal or YAML injection via crafted sysext names.

## Test plan
- [x] `go test ./internal/bakery/... ./internal/github/... ./internal/validate/... ./internal/ignition/...` passes
- [x] New tests: filename mismatch detection, key cap, HTTPS rejection, malformed-hash soft-fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced hash verification: malformed SHA256 digests are now rejected, and SHA512 verification now includes filename matching to ensure digests correspond to expected files.
  * Capped maximum SSH keys returned to 50 to prevent resource exhaustion.
  * Sysext URLs must now use HTTPS; invalid sysext names are rejected during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->