### PR TITLE
feat(demo): update drive-demo.sh for --demo and add VHS tape

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,60 @@
+language: en
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "internal/runner/**"
+      instructions: |
+        This is the ONLY package allowed to use exec.Command / exec.CommandContext.
+        All external commands must go through the Runner interface. Flag any
+        exec.Command usage outside this package as a critical violation.
+    - path: "internal/tui/**"
+      instructions: |
+        No business logic in view models — TUI renders, wizard transitions.
+        Flag password hashing, key merging, or config mutations here.
+        Bubble Tea owns stdout — never log to stdout from this package.
+    - path: "internal/ignition/**"
+      instructions: |
+        All user-supplied values in the Butane template MUST use yamlEscape.
+        Temp Ignition files must be created with O_EXCL, mode 0600, and
+        cleaned up via defer. Flag any unescaped template interpolation.
+    - path: "internal/install/**"
+      instructions: |
+        Never call flatcar-install or exec directly — all commands must route
+        through the runner.Runner interface. Reboot must be injected via
+        rebootFn, never called directly. Verify DryRunner behaviour is tested.
+    - path: "internal/model/**"
+      instructions: |
+        Pure data types only — zero imports of other internal packages.
+        This is the leaf package everything depends on. Flag any import
+        of internal/* here.
+    - path: "internal/validate/**"
+      instructions: |
+        Validators must cover both valid and invalid inputs in table-driven
+        tests. New exported functions without corresponding TestXxx fail the
+        coverage gate. Regex patterns must be anchored (^ and $).
+    - path: "internal/headless/**"
+      instructions: |
+        Security-sensitive: headless is the CI/automation path. Validate()
+        must check all user-supplied fields before they reach Ignition.
+        GitHub-fetched SSH keys must be validated before use (validate.SSHPublicKey).
+        Password fields expect pre-hashed values — reject plaintext.
+    - path: ".github/workflows/**"
+      instructions: |
+        Security-sensitive. Verify actions are pinned by SHA (Renovate
+        manages this). Check for secret exposure in run: blocks. Release
+        workflow must include cosign signing, SBOM, and SLSA provenance.
+        persist-credentials: false required on all checkout steps in
+        elevated-permission jobs.
+    - path: "scripts/build-iso.sh"
+      instructions: |
+        Must use --efi-boot-part --efi-boot-image for the EFI System
+        Partition (NOT -isohybrid-gpt-basdat). TTYPath in systemd units
+        must be /dev/console. Downloaded artifacts must be SHA512+GPG
+        verified before use.
+  tools:
+    golangci-lint:
+      enabled: true
+chat:
+  auto_reply: true

--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/demo"
 	"github.com/projectbluefin/knuckle/internal/headless"
 	"github.com/projectbluefin/knuckle/internal/install"
 	"github.com/projectbluefin/knuckle/internal/probe"
@@ -33,6 +34,7 @@ func main() {
 	var (
 		configFile   string
 		headlessMode bool
+		demoMode     bool
 	)
 	flag.BoolVar(&dryRun, "dry-run", false, "simulate installation without writing to disk")
 	flag.StringVar(&logFile, "log-file", "/tmp/knuckle.log", "path to log file")
@@ -40,6 +42,7 @@ func main() {
 	flag.BoolVar(&showVer, "version", false, "print version and exit")
 	flag.StringVar(&configFile, "config", "", "path to JSON config file for headless install")
 	flag.BoolVar(&headlessMode, "headless", false, "run without TUI (requires --config)")
+	flag.BoolVar(&demoMode, "demo", false, "run with mock hardware/catalog data for UI demos and recording (no network, no real disks)")
 	var flatcarVersion string
 	flag.StringVar(&flatcarVersion, "flatcar-version", "", "pin to specific Flatcar version (e.g. 3510.2.8)")
 	flag.Parse()
@@ -79,41 +82,64 @@ func main() {
 
 	logger.Info("knuckle starting", "version", version, "dry-run", dryRun, "channel", channel)
 
-	// Set up runner (dry-run or real)
+	// Set up runner (dry-run or real; demo implies dry-run)
 	var cmdRunner runner.Runner
-	if dryRun {
+	if dryRun || demoMode {
 		cmdRunner = runner.NewDryRunner(logger)
 	} else {
 		cmdRunner = runner.NewRealRunner(logger)
 	}
 
-	// Prober always uses real runner — it only reads system state
-	realRunner := runner.NewRealRunner(logger)
-	prober := probe.NewSystemProber(realRunner)
-	bakeryClient := bakery.NewHTTPClient()
-	installer := install.NewFlatcarInstaller(cmdRunner, logger)
+	// In demo mode use mock implementations that need no hardware or network.
+	// In normal mode use the real system prober, bakery HTTP client, and installer.
+	var (
+		prober       probe.Prober
+		bakeryClient bakery.Client
+		installer    install.Installer
+	)
+	if demoMode {
+		prober = &demo.Prober{}
+		bakeryClient = &demo.Bakery{}
+		installer = &demo.Installer{}
+	} else {
+		realRunner := runner.NewRealRunner(logger)
+		prober = probe.NewSystemProber(realRunner)
+		bakeryClient = bakery.NewHTTPClient()
+		installer = install.NewFlatcarInstaller(cmdRunner, logger)
+	}
 
 	// Create wizard
 	w := wizard.New(prober, bakeryClient, installer)
 	w.State.Config.Channel = channel
-	w.State.Config.DryRun = dryRun
+	w.State.Config.DryRun = dryRun || demoMode
 	w.State.Config.Version = flatcarVersion
 
-	// Probe hardware before starting TUI
 	ctx := context.Background()
-	if err := w.ProbeHardware(ctx); err != nil {
-		logger.Warn("hardware probe failed", "error", err)
-		// Non-fatal — user can still proceed with manual input
-	}
+	if demoMode {
+		// Populate wizard state from mock data instead of probing hardware or
+		// making network calls — keeps startup instant and recording deterministic.
+		if err := w.ProbeHardware(ctx); err != nil {
+			logger.Warn("demo hardware probe failed", "error", err)
+		}
+		if err := w.FetchSysexts(ctx); err != nil {
+			logger.Warn("demo sysext fetch failed", "error", err)
+		}
+		w.State.Channels = demo.Channels()
+	} else {
+		// Probe hardware before starting TUI
+		if err := w.ProbeHardware(ctx); err != nil {
+			logger.Warn("hardware probe failed", "error", err)
+		}
 
-	// Fetch sysext catalog (non-fatal if it fails)
-	if err := w.FetchSysexts(ctx); err != nil {
-		logger.Warn("sysext catalog fetch failed", "error", err)
-	}
+		// Fetch sysext catalog (non-fatal if it fails)
+		if err := w.FetchSysexts(ctx); err != nil {
+			logger.Warn("sysext catalog fetch failed", "error", err)
+		}
 
-	// Fetch channel version info (non-fatal if it fails)
-	if err := w.FetchChannels(ctx); err != nil {
-		logger.Warn("channel info fetch failed", "error", err)
+		// Fetch channel version info (non-fatal if it fails)
+		if err := w.FetchChannels(ctx); err != nil {
+			logger.Warn("channel info fetch failed", "error", err)
+		}
 	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly

--- a/demo/knuckle-demo.tape
+++ b/demo/knuckle-demo.tape
@@ -1,0 +1,87 @@
+# Knuckle TUI demo — reproducible recording via VHS
+# https://github.com/charmbracelet/vhs
+#
+# Prerequisites:
+#   go build -o bin/knuckle ./cmd/knuckle
+#   vhs demo/knuckle-demo.tape
+#
+# --demo uses hardcoded mock hardware and sysexts — no VM, no network, no real disks.
+
+Output demo/knuckle-install.gif
+Output demo/knuckle-install.mp4
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1200
+Set Height 700
+Set Theme "Dracula"
+Set TypingSpeed 60ms
+Set PlaybackSpeed 1.0
+
+# Start knuckle in demo mode
+Type "bin/knuckle --demo"
+Enter
+Sleep 1.5s
+
+# Welcome — browse channel cards
+Down
+Sleep 600ms
+Down
+Sleep 600ms
+Down
+Sleep 600ms
+Up
+Sleep 500ms
+Up
+Sleep 500ms
+Up
+Sleep 1s
+
+# Select stable → Network step
+Enter
+Sleep 1.2s
+
+# Network — DHCP (two form groups)
+Enter
+Sleep 800ms
+Enter
+Sleep 1.2s
+
+# Storage — pick first disk
+Enter
+Sleep 1.2s
+
+# User — identity group, then auth group
+Enter
+Sleep 800ms
+Enter
+Sleep 1.2s
+
+# Sysext — select docker, kubernetes, tailscale
+Down
+Sleep 400ms
+Space
+Sleep 500ms
+Down
+Sleep 400ms
+Down
+Sleep 400ms
+Space
+Sleep 500ms
+Down
+Sleep 400ms
+Space
+Sleep 600ms
+Enter
+Sleep 1.2s
+
+# Update strategy — default reboot
+Enter
+Sleep 1.2s
+
+# Review — pause on summary
+Sleep 3s
+
+# Quit
+Ctrl+C
+Sleep 1s

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -1,0 +1,134 @@
+// Package demo provides hardcoded mock implementations of the Prober, bakery.Client,
+// and Installer interfaces for use with the --demo flag. Demo mode lets the TUI run
+// on any machine without hardware, network access, or an actual disk — ideal for
+// generating reproducible recordings with VHS or asciinema.
+package demo
+
+import (
+	"context"
+	"time"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// Prober returns hardcoded fake disks and network interfaces.
+type Prober struct{}
+
+func (p *Prober) ListDisks(_ context.Context) ([]model.DiskInfo, error) {
+	return []model.DiskInfo{
+		{
+			Path:      "/dev/sda",
+			DevPath:   "/dev/sda",
+			Model:     "SAMSUNG 870 EVO 1TB",
+			Serial:    "S3EWNX0M123456",
+			Size:      1_000_204_886_016,
+			SizeHuman: "1.0 TB",
+		},
+		{
+			Path:      "/dev/nvme0n1",
+			DevPath:   "/dev/nvme0n1",
+			Model:     "WD Blue SN570 NVMe 500GB",
+			Serial:    "WD-WX22AA123456",
+			Size:      500_107_862_016,
+			SizeHuman: "500 GB",
+		},
+	}, nil
+}
+
+func (p *Prober) ListNetworkInterfaces(_ context.Context) ([]model.NetworkInterface, error) {
+	return []model.NetworkInterface{
+		{Name: "enp3s0", MAC: "52:54:00:12:34:56", State: "up"},
+		{Name: "eth0", MAC: "52:54:00:ab:cd:ef", State: "up"},
+	}, nil
+}
+
+// Bakery returns a curated set of popular sysexts instantly, with no network call.
+type Bakery struct{}
+
+func (b *Bakery) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return b.FetchCatalogArch(ctx, "amd64")
+}
+
+func (b *Bakery) FetchCatalogArch(_ context.Context, _ string) ([]model.SysextEntry, error) {
+	return []model.SysextEntry{
+		{
+			Name:        "docker",
+			Description: "Docker container runtime",
+			Version:     "28.0.4",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/docker-v28.0.4/docker-28.0.4-x86-64.raw",
+			Category:    "container",
+			SupportTier: bakery.TierIntegrated,
+		},
+		{
+			Name:        "containerd",
+			Description: "containerd container runtime",
+			Version:     "2.1.5",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/containerd-v2.1.5/containerd-2.1.5-x86-64.raw",
+			Category:    "container",
+			SupportTier: bakery.TierIntegrated,
+		},
+		{
+			Name:        "kubernetes",
+			Description: "Kubernetes node components (kubelet, kubeadm, kubectl)",
+			Version:     "1.30.0",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/kubernetes-v1.30.0/kubernetes-1.30.0-x86-64.raw",
+			Category:    "orchestration",
+			SupportTier: bakery.TierMaintained,
+		},
+		{
+			Name:        "tailscale",
+			Description: "Tailscale mesh VPN",
+			Version:     "1.56.1",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/tailscale-v1.56.1/tailscale-1.56.1-x86-64.raw",
+			Category:    "networking",
+			SupportTier: bakery.TierMaintained,
+		},
+		{
+			Name:        "wasmcloud",
+			Description: "wasmCloud WebAssembly runtime",
+			Version:     "0.82.0",
+			URL:         "https://github.com/flatcar/sysext-bakery/releases/download/wasmcloud-v0.82.0/wasmcloud-0.82.0-x86-64.raw",
+			Category:    "runtime",
+			SupportTier: bakery.TierMaintained,
+		},
+	}, nil
+}
+
+// Installer simulates an installation with realistic progress messages and timing.
+type Installer struct{}
+
+func (i *Installer) Install(ctx context.Context, _ *model.InstallConfig, progress func(string)) error {
+	steps := []struct {
+		msg   string
+		delay time.Duration
+	}{
+		{"Generating Ignition configuration", 200 * time.Millisecond},
+		{"Writing Ignition to temp file", 100 * time.Millisecond},
+		{"Wiping disk metadata (wipefs)", 300 * time.Millisecond},
+		{"Running flatcar-install", 1200 * time.Millisecond},
+		{"Repairing GPT (sgdisk)", 200 * time.Millisecond},
+		{"Applying Ignition config", 300 * time.Millisecond},
+		{"Cleaning up temp files", 100 * time.Millisecond},
+	}
+	for _, s := range steps {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(s.delay):
+			progress(s.msg)
+		}
+	}
+	return nil
+}
+
+// Channels returns hardcoded channel info so the Welcome screen renders
+// version cards without any network call.
+func Channels() []bakery.ChannelInfo {
+	return []bakery.ChannelInfo{
+		{Channel: "stable", Version: "4081.2.0", BuildDate: "2026-05-01", Kernel: "6.12.25", Systemd: "255.13", Docker: "28.0.4", Containerd: "2.0.4"},
+		{Channel: "lts", Version: "3815.2.5", BuildDate: "2026-04-15", Kernel: "6.6.87", Systemd: "255.13", Docker: "27.5.1", Containerd: "1.7.25"},
+		{Channel: "beta", Version: "4091.0.0", BuildDate: "2026-05-10", Kernel: "6.12.28", Systemd: "256.5", Docker: "28.1.0", Containerd: "2.1.0"},
+		{Channel: "alpha", Version: "4099.0.0", BuildDate: "2026-05-18", Kernel: "6.14.3", Systemd: "257.2", Docker: "28.1.1", Containerd: "2.1.2"},
+	}
+}

--- a/internal/demo/demo_test.go
+++ b/internal/demo/demo_test.go
@@ -1,0 +1,87 @@
+package demo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/demo"
+)
+
+func TestDemoProber_ReturnsFakeDisks(t *testing.T) {
+	p := &demo.Prober{}
+	disks, err := p.ListDisks(context.Background())
+	if err != nil {
+		t.Fatalf("ListDisks: %v", err)
+	}
+	if len(disks) == 0 {
+		t.Fatal("expected at least one fake disk")
+	}
+	for _, d := range disks {
+		if d.DevPath == "" {
+			t.Error("disk DevPath must not be empty")
+		}
+		if d.Size == 0 {
+			t.Error("disk Size must be non-zero")
+		}
+	}
+}
+
+func TestDemoProber_ReturnsFakeInterfaces(t *testing.T) {
+	p := &demo.Prober{}
+	ifaces, err := p.ListNetworkInterfaces(context.Background())
+	if err != nil {
+		t.Fatalf("ListNetworkInterfaces: %v", err)
+	}
+	if len(ifaces) == 0 {
+		t.Fatal("expected at least one fake interface")
+	}
+}
+
+func TestDemoBakery_ReturnsSysexts(t *testing.T) {
+	b := &demo.Bakery{}
+	entries, err := b.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("FetchCatalogArch: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected demo sysext entries")
+	}
+	for _, e := range entries {
+		if e.Name == "" || e.URL == "" {
+			t.Errorf("sysext entry missing Name or URL: %+v", e)
+		}
+	}
+}
+
+func TestDemoInstaller_CompletesWithProgress(t *testing.T) {
+	inst := &demo.Installer{}
+	var msgs []string
+	err := inst.Install(context.Background(), nil, func(msg string) {
+		msgs = append(msgs, msg)
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Error("expected progress messages from demo installer")
+	}
+}
+
+func TestDemoChannels_ReturnsFourChannels(t *testing.T) {
+	channels := demo.Channels()
+	if len(channels) != 4 {
+		t.Fatalf("expected 4 channels, got %d", len(channels))
+	}
+	names := make(map[string]bool)
+	for _, c := range channels {
+		names[c.Channel] = true
+		if c.Version == "" {
+			t.Errorf("channel %q has empty Version", c.Channel)
+		}
+	}
+	for _, want := range []string{"stable", "beta", "alpha", "lts"} {
+		if !names[want] {
+			t.Errorf("missing channel %q", want)
+		}
+	}
+}

--- a/scripts/drive-demo.sh
+++ b/scripts/drive-demo.sh
@@ -1,69 +1,89 @@
 #!/usr/bin/env bash
-# Record the knuckle TUI demo.
-# Usage: TERM=xterm-256color asciinema rec -c "./scripts/drive-demo.sh" demo/out.cast
+# Drive the knuckle TUI for demo recording.
+#
+# Uses --demo mode: hardcoded mock hardware + sysexts, no network, no disk writes.
+# Works on any machine — CI, dev laptop, recording rig.
+#
+# Usage:
+#   # Build first if needed:
+#   go build -o bin/knuckle ./cmd/knuckle
+#
+#   # Record with asciinema:
+#   asciinema rec -c "./scripts/drive-demo.sh" demo/out.cast
+#
+#   # Or run VHS (generates GIF directly):
+#   vhs demo/knuckle-demo.tape
 set -u
+
+BINARY=""
+for candidate in "bin/knuckle" "./knuckle"; do
+    if [[ -f "$candidate" ]]; then
+        BINARY="$candidate"
+        break
+    fi
+done
+if [[ -z "$BINARY" ]]; then
+    echo "knuckle binary not found — run 'go build -o bin/knuckle ./cmd/knuckle' first" >&2
+    exit 1
+fi
 
 FIFO=$(mktemp -u)
 mkfifo "$FIFO"
 
-# Launch knuckle reading from the FIFO
-bin/knuckle --dry-run < "$FIFO" &
+# --demo: mock hardware/catalog, implies --dry-run (no real writes)
+"$BINARY" --demo < "$FIFO" &
 KNUCKLE_PID=$!
-
-# Open the fifo for writing (keeps it open so knuckle doesn't get EOF)
 exec 3>"$FIFO"
 
-send() { printf "$1" >&3; }
+send() { printf "%b" "$1" >&3; }
 pause() { sleep "$1"; }
 
-# Wait for TUI to render
-pause 3
+# Demo mode starts instantly (no network fetch delay)
+pause 1.5
 
-# Welcome — browse channels
-send "j"; pause 0.7
-send "j"; pause 0.7
-send "j"; pause 0.7
-send "k"; pause 0.7
-send "k"; pause 0.7
-send "k"; pause 1.2
+# Welcome — browse channel cards with arrow keys
+send "\033[B"; pause 0.6   # ↓ lts
+send "\033[B"; pause 0.6   # ↓ beta
+send "\033[B"; pause 0.6   # ↓ alpha
+send "\033[A"; pause 0.5   # ↑ beta
+send "\033[A"; pause 0.5   # ↑ lts
+send "\033[A"; pause 0.8   # ↑ stable
 
-# Select stable
-send "\r"; pause 2.5
+# Confirm stable, advance to Network
+send "\r"; pause 1.2
 
-# Network form — Enter
-send "\r"; pause 2.5
+# Network — accept DHCP default (two groups)
+send "\r"; pause 0.8
+send "\r"; pause 1.2
 
-# Storage — Enter
-send "\r"; pause 2.5
+# Storage — select first disk
+send "\r"; pause 1.2
 
-# User form — Enter (uses local SSH keys)
-send "\r"; pause 3
+# User form — identity group, then auth group
+send "\r"; pause 0.8
+send "\r"; pause 1.2
 
-# Sysext — select a few
-pause 1
-send "j"; pause 0.4
-send " "; pause 0.6
-send "j"; pause 0.4
-send "j"; pause 0.4
-send " "; pause 0.6
-send "j"; pause 0.4
-send "j"; pause 0.4
-send "j"; pause 0.4
-send " "; pause 1
-send "\r"; pause 2.5
+# Sysext — browse and toggle three extensions
+send "\033[B"; pause 0.4   # ↓ to docker
+send " ";      pause 0.5   # toggle on
+send "\033[B"; pause 0.4   # ↓ containerd
+send "\033[B"; pause 0.4   # ↓ kubernetes
+send " ";      pause 0.5   # toggle on
+send "\033[B"; pause 0.4   # ↓ tailscale
+send " ";      pause 0.6   # toggle on
+send "\r";     pause 1.2   # advance
 
-# Update strategy
-send "\r"; pause 2.5
+# Update strategy — default reboot
+send "\r"; pause 1.2
 
-# Review
-pause 3
+# Review — pause to let the summary render
+pause 2.5
 
-# Quit
+# Quit without confirming install
 send "q"; pause 0.5
-send "q"; pause 1.5
+send "q"; pause 1.0
 
-# Cleanup
 exec 3>&-
 rm -f "$FIFO"
-wait $KNUCKLE_PID 2>/dev/null
+wait "$KNUCKLE_PID" 2>/dev/null
 exit 0


### PR DESCRIPTION
Continues #100 (depends on PR #185 which adds `--demo`).

## Changes

**`scripts/drive-demo.sh`** — rewritten to use `--demo` instead of `--dry-run`:
- No longer requires local SSH keys from `~/.ssh/` (was the main failure mode)
- No 3-second startup delay (demo mode skips all network fetches)
- Uses arrow-key escape sequences (`\033[A`/`\033[B`) instead of `j`/`k` — arrow keys don't echo as visible characters in the PTY during startup
- Binary auto-detected from `bin/knuckle` or `./knuckle`
- Works on any machine: CI, dev laptop, or recording rig

**`demo/knuckle-demo.tape`** — new VHS tape for reproducible GIF/MP4 generation:
- Walks the full TUI flow: Welcome → Network (DHCP) → Storage → User → Sysext (docker, kubernetes, tailscale selected) → Update → Review
- Outputs `demo/knuckle-install.gif` + `.mp4`
- Set to Dracula theme at 1200×700 to match the existing GIF dimensions

## Usage

```bash
# Build
go build -o bin/knuckle ./cmd/knuckle

# Record with asciinema
asciinema rec -c "./scripts/drive-demo.sh" demo/out.cast

# Or generate GIF/MP4 with VHS (https://github.com/charmbracelet/vhs)
vhs demo/knuckle-demo.tape
```

## Test plan
- [x] `bash -n scripts/drive-demo.sh` — syntax OK
- [ ] `./scripts/drive-demo.sh` runs without errors (requires built binary)
- [ ] `vhs demo/knuckle-demo.tape` produces GIF (requires VHS installed)