### PR TITLE
fix: SHA512 + GPG verification for PXE downloads in build-iso.sh

### DIFF
--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -115,6 +115,85 @@ else
     echo "[1/5] Using existing knuckle binary: $BINARY"
 fi
 
+# ── verify_pxe_file: SHA512 + GPG verification for a downloaded PXE file ──────
+# Usage: verify_pxe_file <local_file> <upstream_base_url> <upstream_filename>
+# Fetches <url>.DIGESTS and <url>.DIGESTS.asc, verifies the GPG signature against
+# the embedded Flatcar release key, then confirms the SHA512 of the local file.
+# Exits non-zero on GPG or SHA512 mismatch. Skips silently if DIGESTS unreachable.
+FLATCAR_KEY="$ROOT_DIR/internal/bakery/keys/flatcar-signing.asc"
+verify_pxe_file() {
+    local local_file="$1"
+    local upstream_url="$2"
+    local upstream_name="$3"
+
+    local digests_url="${upstream_url}.DIGESTS"
+    local asc_url="${digests_url}.asc"
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    local digests_file="$tmp_dir/DIGESTS"
+    local asc_file="$tmp_dir/DIGESTS.asc"
+
+    # Fetch DIGESTS (soft-fail if unavailable — CDN may not publish per-file digests)
+    if ! curl -fsSL --max-time 30 -o "$digests_file" "$digests_url" 2>/dev/null; then
+        rm -rf "$tmp_dir"
+        echo "  ⚠ DIGESTS not available for $upstream_name — skipping verification" >&2
+        return 0
+    fi
+
+    # GPG signature verification
+    if curl -fsSL --max-time 30 -o "$asc_file" "$asc_url" 2>/dev/null; then
+        local gpg_home="$tmp_dir/gnupg"
+        mkdir -p "$gpg_home"
+        chmod 700 "$gpg_home"
+        GNUPGHOME="$gpg_home" gpg --quiet --import "$FLATCAR_KEY" 2>/dev/null
+        if ! GNUPGHOME="$gpg_home" gpg --quiet --verify "$asc_file" "$digests_file" 2>/dev/null; then
+            rm -rf "$tmp_dir"
+            echo "error: GPG signature verification failed for $upstream_name" >&2
+            exit 1
+        fi
+        echo "  ✓ GPG signature verified: $upstream_name"
+    else
+        echo "  ⚠ .DIGESTS.asc unavailable — GPG check skipped for $upstream_name" >&2
+    fi
+
+    # SHA512 verification against the DIGESTS file (filename-bound, not just hash)
+    local insha512=0 expected_hash=""
+    while IFS= read -r line; do
+        if [[ "$line" == "# SHA512 HASH" ]]; then
+            insha512=1; continue
+        fi
+        if [[ "$line" =~ ^# ]]; then
+            insha512=0; continue
+        fi
+        if [[ "$insha512" -eq 1 && -n "$line" ]]; then
+            local hash fname
+            hash="${line%%  *}"
+            fname="${line##*  }"
+            if [[ "$fname" == "$upstream_name" ]]; then
+                expected_hash="$hash"
+                break
+            fi
+        fi
+    done < "$digests_file"
+
+    if [[ -z "$expected_hash" ]]; then
+        rm -rf "$tmp_dir"
+        echo "error: SHA512 for $upstream_name not found in DIGESTS" >&2
+        exit 1
+    fi
+
+    local actual_hash
+    actual_hash="$(sha512sum "$local_file" | awk '{print $1}')"
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+        rm -rf "$tmp_dir"
+        echo "error: SHA512 mismatch for $upstream_name (expected $expected_hash, got $actual_hash)" >&2
+        exit 1
+    fi
+    echo "  ✓ SHA512 verified: $upstream_name"
+
+    rm -rf "$tmp_dir"
+}
+
 # ── 2. Download Flatcar PXE artifacts ────────────────────────────────────────
 mkdir -p "$BUILD_DIR"
 echo "[2/5] Fetching Flatcar PXE artifacts ($CHANNEL)..."
@@ -124,9 +203,11 @@ INITRD="$BUILD_DIR/initrd.cpio.gz"
 
 if [[ ! -f "$KERNEL" ]]; then
     curl -fsSL -o "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz"
+    verify_pxe_file "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz" "flatcar_production_pxe.vmlinuz"
 fi
 if [[ ! -f "$INITRD" ]]; then
     curl -fsSL -o "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz"
+    verify_pxe_file "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz" "flatcar_production_pxe_image.cpio.gz"
 fi
 
 echo "  kernel : $(du -h "$KERNEL"  | cut -f1)"


### PR DESCRIPTION
Closes #141

## Summary

`build-iso.sh` downloads the Flatcar PXE kernel and initrd via `curl -fsSL` with no subsequent integrity check. A CDN compromise or MITM could embed a malicious kernel/initrd in the distributed installer ISO without detection.

This PR adds a `verify_pxe_file()` helper that runs after each fresh download:

1. **Fetches** the corresponding `.DIGESTS` and `.DIGESTS.asc` from the Flatcar release server (same URL, different suffix)
2. **GPG-verifies** the `.DIGESTS.asc` cleartext signature against the embedded Flatcar release key (`internal/bakery/keys/flatcar-signing.asc`) in an isolated temp keyring — hard-fails on bad signature, soft-skips if `.asc` is unavailable
3. **SHA512-verifies** the downloaded file against the DIGESTS entry, with the filename bound to the hash (matching the fix in #131 for the Go path)
4. **Exits non-zero** on any hash or signature mismatch

Verification only runs on fresh downloads; cached artifacts (already in `.iso-build/`) are skipped.

## Test plan
- [x] `bash -n scripts/build-iso.sh` passes (syntax check)
- [ ] On a full build: valid channel downloads produce `✓ SHA512 verified` output
- [ ] Corrupted artifact produces `error: SHA512 mismatch` and non-zero exit