### PR TITLE
fix: cap headless swap.size_mb at 32 GiB (MaxSwapSizeMB)

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -331,9 +331,15 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
 	}
 
-	// Swap size must be non-negative if explicit
-	if c.Swap != nil && c.Swap.SizeMB < 0 {
-		return fmt.Errorf("swap.size_mb: must be ≥ 0 (got %d)", c.Swap.SizeMB)
+	// Swap size must be within [0, MaxSwapSizeMB]
+	if c.Swap != nil {
+		if c.Swap.SizeMB < 0 {
+			return fmt.Errorf("swap.size_mb: must be ≥ 0 (got %d)", c.Swap.SizeMB)
+		}
+		if c.Swap.SizeMB > model.MaxSwapSizeMB {
+			return fmt.Errorf("swap.size_mb: %d MiB exceeds maximum %d MiB (%.0f GiB)",
+				c.Swap.SizeMB, model.MaxSwapSizeMB, float64(model.MaxSwapSizeMB)/1024)
+		}
 	}
 
 	// Tailscale

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -1563,3 +1563,39 @@ func TestRun_InstallerError(t *testing.T) {
 		t.Fatal("expected error from installer failure, got nil")
 	}
 }
+func TestValidate_SwapSizeNegative(t *testing.T) {
+	cfg := &Config{
+		Channel: "stable",
+		Disk:    "/dev/vda",
+		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@qa"}}},
+		Swap:    &SwapConfig{Enabled: true, SizeMB: -1},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for negative swap size, got nil")
+	}
+}
+
+func TestValidate_SwapSizeExceedsMax(t *testing.T) {
+	cfg := &Config{
+		Channel: "stable",
+		Disk:    "/dev/vda",
+		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@qa"}}},
+		Swap:    &SwapConfig{Enabled: true, SizeMB: 999999},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for swap size > MaxSwapSizeMB, got nil")
+	}
+}
+
+func TestValidate_SwapSizeAtMax(t *testing.T) {
+	cfg := &Config{
+		Channel: "stable",
+		Disk:    "/dev/vda",
+		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@qa"}}},
+		Swap:    &SwapConfig{Enabled: true, SizeMB: model.MaxSwapSizeMB},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("size_mb at exact maximum should be valid, got: %v", err)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -82,6 +82,12 @@ type SwapConfig struct {
 // for home-server workloads; explicit SizeMB always overrides.
 const DefaultSwapSizeMB = 4096
 
+// MaxSwapSizeMB is the upper bound accepted by headless Config.Validate().
+// 32 GiB (8× the default) covers any realistic home-server workload while
+// preventing a misconfigured size_mb from hanging fallocate for hours or
+// silently exhausting the target disk.
+const MaxSwapSizeMB = 32768
+
 // TailscaleConfig holds optional Tailscale provisioning for the installed system.
 // Populated only when the tailscale sysext is selected. AuthKey is written to
 // /etc/tailscale/tailscale.env (mode 0600) and consumed by a oneshot systemd


### PR DESCRIPTION
Closes #182

## Summary

`Config.Validate()` rejected negative `size_mb` values but had no upper bound. A caller could pass `{"swap": {"size_mb": 999999}}` (~976 GiB) and the config would be accepted. At install time `knuckle-create-swapfile.service` calls `fallocate -l ${SIZE}M /var/swapfile`, which would either hang for a very long time or exhaust all disk space, leaving the installed system with a failed systemd unit and no usable swap — with no error message linking the failure back to the misconfigured value.

## Changes

- `model`: adds `MaxSwapSizeMB = 32768` (32 GiB, 8× the 4 GiB default) as a named constant
- `headless Validate()`: expands the existing swap block to check the upper bound; error includes both the MiB value and its GiB equivalent for operator clarity
- `headless_test`: three new cases — negative size rejected, value exceeding max rejected, value exactly at max accepted

## Test plan
- [x] `go test ./internal/headless/... ./internal/model/...` passes
- [x] `TestValidate_SwapSizeNegative` — negative rejected
- [x] `TestValidate_SwapSizeExceedsMax` — 999999 MiB rejected
- [x] `TestValidate_SwapSizeAtMax` — 32768 MiB accepted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Swap size validation now enforces a maximum size limit with enhanced error reporting that clearly communicates the limit and any configured value exceeding it, in appropriate units.

## Tests
* Added comprehensive test coverage for swap size constraint validation, including boundary conditions and out-of-range scenarios to ensure configuration validation works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->