### PR TITLE
fix: partial channel results, headless timeout, and SSH key base64 validation

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
 	"github.com/projectbluefin/knuckle/internal/headless"
@@ -168,8 +169,9 @@ func runHeadless(configPath string, dryRun bool, logFile string) {
 
 	installer := install.NewFlatcarInstaller(cmdRunner, logger)
 
-	// Run headless install
-	ctx := context.Background()
+	// Run headless install with a 30-minute wall-clock timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 	if err := headless.Run(ctx, cfg, installer, logger); err != nil {
 		fmt.Fprintf(os.Stderr, "\n❌ %v\n", err)
 		os.Exit(1)
@@ -177,7 +179,7 @@ func runHeadless(configPath string, dryRun bool, logFile string) {
 
 	// Handle reboot through runner (keeps DryRunner/SpyRunner semantics)
 	if cfg.Reboot && !cfg.DryRun {
-		if _, err := cmdRunner.Run(ctx, "systemctl", "reboot"); err != nil {
+		if _, err := cmdRunner.Run(context.Background(), "systemctl", "reboot"); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: reboot failed: %v\n", err)
 			os.Exit(1)
 		}

--- a/internal/bakery/channels.go
+++ b/internal/bakery/channels.go
@@ -145,6 +145,8 @@ func FetchAllChannelsArch(ctx context.Context, arch string) ([]ChannelInfo, erro
 }
 
 // fetchAllChannelsWithURLFn is a helper for parallel channel fetching with custom URLs.
+// Channels that fail are skipped and a combined error is returned alongside the
+// partial results so callers can choose to proceed with what succeeded.
 func fetchAllChannelsWithURLFn(ctx context.Context, urlFn func(string) (string, string), channels ...string) ([]ChannelInfo, error) {
 	if len(channels) == 0 {
 		channels = []string{"stable", "beta", "alpha", "lts"}
@@ -160,7 +162,7 @@ func fetchAllChannelsWithURLFn(ctx context.Context, urlFn func(string) (string, 
 			vURL, pURL := urlFn(channel)
 			info, err := fetchChannelInfoFromURLs(ctx, channel, vURL, pURL)
 			if err != nil {
-				errs[idx] = err
+				errs[idx] = fmt.Errorf("%s: %w", channel, err)
 				return
 			}
 			results[idx] = *info
@@ -168,14 +170,25 @@ func fetchAllChannelsWithURLFn(ctx context.Context, urlFn func(string) (string, 
 	}
 	wg.Wait()
 
-	// Return first error encountered
-	for _, err := range errs {
+	// Collect successful results and accumulate per-channel errors.
+	var out []ChannelInfo
+	var firstErr error
+	for i, err := range errs {
 		if err != nil {
-			return nil, err
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if results[i].Channel != "" {
+			out = append(out, results[i])
 		}
 	}
+	if firstErr != nil && len(out) == 0 {
+		return nil, firstErr
+	}
 
-	return results, nil
+	return out, firstErr
 }
 
 // httpGet performs a GET request with the shared client and returns the body as a string.

--- a/internal/github/github_security_test.go
+++ b/internal/github/github_security_test.go
@@ -17,7 +17,7 @@ func TestFetchKeys_UsernamePathTraversal(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestedPath = r.URL.Path
 		// Return a valid key for any request so we can inspect the path
-		_, _ = fmt.Fprintln(w, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@test")
+		_, _ = fmt.Fprintln(w, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@test")
 	}))
 	defer srv.Close()
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -44,7 +44,7 @@ func TestClient_FetchKeys_WithTestServer(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/testuser.keys":
-			_, _ = fmt.Fprintln(w, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest testuser@github")
+			_, _ = fmt.Fprintln(w, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 testuser@github")
 		case "/nokeys.keys":
 			_, _ = fmt.Fprintln(w, "")
 		case "/gone.keys":

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -456,7 +456,7 @@ func TestToInstallConfig_StaticNetwork(t *testing.T) {
 }
 
 func TestRun_GitHubUser(t *testing.T) {
-	const fakeKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGitHubKey github-test-key"
+	const fakeKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 github-test-key"
 
 	old := fetchGitHubKeysFunc
 	fetchGitHubKeysFunc = func(_ context.Context, username string) ([]string, error) {

--- a/internal/ignition/compile_test.go
+++ b/internal/ignition/compile_test.go
@@ -87,7 +87,7 @@ passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAItest test@test
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@test
 `
 	got, err := CompileToIgnition(butane)
 	if err != nil {

--- a/internal/ignition/ignition_edge_test.go
+++ b/internal/ignition/ignition_edge_test.go
@@ -44,7 +44,7 @@ func TestGenerateButane_ZeroUsers_WithSSHKeys(t *testing.T) {
 		Hostname: "keyed-node",
 		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
 		Users:    []model.UserConfig{},
-		SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV test@host"},
+		SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@host"},
 	}
 
 	output, err := g.GenerateButane(cfg)
@@ -55,7 +55,7 @@ func TestGenerateButane_ZeroUsers_WithSSHKeys(t *testing.T) {
 	if !strings.Contains(output, `name: "core"`) {
 		t.Error("expected default 'core' user")
 	}
-	if !strings.Contains(output, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV") {
+	if !strings.Contains(output, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7") {
 		t.Error("expected SSH key on default core user")
 	}
 
@@ -253,11 +253,11 @@ func TestGenerateButane_SSHKeyWithSpecialComment(t *testing.T) {
 		name string
 		key  string
 	}{
-		{"key with email comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV user@host.example.com"},
-		{"key with spaces in comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV John Doe's Key"},
-		{"key with quotes in comment", `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV "quoted comment"`},
-		{"key with backslash", `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV C:\Users\test`},
-		{"key with unicode", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV ñoño@café"},
+		{"key with email comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 user@host.example.com"},
+		{"key with spaces in comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 John Doe's Key"},
+		{"key with quotes in comment", `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 "quoted comment"`},
+		{"key with backslash", `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 C:\Users\test`},
+		{"key with unicode", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 ñoño@café"},
 	}
 
 	for _, tc := range tests {
@@ -287,7 +287,7 @@ func TestGenerateButane_SSHKeyWithSpecialComment(t *testing.T) {
 
 func TestGenerateButane_LongRSAKey(t *testing.T) {
 	// Simulate a 4096-bit RSA key (~550 chars base64 + prefix + comment)
-	longKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLOoG8r0Mz8P5Z5q5n5oK3m3q5P" +
+	longKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjTid/Xxpik4yiFwhLdPiIkG28XBLeIqvb0/nAwjyYJU8KU7qy91tGCFf/09D3VTnJbp3jfrOwboxb4iL+BiowC5bhbdJtHkQ89tx/xDw8ljrOx025UWp6EvOrD+rk7Aw4kYnLJ0CA5MvzdgVOal0brgHIpw34hbrP/yPNdv/H8VMsZBT+pXDQP0JcGe0K8HRM54cn/xIrSYnUvEZBb+kpscPXJtUGFNDSFxFp7fPhlViYLxDuNQtRgc7u3mAMuLMbxI6JxkIsvZ14PxxFTQ4Vq+BnJEazHgFn3wz86dHqanwx/sE9bBWsk7fhV2rfWpI1WI4KaTVfgeFaJ404VRkP" +
 		strings.Repeat("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", 10) +
 		" user@very-long-key-host.example.com"
 
@@ -324,8 +324,8 @@ func TestGenerateButane_LongRSAKey(t *testing.T) {
 func TestGenerateButane_MultipleSSHKeysPerUser(t *testing.T) {
 	g := NewGenerator()
 	keys := []string{
-		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBcV key1@host",
-		"ssh-rsa AAAAB3NzaC1yc2EAAAA" + strings.Repeat("X", 500) + " key2@host",
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 key1@host",
+		"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjTid/Xxpik4yiFwhLdPiIkG28XBLeIqvb0/nAwjyYJU8KU7qy91tGCFf/09D3VTnJbp3jfrOwboxb4iL+BiowC5bhbdJtHkQ89tx/xDw8ljrOx025UWp6EvOrD+rk7Aw4kYnLJ0CA5MvzdgVOal0brgHIpw34hbrP/yPNdv/H8VMsZBT+pXDQP0JcGe0K8HRM54cn/xIrSYnUvEZBb+kpscPXJtUGFNDSFxFp7fPhlViYLxDuNQtRgc7u3mAMuLMbxI6JxkIsvZ14PxxFTQ4Vq+BnJEazHgFn3wz86dHqanwx/sE9bBWsk7fhV2rfWpI1WI4KaTVfgeFaJ404VRkP" + strings.Repeat("X", 500) + " key2@host",
 		"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAI key3@host",
 	}
 

--- a/internal/iso/iso_test.go
+++ b/internal/iso/iso_test.go
@@ -53,7 +53,7 @@ func TestGenerateInstallerIgnition(t *testing.T) {
 	})
 
 	t.Run("with SSH key", func(t *testing.T) {
-		key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAATEST test@example.com"
+		key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@example.com"
 		data, err := GenerateInstallerIgnition(key)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/internal/tui/user_step_test.go
+++ b/internal/tui/user_step_test.go
@@ -160,8 +160,8 @@ func TestFetchKeysWithKeys_Advances(t *testing.T) {
 	m.sshKeyInput = ""
 
 	githubKeys := []string{
-		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA github1@user",
-		"ssh-rsa AAAAB3NzaC1yc2EAAAA github2@user",
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 github1@user",
+		"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjTid/Xxpik4yiFwhLdPiIkG28XBLeIqvb0/nAwjyYJU8KU7qy91tGCFf/09D3VTnJbp3jfrOwboxb4iL+BiowC5bhbdJtHkQ89tx/xDw8ljrOx025UWp6EvOrD+rk7Aw4kYnLJ0CA5MvzdgVOal0brgHIpw34hbrP/yPNdv/H8VMsZBT+pXDQP0JcGe0K8HRM54cn/xIrSYnUvEZBb+kpscPXJtUGFNDSFxFp7fPhlViYLxDuNQtRgc7u3mAMuLMbxI6JxkIsvZ14PxxFTQ4Vq+BnJEazHgFn3wz86dHqanwx/sE9bBWsk7fhV2rfWpI1WI4KaTVfgeFaJ404VRkP github2@user",
 	}
 	newModel, _ := m.Update(fetchKeysMsg{keys: githubKeys, err: nil})
 	got := newModel.(*Model)
@@ -260,7 +260,7 @@ func TestEnterUserStep_ManualSSHKeyOnly_Advances(t *testing.T) {
 	m.activeForm = nil
 
 	// Set the manual SSH key field; clear GitHub so no async fetch fires.
-	const manualKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA manualkey@host"
+	const manualKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 manualkey@host"
 	for i := range m.fields {
 		switch m.fields[i].key {
 		case "github_user":
@@ -348,7 +348,7 @@ func TestFetchKeysGitHubPlusLocal_MergesAndAdvances(t *testing.T) {
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		t.Fatalf("creating temp .ssh dir: %v", err)
 	}
-	const localKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI localkey@installer"
+	const localKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 localkey@installer"
 	if err := os.WriteFile(filepath.Join(sshDir, "id_ed25519.pub"),
 		[]byte(localKey+"\n"), 0600); err != nil {
 		t.Fatalf("writing temp pubkey: %v", err)
@@ -362,7 +362,7 @@ func TestFetchKeysGitHubPlusLocal_MergesAndAdvances(t *testing.T) {
 	m := New(w)
 	m.sshKeyInput = ""
 
-	githubKeys := []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA githubkey@user"}
+	githubKeys := []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 githubkey@user"}
 	newModel, _ := m.Update(fetchKeysMsg{keys: githubKeys, err: nil})
 	got := newModel.(*Model)
 
@@ -408,7 +408,7 @@ func TestEnterUserStep_WithLocalKeys_Advances(t *testing.T) {
 		t.Fatalf("creating temp .ssh dir: %v", err)
 	}
 	// Key format only needs type + base64-ish blob to pass validate.SSHPublicKey.
-	keyLine := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBXntestlocalkey test@local\n"
+	keyLine := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@local\n"
 	if err := os.WriteFile(filepath.Join(sshDir, "id_ed25519.pub"), []byte(keyLine), 0600); err != nil {
 		t.Fatalf("writing temp pubkey: %v", err)
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -2,6 +2,7 @@
 package validate
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net"
 	"regexp"
@@ -87,12 +88,20 @@ func SSHPublicKey(s string) error {
 		"sk-ssh-ed25519@openssh.com",
 		"sk-ecdsa-sha2-nistp256@openssh.com",
 	}
+	validType := false
 	for _, t := range validTypes {
 		if parts[0] == t {
-			return nil
+			validType = true
+			break
 		}
 	}
-	return fmt.Errorf("unsupported SSH key type: %s", parts[0])
+	if !validType {
+		return fmt.Errorf("unsupported SSH key type: %s", parts[0])
+	}
+	if _, err := base64.StdEncoding.DecodeString(parts[1]); err != nil {
+		return fmt.Errorf("invalid SSH key: base64 payload is malformed")
+	}
+	return nil
 }
 
 // Username validates a Linux username.

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -99,15 +99,16 @@ func TestSSHPublicKey(t *testing.T) {
 		input   string
 		wantErr bool
 	}{
-		{"valid ed25519", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample user@host", false},
-		{"valid rsa", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQExample user@host", false},
+		{"valid ed25519", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 user@host", false},
+		{"valid rsa", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDjTid/Xxpik4yiFwhLdPiIkG28XBLeIqvb0/nAwjyYJU8KU7qy91tGCFf/09D3VTnJbp3jfrOwboxb4iL+BiowC5bhbdJtHkQ89tx/xDw8ljrOx025UWp6EvOrD+rk7Aw4kYnLJ0CA5MvzdgVOal0brgHIpw34hbrP/yPNdv/H8VMsZBT+pXDQP0JcGe0K8HRM54cn/xIrSYnUvEZBb+kpscPXJtUGFNDSFxFp7fPhlViYLxDuNQtRgc7u3mAMuLMbxI6JxkIsvZ14PxxFTQ4Vq+BnJEazHgFn3wz86dHqanwx/sE9bBWsk7fhV2rfWpI1WI4KaTVfgeFaJ404VRkP user@host", false},
 		{"valid ecdsa", "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY= comment", false},
-		{"valid no comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample", false},
+		{"valid no comment", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7", false},
 		{"valid sk key", "sk-ssh-ed25519@openssh.com AAAAG3NrLXNzaC1lZDI1NTE5 user", false},
 		{"invalid empty", "", true},
 		{"invalid no data", "ssh-ed25519", true},
-		{"invalid type", "ssh-invalid AAAAC3NzaC1lZDI1NTE5AAAAIExample", true},
+		{"invalid type", "ssh-invalid AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7", true},
 		{"invalid just text", "notakey", true},
+		{"invalid base64 payload", "ssh-ed25519 not!valid@base64 user@host", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -114,7 +114,7 @@ func TestNextAndPrevious(t *testing.T) {
 	}
 	// StepUser -> StepSysext: need user
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
 	}
 	if err := w.Next(); err != nil {
 		t.Fatalf("Next from User: %v", err)
@@ -257,7 +257,7 @@ func TestValidateUserValid(t *testing.T) {
 	w.State.Config.Users = []model.UserConfig{
 		{
 			Username: "core",
-			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test@host"},
+			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@host"},
 		},
 	}
 
@@ -630,7 +630,7 @@ func TestNextSkipsNvidiaWhenNotSelected(t *testing.T) {
 	w.State.Config.Network.Mode = model.NetworkDHCP
 	w.State.Config.Disk.DevPath = "/dev/sda"
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
 	}
 	w.State.Config.Channel = "stable"
 	// No nvidia-runtime in sysexts
@@ -653,7 +653,7 @@ func TestNextVisitsNvidiaWhenSelected(t *testing.T) {
 	w.State.Config.Network.Mode = model.NetworkDHCP
 	w.State.Config.Disk.DevPath = "/dev/sda"
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
 	}
 	w.State.Config.Channel = "stable"
 	// nvidia-runtime IS selected
@@ -738,7 +738,7 @@ func TestBackAndModify_SSHKeysRebuilt(t *testing.T) {
 	w.State.Config.Network.Mode = model.NetworkDHCP
 	w.State.Config.Disk.DevPath = "/dev/sda"
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI original"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 original"}},
 	}
 	w.State.CurrentStep = model.StepReview
 
@@ -749,7 +749,7 @@ func TestBackAndModify_SSHKeysRebuilt(t *testing.T) {
 	}
 
 	// Modify SSH keys (simulates user editing)
-	w.State.Config.Users[0].SSHKeys = []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI newkey"}
+	w.State.Config.Users[0].SSHKeys = []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 newkey"}
 
 	// Advance back to Review
 	if err := w.Next(); err != nil {
@@ -769,7 +769,7 @@ func TestBackAndModify_SSHKeysRebuilt(t *testing.T) {
 	}
 
 	// Verify the config reflects the NEW key
-	if w.State.Config.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI newkey" {
+	if w.State.Config.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 newkey" {
 		t.Errorf("SSH key not updated after back-navigation, got: %v", w.State.Config.Users[0].SSHKeys)
 	}
 
@@ -812,7 +812,7 @@ func TestFullHappyPath_WelcomeToDone(t *testing.T) {
 
 	// StepUser — add a user with SSH key
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test@laptop"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@laptop"}},
 	}
 	w.State.Config.Hostname = "flatcar-node-01"
 	if err := w.Next(); err != nil {
@@ -958,8 +958,8 @@ func TestValidateUser_SecondUserInvalidUsername(t *testing.T) {
 	w, _, _, _ := newTestWizard()
 	w.State.CurrentStep = model.StepUser
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
-		{Username: "root", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test2"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
+		{Username: "root", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test2"}},
 	}
 
 	// "root" may or may not be valid depending on validate.Username — test the boundary
@@ -1029,7 +1029,7 @@ func TestFullHappyPath_WithNvidia(t *testing.T) {
 	w.State.Config.Network.Mode = model.NetworkDHCP
 	w.State.Config.Disk.DevPath = "/dev/sda"
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
 	}
 	w.State.Config.NvidiaDriverVersion = "570-open"
 	w.State.Sysexts = []model.SysextEntry{
@@ -1167,7 +1167,7 @@ func TestValidateUser_RejectsRoot(t *testing.T) {
 	w, _, _, _ := newTestWizard()
 	w.State.CurrentStep = model.StepUser
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "root", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test"}},
+		{Username: "root", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
 	}
 
 	// validate.Username may or may not reject "root" — test what actually happens
@@ -1253,8 +1253,8 @@ func TestRouteA_DHCP_GitHubKeys_NoSysext(t *testing.T) {
 		{
 			Username: "core",
 			SSHKeys: []string{
-				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGithubKey1 user@laptop",
-				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGithubKey2 user@desktop",
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 user@laptop",
+				"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 user@desktop",
 			},
 		},
 	}
@@ -1622,7 +1622,7 @@ func TestRouteD_NvidiaRuntime_DriverSetup(t *testing.T) {
 	// ── User ──────────────────────────────────────────────────────────────
 	w.State.Config.Hostname = "gpu-node-01"
 	w.State.Config.Users = []model.UserConfig{
-		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpuKey user@workstation"}},
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 user@workstation"}},
 	}
 	st.record(w, t, "User→Sysext")
 
@@ -1731,7 +1731,7 @@ func TestRouteE_ReviewBackToUser_FixAndReadvance(t *testing.T) {
 	w.State.Config.Users = []model.UserConfig{
 		{
 			Username: "core",
-			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOriginalKey original@host"},
+			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 original@host"},
 		},
 	}
 
@@ -1762,11 +1762,11 @@ func TestRouteE_ReviewBackToUser_FixAndReadvance(t *testing.T) {
 	w.State.Config.Users = []model.UserConfig{
 		{
 			Username: "core",
-			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFixedKey fixed@workstation"},
+			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 fixed@workstation"},
 		},
 		{
 			Username: "admin",
-			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAdminKey admin@ci"},
+			SSHKeys:  []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 admin@ci"},
 		},
 	}
 	// Validate User step with new config
@@ -1803,7 +1803,7 @@ func TestRouteE_ReviewBackToUser_FixAndReadvance(t *testing.T) {
 	if len(w.State.Config.Users) != 2 {
 		t.Fatalf("expected 2 users after edit, got %d", len(w.State.Config.Users))
 	}
-	if w.State.Config.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFixedKey fixed@workstation" {
+	if w.State.Config.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 fixed@workstation" {
 		t.Errorf("SSH key not updated: got %q", w.State.Config.Users[0].SSHKeys[0])
 	}
 	if w.State.Config.Users[1].Username != "admin" {
@@ -1846,7 +1846,7 @@ func TestRouteE_ReviewBackToUser_FixAndReadvance(t *testing.T) {
 	if len(cfg.Users) != 2 {
 		t.Fatalf("final config: expected 2 users, got %d", len(cfg.Users))
 	}
-	if cfg.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFixedKey fixed@workstation" {
+	if cfg.Users[0].SSHKeys[0] != "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 fixed@workstation" {
 		t.Errorf("final config: wrong SSH key for core: %q", cfg.Users[0].SSHKeys[0])
 	}
 	if cfg.Users[1].Username != "admin" {
@@ -1857,10 +1857,10 @@ func TestRouteE_ReviewBackToUser_FixAndReadvance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateButane after Route E: %v", err)
 	}
-	if strings.Contains(butane, "OriginalKey") {
+	if strings.Contains(butane, "original@host") {
 		t.Error("Butane still contains original SSH key — config mutation not propagated")
 	}
-	if !strings.Contains(butane, "FixedKey") {
+	if !strings.Contains(butane, "fixed@workstation") {
 		t.Error("Butane does not contain the fixed SSH key")
 	}
 }


### PR DESCRIPTION
Closes #172
Closes #173
Closes #174

## Summary

Three bug fixes in one PR:

### #172 — `FetchAllChannelsArch` partial results on channel error

Previously a single channel fetch failure (e.g. beta temporarily unreachable) caused the entire call to return `nil, err`, discarding successful stable/alpha/lts results. Now successful channel results are returned alongside the first error. Callers that need all channels can still check `err != nil`; callers that just need the catalog can proceed with what succeeded.

### #173 — Headless install has no wall-clock timeout

`runHeadless` was calling `context.Background()` with no deadline. A hung `flatcar-install` (slow network download, unresponsive disk) could keep the process alive forever in CI/automated environments. Fixed with a `context.WithTimeout(30 * time.Minute)` wrapping the install; the reboot command (post-install) uses a fresh `context.Background()` since it runs after the timeout scope.

### #174 — `validate.SSHPublicKey()` doesn't validate base64 payload

The function checked the key-type prefix (`ssh-ed25519`, `ssh-rsa`, etc.) but never decoded the base64 payload. A value like `"ssh-ed25519 notvalidbase64"` passed validation and would end up in Ignition, causing silent SSH auth failure at the target system. Now `base64.StdEncoding.DecodeString` is called on `parts[1]`; malformed payloads are rejected.

All test SSH key payloads have been updated to use a real `ssh-keygen`-generated ed25519 key so the new base64 check passes consistently.

## Test plan
- [x] `go test ./...` passes (all 13 packages)
- [x] New test case `invalid base64 payload` in `TestSSHPublicKey`