### PR TITLE
fix: persist-credentials: false in release.yml and Renovate SHA pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:
@@ -122,6 +124,8 @@ jobs:
     needs: release-amd64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>projectbluefin/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
Closes #147
Closes #148

## Summary
- **#147**: Both `release-amd64` and `release-arm64` `actions/checkout` steps now set `persist-credentials: false`. Without this, the elevated GITHUB_TOKEN (`contents:write`, `packages:write`, `id-token:write`) is persisted in the git config for the entire job and accessible to any subsequent step — including third-party actions like `cosign-installer`, `setup-oras`, and `sbom-action`.
- **#148**: `renovate.json` now enables `pinDigests: true` for `github-actions` packages. Renovate will open PRs to pin all action references to full commit SHAs and automatically send updates as new versions are released. This is the systematic fix — maintaining SHAs manually goes stale.

## Test plan
- [x] Release workflow still checks out at job start
- [x] Renovate configuration validated against schema
- [ ] Renovate will open follow-up PRs pinning all action SHAs once this merges