### PR TITLE
fix: add SSH keep-alive to vm-e2e recipe for long-running flatcar-install

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -906,7 +906,7 @@ hardware-repro:
         -display none -daemonize -pidfile "$PIDFILE" \
         -serial file:.vm/hardware-installer-serial.log
 
-    HARDWARE_SSH="ssh {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -p 2222 core@127.0.0.1"
+    HARDWARE_SSH="ssh {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
     HARDWARE_SCP="scp {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -P 2222"
 
     ok=0

--- a/Justfile
+++ b/Justfile
@@ -260,7 +260,7 @@ vm-e2e:
     printf '{"channel":"stable","hostname":"e2e-verified","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","update_strategy":"off","reboot":false}\n' \
         "$E2E_PUB" > .vm/e2e-config.json
 
-    E2E_SSH="ssh {{SSH_OPTS}} -i .vm/e2e_key -p 2222 core@127.0.0.1"
+    E2E_SSH="ssh {{SSH_OPTS}} -i .vm/e2e_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
     E2E_SCP="scp {{SSH_OPTS}} -i .vm/e2e_key -P 2222"
 
     # ── Step 1: Boot installer VM ──────────────────────────────────────────


### PR DESCRIPTION
This fix addresses SSH session timeouts during the long-running flatcar-install download phase in the vm-e2e recipe.

## Problem
The flatcar-install download takes 10-15 minutes and was dropping SSH connections due to inactivity timeouts.

## Solution
Added SSH keep-alive options to the E2E_SSH variable in the Justfile:
- `ServerAliveInterval=30` — sends keep-alive packet every 30 seconds
- `ServerAliveCountMax=10` — allows up to 10 unanswered packets before disconnecting

## Testing
All 4 vm-e2e passes complete successfully with this fix, preventing premature SSH disconnections during long-running operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM connectivity stability by adding keepalive options to SSH connections, preventing timeouts during extended operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->