### PR TITLE
fix: TailscaleRoutes all-comma bypass, headless github_user validation, wizard partial channels

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -307,6 +307,11 @@ func (c *Config) Validate() error {
 			if len(u.SSHKeys) == 0 && u.Password == "" && u.GithubUser == "" {
 				return fmt.Errorf("users[%d] (%s): must have ssh_keys, password, or github_user", i, u.Username)
 			}
+			if u.GithubUser != "" {
+				if err := validate.GitHubUsername(u.GithubUser); err != nil {
+					return fmt.Errorf("users[%d] (%s): github_user: %w", i, u.Username, err)
+				}
+			}
 			if u.Password != "" {
 				if err := validate.PasswordHash(u.Password); err != nil {
 					return fmt.Errorf("users[%d] (%s): %w", i, u.Username, err)

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -1486,3 +1486,28 @@ func TestToInstallConfig_PasswordOnlyUser_SetsPasswordHash(t *testing.T) {
 		t.Error("BUG: password-only user has empty PasswordHash in InstallConfig — CheckConsistency will reject it")
 	}
 }
+
+func TestValidate_InvalidGitHubUsername(t *testing.T) {
+	cfg := &Config{
+		Channel: "stable",
+		Disk:    "/dev/vda",
+		Users:   []UserConfig{{Username: "core", GithubUser: "@@@bad"}},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error for invalid github_user format, got nil")
+	}
+}
+
+func TestValidate_ValidGitHubUsername(t *testing.T) {
+	cfg := &Config{
+		Channel: "stable",
+		Disk:    "/dev/vda",
+		Users:   []UserConfig{{Username: "core", GithubUser: "octocat"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		// Should pass format check (SSH key fetch happens at Run time, not Validate)
+		if !strings.Contains(err.Error(), "github_user") {
+			t.Errorf("unexpected error (not about github_user): %v", err)
+		}
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -349,10 +349,12 @@ func SysextName(s string) error {
 }
 
 // TailscaleRoutes validates a comma-separated list of CIDRs for --advertise-routes.
+// At least one non-empty valid CIDR must be present; all-comma inputs like "," are rejected.
 func TailscaleRoutes(s string) error {
 	if strings.TrimSpace(s) == "" {
 		return fmt.Errorf("at least one route is required for subnet router mode")
 	}
+	found := 0
 	for _, raw := range strings.Split(s, ",") {
 		r := strings.TrimSpace(raw)
 		if r == "" {
@@ -361,6 +363,10 @@ func TailscaleRoutes(s string) error {
 		if err := CIDR(r); err != nil {
 			return fmt.Errorf("route %q: %w", r, err)
 		}
+		found++
+	}
+	if found == 0 {
+		return fmt.Errorf("at least one route is required for subnet router mode")
 	}
 	return nil
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -665,3 +665,12 @@ func TestTailscaleRoutes(t *testing.T) {
 		t.Error("expected error for invalid CIDR")
 	}
 }
+
+func TestTailscaleRoutes_AllCommas(t *testing.T) {
+	// Inputs that consist only of commas/spaces must be rejected.
+	for _, bad := range []string{",", " , ", ",,", " "} {
+		if err := TailscaleRoutes(bad); err == nil {
+			t.Errorf("TailscaleRoutes(%q) should fail: no valid CIDRs present", bad)
+		}
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -382,11 +382,13 @@ func (w *Wizard) FetchSysexts(ctx context.Context) error {
 // FetchChannels loads version info for all release channels
 func (w *Wizard) FetchChannels(ctx context.Context) error {
 	channels, err := bakery.FetchAllChannels(ctx)
-	if err != nil {
-		return err
+	if len(channels) > 0 {
+		// Use whatever channels succeeded; partial failures (e.g. one channel
+		// temporarily unreachable) are not fatal — surface only a total outage.
+		w.State.Channels = channels
+		return nil
 	}
-	w.State.Channels = channels
-	return nil
+	return err
 }
 
 // Execute runs the installation


### PR DESCRIPTION
Closes #189
Closes #190
Closes #191

## Three small correctness bugs

### #189 — `TailscaleRoutes` accepts all-comma input

`","` or `" , "` passed validation because the empty-string guard only checks the full string, not whether any non-empty CIDR was actually found. The fix tracks a `found` counter and rejects inputs where every segment is empty. `TestTailscaleRoutes_AllCommas` covers the bypass cases.

### #190 — `headless.Config.Validate()` skips `github_user` format check

`validate.GitHubUsername()` was only called in the TUI wizard path. The headless path checked for presence only, so `"@@@bad"` or a 40-char username passed `Validate()` and failed mid-install with a cryptic GitHub API error. Fix adds the call in the users loop, matching the wizard's behaviour. Two new regression tests added.

### #191 — `wizard.FetchChannels` discards partial channel results

`bakery.FetchAllChannels` (updated in #179) can return both a non-nil slice **and** a non-nil error when some channels succeed and others fail. `wizard.FetchChannels` returned on `err != nil`, discarding the successfully fetched channels. Fix: assign `w.State.Channels` whenever `len(channels) > 0`; only surface the error on total failure.

## Test plan
- [x] `go test ./internal/validate/... ./internal/headless/... ./internal/wizard/...` passes
- [x] `TestTailscaleRoutes_AllCommas` — `,` and ` , ` rejected
- [x] `TestValidate_InvalidGitHubUsername` — `@@@bad` rejected at Validate time