### PR TITLE
fix(#205): yamlEscape .Timezone in ignition template

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -253,7 +253,7 @@ storage:
 {{- if .Timezone}}
   links:
     - path: /etc/localtime
-      target: "/usr/share/zoneinfo/{{.Timezone}}"
+      target: "/usr/share/zoneinfo/{{.Timezone | yamlEscape}}"
       overwrite: true
 {{- end}}
 systemd:


### PR DESCRIPTION
## Summary
- `.Timezone` in the Butane/Ignition template lacked `| yamlEscape`, unlike every other string field in the template
- A malformed or adversarial timezone value could inject arbitrary YAML into the generated config
- One-character fix: `{{.Timezone}}` → `{{.Timezone | yamlEscape}}`

Closes #205

## Test plan
- [ ] Existing timezone tests (`TestGenerateButaneTimezoneLink`, `TestGenerateButaneTimezoneAndStatic`) still pass
- [ ] `go test ./internal/ignition/... -v` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)