### PR TITLE
feat: add --demo flag for mock-data TUI recording + CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,60 @@
+language: en
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "internal/runner/**"
+      instructions: |
+        This is the ONLY package allowed to use exec.Command / exec.CommandContext.
+        All external commands must go through the Runner interface. Flag any
+        exec.Command usage outside this package as a critical violation.
+    - path: "internal/tui/**"
+      instructions: |
+        No business logic in view models — TUI renders, wizard transitions.
+        Flag password hashing, key merging, or config mutations here.
+        Bubble Tea owns stdout — never log to stdout from this package.
+    - path: "internal/ignition/**"
+      instructions: |
+        All user-supplied values in the Butane template MUST use yamlEscape.
+        Temp Ignition files must be created with O_EXCL, mode 0600, and
+        cleaned up via defer. Flag any unescaped template interpolation.
+    - path: "internal/install/**"
+      instructions: |
+        Never call flatcar-install or exec directly — all commands must route
+        through the runner.Runner interface. Reboot must be injected via
+        rebootFn, never called directly. Verify DryRunner behaviour is tested.
+    - path: "internal/model/**"
+      instructions: |
+        Pure data types only — zero imports of other internal packages.
+        This is the leaf package everything depends on. Flag any import
+        of internal/* here.
+    - path: "internal/validate/**"
+      instructions: |
+        Validators must cover both valid and invalid inputs in table-driven
+        tests. New exported functions without corresponding TestXxx fail the
+        coverage gate. Regex patterns must be anchored (^ and $).
+    - path: "internal/headless/**"
+      instructions: |
+        Security-sensitive: headless is the CI/automation path. Validate()
+        must check all user-supplied fields before they reach Ignition.
+        GitHub-fetched SSH keys must be validated before use (validate.SSHPublicKey).
+        Password fields expect pre-hashed values — reject plaintext.
+    - path: ".github/workflows/**"
+      instructions: |
+        Security-sensitive. Verify actions are pinned by SHA (Renovate
+        manages this). Check for secret exposure in run: blocks. Release
+        workflow must include cosign signing, SBOM, and SLSA provenance.
+        persist-credentials: false required on all checkout steps in
+        elevated-permission jobs.
+    - path: "scripts/build-iso.sh"
+      instructions: |
+        Must use --efi-boot-part --efi-boot-image for the EFI System
+        Partition (NOT -isohybrid-gpt-basdat). TTYPath in systemd units
+        must be /dev/console. Downloaded artifacts must be SHA512+GPG
+        verified before use.
+  tools:
+    golangci-lint:
+      enabled: true
+chat:
+  auto_reply: true

--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/demo"
 	"github.com/projectbluefin/knuckle/internal/headless"
 	"github.com/projectbluefin/knuckle/internal/install"
 	"github.com/projectbluefin/knuckle/internal/probe"
@@ -33,6 +34,7 @@ func main() {
 	var (
 		configFile   string
 		headlessMode bool
+		demoMode     bool
 	)
 	flag.BoolVar(&dryRun, "dry-run", false, "simulate installation without writing to disk")
 	flag.StringVar(&logFile, "log-file", "/tmp/knuckle.log", "path to log file")
@@ -40,6 +42,7 @@ func main() {
 	flag.BoolVar(&showVer, "version", false, "print version and exit")
 	flag.StringVar(&configFile, "config", "", "path to JSON config file for headless install")
 	flag.BoolVar(&headlessMode, "headless", false, "run without TUI (requires --config)")
+	flag.BoolVar(&demoMode, "demo", false, "run with mock hardware/catalog data for UI demos and recording (no network, no real disks)")
 	var flatcarVersion string
 	flag.StringVar(&flatcarVersion, "flatcar-version", "", "pin to specific Flatcar version (e.g. 3510.2.8)")
 	flag.Parse()
@@ -79,41 +82,64 @@ func main() {
 
 	logger.Info("knuckle starting", "version", version, "dry-run", dryRun, "channel", channel)
 
-	// Set up runner (dry-run or real)
+	// Set up runner (dry-run or real; demo implies dry-run)
 	var cmdRunner runner.Runner
-	if dryRun {
+	if dryRun || demoMode {
 		cmdRunner = runner.NewDryRunner(logger)
 	} else {
 		cmdRunner = runner.NewRealRunner(logger)
 	}
 
-	// Prober always uses real runner — it only reads system state
-	realRunner := runner.NewRealRunner(logger)
-	prober := probe.NewSystemProber(realRunner)
-	bakeryClient := bakery.NewHTTPClient()
-	installer := install.NewFlatcarInstaller(cmdRunner, logger)
+	// In demo mode use mock implementations that need no hardware or network.
+	// In normal mode use the real system prober, bakery HTTP client, and installer.
+	var (
+		prober       probe.Prober
+		bakeryClient bakery.Client
+		installer    install.Installer
+	)
+	if demoMode {
+		prober = &demo.Prober{}
+		bakeryClient = &demo.Bakery{}
+		installer = &demo.Installer{}
+	} else {
+		realRunner := runner.NewRealRunner(logger)
+		prober = probe.NewSystemProber(realRunner)
+		bakeryClient = bakery.NewHTTPClient()
+		installer = install.NewFlatcarInstaller(cmdRunner, logger)
+	}
 
 	// Create wizard
 	w := wizard.New(prober, bakeryClient, installer)
 	w.State.Config.Channel = channel
-	w.State.Config.DryRun = dryRun
+	w.State.Config.DryRun = dryRun || demoMode
 	w.State.Config.Version = flatcarVersion
 
-	// Probe hardware before starting TUI
 	ctx := context.Background()
-	if err := w.ProbeHardware(ctx); err != nil {
-		logger.Warn("hardware probe failed", "error", err)
-		// Non-fatal — user can still proceed with manual input
-	}
+	if demoMode {
+		// Populate wizard state from mock data instead of probing hardware or
+		// making network calls — keeps startup instant and recording deterministic.
+		if err := w.ProbeHardware(ctx); err != nil {
+			logger.Warn("demo hardware probe failed", "error", err)
+		}
+		if err := w.FetchSysexts(ctx); err != nil {
+			logger.Warn("demo sysext fetch failed", "error", err)
+		}
+		w.State.Channels = demo.Channels()
+	} else {
+		// Probe hardware before starting TUI
+		if err := w.ProbeHardware(ctx); err != nil {
+			logger.Warn("hardware probe failed", "error", err)
+		}
 
-	// Fetch sysext catalog (non-fatal if it fails)
-	if err := w.FetchSysexts(ctx); err != nil {
-		logger.Warn("sysext catalog fetch failed", "error", err)
-	}
+		// Fetch sysext catalog (non-fatal if it fails)
+		if err := w.FetchSysexts(ctx); err != nil {
+			logger.Warn("sysext catalog fetch failed", "error", err)
+		}
 
-	// Fetch channel version info (non-fatal if it fails)
-	if err := w.FetchChannels(ctx); err != nil {
-		logger.Warn("channel info fetch failed", "error", err)
+		// Fetch channel version info (non-fatal if it fails)
+		if err := w.FetchChannels(ctx); err != nil {
+			logger.Warn("channel info fetch failed", "error", err)
+		}
 	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -1,0 +1,134 @@
+// Package demo provides hardcoded mock implementations of the Prober, bakery.Client,
+// and Installer interfaces for use with the --demo flag. Demo mode lets the TUI run
+// on any machine without hardware, network access, or an actual disk — ideal for
+// generating reproducible recordings with VHS or asciinema.
+package demo
+
+import (
+	"context"
+	"time"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// Prober returns hardcoded fake disks and network interfaces.
+type Prober struct{}
+
+func (p *Prober) ListDisks(_ context.Context) ([]model.DiskInfo, error) {
+	return []model.DiskInfo{
+		{
+			Path:      "/dev/sda",
+			DevPath:   "/dev/sda",
+			Model:     "SAMSUNG 870 EVO 1TB",
+			Serial:    "S3EWNX0M123456",
+			Size:      1_000_204_886_016,
+			SizeHuman: "1.0 TB",
+		},
+		{
+			Path:      "/dev/nvme0n1",
+			DevPath:   "/dev/nvme0n1",
+			Model:     "WD Blue SN570 NVMe 500GB",
+			Serial:    "WD-WX22AA123456",
+			Size:      500_107_862_016,
+			SizeHuman: "500 GB",
+		},
+	}, nil
+}
+
+func (p *Prober) ListNetworkInterfaces(_ context.Context) ([]model.NetworkInterface, error) {
+	return []model.NetworkInterface{
+		{Name: "enp3s0", MAC: "52:54:00:12:34:56", State: "up"},
+		{Name: "eth0", MAC: "52:54:00:ab:cd:ef", State: "up"},
+	}, nil
+}
+
+// Bakery returns a curated set of popular sysexts instantly, with no network call.
+type Bakery struct{}
+
+func (b *Bakery) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return b.FetchCatalogArch(ctx, "amd64")
+}
+
+func (b *Bakery) FetchCatalogArch(_ context.Context, _ string) ([]model.SysextEntry, error) {
+	return []model.SysextEntry{
+		{
+			Name:        "docker",
+			Description: "Docker container runtime",
+			Version:     "28.0.4",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/docker-v28.0.4/docker-28.0.4-x86-64.raw",
+			Category:    "container",
+			SupportTier: bakery.TierIntegrated,
+		},
+		{
+			Name:        "containerd",
+			Description: "containerd container runtime",
+			Version:     "2.1.5",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/containerd-v2.1.5/containerd-2.1.5-x86-64.raw",
+			Category:    "container",
+			SupportTier: bakery.TierIntegrated,
+		},
+		{
+			Name:        "kubernetes",
+			Description: "Kubernetes node components (kubelet, kubeadm, kubectl)",
+			Version:     "1.30.0",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/kubernetes-v1.30.0/kubernetes-1.30.0-x86-64.raw",
+			Category:    "orchestration",
+			SupportTier: bakery.TierMaintained,
+		},
+		{
+			Name:        "tailscale",
+			Description: "Tailscale mesh VPN",
+			Version:     "1.56.1",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/tailscale-v1.56.1/tailscale-1.56.1-x86-64.raw",
+			Category:    "networking",
+			SupportTier: bakery.TierMaintained,
+		},
+		{
+			Name:        "wasmcloud",
+			Description: "wasmCloud WebAssembly runtime",
+			Version:     "0.82.0",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/wasmcloud-v0.82.0/wasmcloud-0.82.0-x86-64.raw",
+			Category:    "runtime",
+			SupportTier: bakery.TierMaintained,
+		},
+	}, nil
+}
+
+// Installer simulates an installation with realistic progress messages and timing.
+type Installer struct{}
+
+func (i *Installer) Install(ctx context.Context, _ *model.InstallConfig, progress func(string)) error {
+	steps := []struct {
+		msg   string
+		delay time.Duration
+	}{
+		{"Generating Ignition configuration", 200 * time.Millisecond},
+		{"Writing Ignition to temp file", 100 * time.Millisecond},
+		{"Wiping disk metadata (wipefs)", 300 * time.Millisecond},
+		{"Running flatcar-install", 1200 * time.Millisecond},
+		{"Repairing GPT (sgdisk)", 200 * time.Millisecond},
+		{"Applying Ignition config", 300 * time.Millisecond},
+		{"Cleaning up temp files", 100 * time.Millisecond},
+	}
+	for _, s := range steps {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(s.delay):
+			progress(s.msg)
+		}
+	}
+	return nil
+}
+
+// Channels returns hardcoded channel info so the Welcome screen renders
+// version cards without any network call.
+func Channels() []bakery.ChannelInfo {
+	return []bakery.ChannelInfo{
+		{Channel: "stable", Version: "4081.2.0", BuildDate: "2026-05-01", Kernel: "6.12.25", Systemd: "255.13", Docker: "28.0.4", Containerd: "2.0.4"},
+		{Channel: "lts", Version: "3815.2.5", BuildDate: "2026-04-15", Kernel: "6.6.87", Systemd: "255.13", Docker: "27.5.1", Containerd: "1.7.25"},
+		{Channel: "beta", Version: "4091.0.0", BuildDate: "2026-05-10", Kernel: "6.12.28", Systemd: "256.5", Docker: "28.1.0", Containerd: "2.1.0"},
+		{Channel: "alpha", Version: "4099.0.0", BuildDate: "2026-05-18", Kernel: "6.14.3", Systemd: "257.2", Docker: "28.1.1", Containerd: "2.1.2"},
+	}
+}

--- a/internal/demo/demo_test.go
+++ b/internal/demo/demo_test.go
@@ -1,0 +1,87 @@
+package demo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/demo"
+)
+
+func TestDemoProber_ReturnsFakeDisks(t *testing.T) {
+	p := &demo.Prober{}
+	disks, err := p.ListDisks(context.Background())
+	if err != nil {
+		t.Fatalf("ListDisks: %v", err)
+	}
+	if len(disks) == 0 {
+		t.Fatal("expected at least one fake disk")
+	}
+	for _, d := range disks {
+		if d.DevPath == "" {
+			t.Error("disk DevPath must not be empty")
+		}
+		if d.Size == 0 {
+			t.Error("disk Size must be non-zero")
+		}
+	}
+}
+
+func TestDemoProber_ReturnsFakeInterfaces(t *testing.T) {
+	p := &demo.Prober{}
+	ifaces, err := p.ListNetworkInterfaces(context.Background())
+	if err != nil {
+		t.Fatalf("ListNetworkInterfaces: %v", err)
+	}
+	if len(ifaces) == 0 {
+		t.Fatal("expected at least one fake interface")
+	}
+}
+
+func TestDemoBakery_ReturnsSysexts(t *testing.T) {
+	b := &demo.Bakery{}
+	entries, err := b.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("FetchCatalogArch: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected demo sysext entries")
+	}
+	for _, e := range entries {
+		if e.Name == "" || e.URL == "" {
+			t.Errorf("sysext entry missing Name or URL: %+v", e)
+		}
+	}
+}
+
+func TestDemoInstaller_CompletesWithProgress(t *testing.T) {
+	inst := &demo.Installer{}
+	var msgs []string
+	err := inst.Install(context.Background(), nil, func(msg string) {
+		msgs = append(msgs, msg)
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Error("expected progress messages from demo installer")
+	}
+}
+
+func TestDemoChannels_ReturnsFourChannels(t *testing.T) {
+	channels := demo.Channels()
+	if len(channels) != 4 {
+		t.Fatalf("expected 4 channels, got %d", len(channels))
+	}
+	names := make(map[string]bool)
+	for _, c := range channels {
+		names[c.Channel] = true
+		if c.Version == "" {
+			t.Errorf("channel %q has empty Version", c.Channel)
+		}
+	}
+	for _, want := range []string{"stable", "beta", "alpha", "lts"} {
+		if !names[want] {
+			t.Errorf("missing channel %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #100
Closes #106

## Summary

Two independent improvements in one branch:

---

### `--demo` flag (#100)

Recording a knuckle TUI demo currently requires a human, a VM, and careful keystroke timing. This PR adds `--demo` mode that runs the full TUI with hardcoded mock data — no hardware probe, no network, no unmounted-disk requirement.

**New package `internal/demo`:**
- `Prober` — returns two realistic fake disks (1 TB SATA + 500 GB NVMe) and two fake NICs; no `lsblk` or `ip` invocations
- `Bakery` — returns 5 curated sysext entries (docker, containerd, kubernetes, tailscale, wasmcloud) instantly, bypassing the GitHub Releases API
- `Installer` — simulates a multi-step install with staged progress callbacks and realistic timing (total ~2.6 s)
- `Channels()` — returns hardcoded channel info for all four channels so the Welcome screen renders version cards without any HTTP call

**`cmd/knuckle/main.go`:**
- `--demo` flag swaps in the mock implementations and implies `--dry-run` (no writes)
- Demo mode calls `ProbeHardware` and `FetchSysexts` via the mock prober/bakery, then sets `w.State.Channels = demo.Channels()` — no `FetchChannels` network call
- Normal mode is unchanged

**Usage:**
```
knuckle --demo        # drive with arrow keys / Enter
vhs demo/knuckle.tape # drive with VHS for reproducible GIFs
```

---

### `.coderabbit.yaml` (#106)

Configures CodeRabbit with project-specific path instructions for the packages where architecture invariants matter: `runner` (exec isolation), `tui` (no business logic), `ignition` (yamlEscape + secure temp files), `headless` (validate before Ignition), `model` (leaf package), `validate` (test coverage gate), CI workflows (SHA pinning, cosign), and `build-iso.sh` (EFI flags, SHA+GPG verification).

## Test plan
- [x] `go test ./...` passes (all 14 packages including `internal/demo`)
- [x] `go build ./cmd/knuckle` succeeds
- [x] Demo installer test completes in ~2.6 s and emits progress messages