### PR TITLE
fix(#212): validate GitHub SSH keys individually in TUI before embedding in Ignition

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -190,6 +190,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = fmt.Errorf("%w — edit the username and press Enter to retry, or clear it and add an SSH key or password instead", msg.err)
 			return m, nil
 		}
+		for _, k := range msg.keys {
+			if err := validate.SSHPublicKey(k); err != nil {
+				m.err = fmt.Errorf("invalid SSH key from GitHub: %w", err)
+				return m, nil
+			}
+		}
 		m.Wizard.ApplyGitHubKeys(msg.keys, detectLocalSSHKeys(), m.sshKeyInput)
 		if !m.Wizard.HasAnyAuthentication() {
 			m.err = fmt.Errorf("no SSH keys found — add a key manually, set a password, or use a GitHub user with public keys")

--- a/internal/tui/user_step_test.go
+++ b/internal/tui/user_step_test.go
@@ -437,3 +437,34 @@ func TestEnterUserStep_WithLocalKeys_Advances(t *testing.T) {
 		t.Errorf("expected to advance past StepUser when local SSH key is present, still on StepUser")
 	}
 }
+
+// --- fetchKeysMsg: invalid key from GitHub ---
+
+// TestFetchKeysInvalidKey_SetsError verifies that when GitHub returns a key
+// that fails validate.SSHPublicKey(), the model sets an error and does not
+// call ApplyGitHubKeys — preventing malformed keys from reaching Ignition.
+func TestFetchKeysInvalidKey_SetsError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUser
+	w.State.Config.Users = []model.UserConfig{{Username: "core"}}
+
+	m := New(w)
+	// "not-a-real-key" will fail SSHPublicKey() validation.
+	newModel, _ := m.Update(fetchKeysMsg{keys: []string{"not-a-real-key"}, err: nil})
+	got := newModel.(*Model)
+
+	if got.err == nil {
+		t.Fatal("expected err to be set for invalid GitHub SSH key, got nil")
+	}
+	if !strings.Contains(got.err.Error(), "invalid SSH key from GitHub") {
+		t.Errorf("expected 'invalid SSH key from GitHub' in error, got: %v", got.err)
+	}
+	if got.Wizard.State.CurrentStep != model.StepUser {
+		t.Errorf("expected to remain on StepUser after invalid key, got %v", got.Wizard.State.CurrentStep)
+	}
+	if len(got.Wizard.State.Config.Users[0].SSHKeys) != 0 {
+		t.Errorf("invalid key should not be stored in config, got: %v", got.Wizard.State.Config.Users[0].SSHKeys)
+	}
+}


### PR DESCRIPTION
## Summary
- The TUI's `fetchKeysMsg` handler was passing GitHub-fetched keys directly to `ApplyGitHubKeys()` without any per-key validation
- The headless path already did per-key `validate.SSHPublicKey()` checks (Step 2 in `headless.Run()`) — this brings the TUI path to parity
- A malformed line from GitHub's `.keys` endpoint would have been silently written into the Ignition `authorized_keys`, potentially locking users out of SSH
- Fix: loop `validate.SSHPublicKey()` over `msg.keys` before `ApplyGitHubKeys()`; on failure set `m.err` and return early
- Added `TestFetchKeysInvalidKey_SetsError` covering the new branch

Closes #212

## Test plan
- [ ] `go test ./internal/tui/... -run TestFetchKeysInvalidKey -v` passes
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)