### PR TITLE
refactor(catalog_check): extract checkCatalog() and add unit tests

### DIFF
--- a/scripts/catalog_check/check.go
+++ b/scripts/catalog_check/check.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// checkCatalog compares a slice of catalog entries against the curated
+// descriptions in internal/bakery/descriptions.go. It returns the number
+// of covered entries and a slice of entries that have no curated description.
+// The function is pure (no network, no I/O) and designed for unit testing.
+func checkCatalog(entries []model.SysextEntry) (covered int, missing []bakery.MissingEntry) {
+	for _, e := range entries {
+		if _, ok := bakery.Lookup(e.Name); ok {
+			covered++
+		} else {
+			missing = append(missing, bakery.MissingEntry{
+				Name:    e.Name,
+				Version: e.Version,
+				URL:     e.URL,
+			})
+		}
+	}
+	return covered, missing
+}

--- a/scripts/catalog_check/check_test.go
+++ b/scripts/catalog_check/check_test.go
@@ -23,14 +23,14 @@ func TestCheckCatalog_AllCovered(t *testing.T) {
 func TestCheckCatalog_NoneKnown(t *testing.T) {
 	entries := []model.SysextEntry{
 		{Name: "totally-unknown-sysext-xyz", Version: "1.0.0", URL: "https://example.com/x.raw"},
-		{Name: "another-mystery-ext-abc",    Version: "2.0.0", URL: "https://example.com/y.raw"},
+		{Name: "another-mystery-ext-abc", Version: "2.0.0", URL: "https://example.com/y.raw"},
 	}
 	covered, missing := checkCatalog(entries)
 	if covered != 0 {
 		t.Errorf("covered = %d, want 0", covered)
 	}
 	if len(missing) != 2 {
-		t.Errorf("missing count = %d, want 2", len(missing))
+		t.Fatalf("missing count = %d, want 2", len(missing))
 	}
 	if missing[0].Name != "totally-unknown-sysext-xyz" {
 		t.Errorf("missing[0].Name = %q, want totally-unknown-sysext-xyz", missing[0].Name)
@@ -42,16 +42,16 @@ func TestCheckCatalog_NoneKnown(t *testing.T) {
 
 func TestCheckCatalog_Mixed(t *testing.T) {
 	entries := []model.SysextEntry{
-		{Name: "docker",        Version: "28.0.0", URL: "https://example.com/docker.raw"},
-		{Name: "unknown-ext",  Version: "1.0.0",  URL: "https://example.com/unknown.raw"},
-		{Name: "tailscale",    Version: "1.56.1",  URL: "https://example.com/tailscale.raw"},
+		{Name: "docker", Version: "28.0.0", URL: "https://example.com/docker.raw"},
+		{Name: "unknown-ext", Version: "1.0.0", URL: "https://example.com/unknown.raw"},
+		{Name: "tailscale", Version: "1.56.1", URL: "https://example.com/tailscale.raw"},
 	}
 	covered, missing := checkCatalog(entries)
 	if covered != 2 {
 		t.Errorf("covered = %d, want 2 (docker + tailscale)", covered)
 	}
 	if len(missing) != 1 {
-		t.Errorf("missing count = %d, want 1", len(missing))
+		t.Fatalf("missing count = %d, want 1", len(missing))
 	}
 	if missing[0].Name != "unknown-ext" {
 		t.Errorf("missing[0].Name = %q, want unknown-ext", missing[0].Name)

--- a/scripts/catalog_check/check_test.go
+++ b/scripts/catalog_check/check_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestCheckCatalog_AllCovered(t *testing.T) {
+	// "docker" is a well-known entry in descriptions.go.
+	entries := []model.SysextEntry{
+		{Name: "docker", Version: "28.0.0", URL: "https://example.com/docker.raw"},
+	}
+	covered, missing := checkCatalog(entries)
+	if covered != 1 {
+		t.Errorf("covered = %d, want 1", covered)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty", missing)
+	}
+}
+
+func TestCheckCatalog_NoneKnown(t *testing.T) {
+	entries := []model.SysextEntry{
+		{Name: "totally-unknown-sysext-xyz", Version: "1.0.0", URL: "https://example.com/x.raw"},
+		{Name: "another-mystery-ext-abc",    Version: "2.0.0", URL: "https://example.com/y.raw"},
+	}
+	covered, missing := checkCatalog(entries)
+	if covered != 0 {
+		t.Errorf("covered = %d, want 0", covered)
+	}
+	if len(missing) != 2 {
+		t.Errorf("missing count = %d, want 2", len(missing))
+	}
+	if missing[0].Name != "totally-unknown-sysext-xyz" {
+		t.Errorf("missing[0].Name = %q, want totally-unknown-sysext-xyz", missing[0].Name)
+	}
+	if missing[0].URL != "https://example.com/x.raw" {
+		t.Errorf("missing[0].URL = %q, want https://example.com/x.raw", missing[0].URL)
+	}
+}
+
+func TestCheckCatalog_Mixed(t *testing.T) {
+	entries := []model.SysextEntry{
+		{Name: "docker",        Version: "28.0.0", URL: "https://example.com/docker.raw"},
+		{Name: "unknown-ext",  Version: "1.0.0",  URL: "https://example.com/unknown.raw"},
+		{Name: "tailscale",    Version: "1.56.1",  URL: "https://example.com/tailscale.raw"},
+	}
+	covered, missing := checkCatalog(entries)
+	if covered != 2 {
+		t.Errorf("covered = %d, want 2 (docker + tailscale)", covered)
+	}
+	if len(missing) != 1 {
+		t.Errorf("missing count = %d, want 1", len(missing))
+	}
+	if missing[0].Name != "unknown-ext" {
+		t.Errorf("missing[0].Name = %q, want unknown-ext", missing[0].Name)
+	}
+}
+
+func TestCheckCatalog_Empty(t *testing.T) {
+	covered, missing := checkCatalog(nil)
+	if covered != 0 || len(missing) != 0 {
+		t.Errorf("empty catalog: covered=%d missing=%d, want both 0", covered, len(missing))
+	}
+}

--- a/scripts/catalog_check/main.go
+++ b/scripts/catalog_check/main.go
@@ -49,22 +49,14 @@ func main() {
 		return entries[i].Name < entries[j].Name
 	})
 
-	var missing []bakery.MissingEntry
-	var covered int
+	covered, missing := checkCatalog(entries)
 
 	for _, e := range entries {
-		meta, ok := bakery.Lookup(e.Name)
-		if !ok {
-			missing = append(missing, bakery.MissingEntry{
-				Name:    e.Name,
-				Version: e.Version,
-				URL:     e.URL,
-			})
-			fmt.Printf("  MISSING  %-22s  v%s\n", e.Name, e.Version)
-		} else {
-			covered++
+		if meta, ok := bakery.Lookup(e.Name); ok {
 			fmt.Printf("  ok       %-22s  v%-12s  %s · %s\n",
 				e.Name, e.Version, meta.SupportTier, meta.Category)
+		} else {
+			fmt.Printf("  MISSING  %-22s  v%s\n", e.Name, e.Version)
 		}
 	}
 


### PR DESCRIPTION
Closes #199

## Problem
`scripts/catalog_check/main.go` had zero test coverage because the comparison logic was embedded in `main()` alongside all the I/O, requiring a live network call to test.

## Solution
Extract the pure comparison logic into `checkCatalog(entries []model.SysextEntry) (covered int, missing []bakery.MissingEntry)` in a new `check.go` file. The function has no I/O — it just calls `bakery.Lookup()` against the in-memory description catalog.

`main()` is updated to call `checkCatalog()` for the coverage/missing pass; the display loop and print format are unchanged.

## Tests (`check_test.go`)
Four table cases, no network required:
- All covered: `docker` is a known extension → covered=1, missing=[]
- None known: two unknown names → covered=0, missing has both entries with correct Name/URL
- Mixed: docker+tailscale known, unknown-ext not → covered=2, missing=[unknown-ext]
- Empty input: → covered=0, missing=[]

These run in `just ci` via `go test ./scripts/catalog_check/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for catalog validation with multiple scenarios including all entries known, no entries known, mixed entries, and empty catalogs.

* **Refactor**
  * Refactored catalog verification logic into reusable components to improve code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->