### PR TITLE
test: cover formatCommandError, FetchChannels, sysextList edge cases

### DIFF
--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -593,3 +593,68 @@ func TestCleanupIgnitionFile_AlreadyRemoved(t *testing.T) {
 		t.Error("ignitionPath should be cleared after cleanup")
 	}
 }
+
+// ── formatCommandError branches ───────────────────────────────────────────────
+
+func TestFormatCommandError_WithStderr(t *testing.T) {
+	r := &runner.Result{ExitCode: 1, Stderr: "  disk not found  "}
+	err := formatCommandError("flatcar-install failed", r, nil)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "exit 1") || !strings.Contains(got, "disk not found") {
+		t.Errorf("unexpected error: %v", got)
+	}
+}
+
+func TestFormatCommandError_NonZeroExitWithErr(t *testing.T) {
+	r := &runner.Result{ExitCode: 2, Stderr: ""}
+	inner := fmt.Errorf("signal: killed")
+	err := formatCommandError("mount failed", r, inner)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "exit 2") || !strings.Contains(got, "signal: killed") {
+		t.Errorf("unexpected error: %v", got)
+	}
+}
+
+func TestFormatCommandError_NonZeroExitNoErr(t *testing.T) {
+	r := &runner.Result{ExitCode: 3, Stderr: ""}
+	err := formatCommandError("mkfs failed", r, nil)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "mkfs failed") || !strings.Contains(got, "exit 3") {
+		t.Errorf("unexpected error: %v", got)
+	}
+	// Should NOT have a wrapping error since inner was nil
+	if strings.Contains(got, "<nil>") {
+		t.Errorf("nil err should not appear in message: %v", got)
+	}
+}
+
+func TestFormatCommandError_NilResultWithErr(t *testing.T) {
+	inner := fmt.Errorf("connection refused")
+	err := formatCommandError("download failed", nil, inner)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "download failed") || !strings.Contains(got, "connection refused") {
+		t.Errorf("unexpected error: %v", got)
+	}
+}
+
+func TestFormatCommandError_NilResultNilErr(t *testing.T) {
+	err := formatCommandError("unknown op", nil, nil)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if err.Error() != "unknown op failed" {
+		t.Errorf("got %q, want %q", err.Error(), "unknown op failed")
+	}
+}

--- a/internal/tui/tui_coverage_test.go
+++ b/internal/tui/tui_coverage_test.go
@@ -345,3 +345,40 @@ func TestDetectLocalSSHKeys_SkipsNonKeyLines(t *testing.T) {
 		t.Errorf("expected 1 key (comment/blank/garbage skipped), got %d: %v", len(keys), keys)
 	}
 }
+
+// ── sysext_list.go: cursor and lookup edge cases ──────────────────────────────
+
+func TestSysextListCursorIdx_NotReady(t *testing.T) {
+	m := New(newTestWizard())
+	m.sysextListReady = false
+	m.cursor = 3
+	if got := m.sysextListCursorIdx(); got != 3 {
+		t.Errorf("sysextListCursorIdx with !ready = %d, want 3", got)
+	}
+}
+
+func TestSysextListCursorIdx_ReadyNoSelection(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", SupportTier: bakery.TierIntegrated},
+	}
+	m := New(w)
+	m.sysextListReady = true
+	m.cursor = 7
+	// sysextList is initialised but has no selected item → falls through to m.cursor
+	if got := m.sysextListCursorIdx(); got != 7 {
+		t.Errorf("sysextListCursorIdx with no selection = %d, want 7", got)
+	}
+}
+
+func TestSysextListLookup_NotFound(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", SupportTier: bakery.TierIntegrated},
+	}
+	m := New(w)
+	// index 99 doesn't exist in the list → should return 0
+	if got := m.sysextListLookup(99); got != 0 {
+		t.Errorf("sysextListLookup(notFound) = %d, want 0", got)
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -15,6 +15,9 @@ import (
 	"github.com/projectbluefin/knuckle/internal/validate"
 )
 
+// fetchAllChannelsFn is a package-level hook so tests can inject a mock.
+var fetchAllChannelsFn = bakery.FetchAllChannels
+
 // State holds the complete wizard state
 type State struct {
 	CurrentStep model.WizardStep
@@ -381,7 +384,7 @@ func (w *Wizard) FetchSysexts(ctx context.Context) error {
 
 // FetchChannels loads version info for all release channels
 func (w *Wizard) FetchChannels(ctx context.Context) error {
-	channels, err := bakery.FetchAllChannels(ctx)
+	channels, err := fetchAllChannelsFn(ctx)
 	if len(channels) > 0 {
 		// Use whatever channels succeeded; partial failures (e.g. one channel
 		// temporarily unreachable) are not fatal — surface only a total outage.

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/projectbluefin/knuckle/internal/bakery"
 	"github.com/projectbluefin/knuckle/internal/model"
 )
 
@@ -1872,6 +1873,48 @@ func TestFetchChannels_CancelledContext(t *testing.T) {
 	err := w.FetchChannels(ctx)
 	if err == nil {
 		t.Fatal("FetchChannels with cancelled context: expected error, got nil")
+	}
+}
+
+func TestFetchChannels_SuccessStoresChannels(t *testing.T) {
+	want := []bakery.ChannelInfo{
+		{Channel: "stable", Version: "3510.2.0"},
+		{Channel: "beta", Version: "3520.0.0"},
+	}
+	old := fetchAllChannelsFn
+	fetchAllChannelsFn = func(_ context.Context) ([]bakery.ChannelInfo, error) {
+		return want, nil
+	}
+	defer func() { fetchAllChannelsFn = old }()
+
+	w, _, _, _ := newTestWizard()
+	if err := w.FetchChannels(context.Background()); err != nil {
+		t.Fatalf("FetchChannels: unexpected error: %v", err)
+	}
+	if len(w.State.Channels) != len(want) {
+		t.Fatalf("got %d channels, want %d", len(w.State.Channels), len(want))
+	}
+	if w.State.Channels[0].Channel != "stable" {
+		t.Errorf("got channel %q, want %q", w.State.Channels[0].Channel, "stable")
+	}
+}
+
+func TestFetchChannels_PartialResultUsed(t *testing.T) {
+	// When some channels succeed and err is non-nil, use the partial result.
+	partial := []bakery.ChannelInfo{{Channel: "stable", Version: "3510.2.0"}}
+	old := fetchAllChannelsFn
+	fetchAllChannelsFn = func(_ context.Context) ([]bakery.ChannelInfo, error) {
+		return partial, fmt.Errorf("beta channel unreachable")
+	}
+	defer func() { fetchAllChannelsFn = old }()
+
+	w, _, _, _ := newTestWizard()
+	err := w.FetchChannels(context.Background())
+	if err != nil {
+		t.Errorf("expected nil error when partial results available, got: %v", err)
+	}
+	if len(w.State.Channels) != 1 {
+		t.Errorf("got %d channels, want 1", len(w.State.Channels))
 	}
 }
 


### PR DESCRIPTION
## Summary

Three sets of coverage improvements against functions with no direct tests on `upstream/main`:

| Function | Before | After | Change |
|---|---|---|---|
| `install.formatCommandError` | 63.6% | 100% | 5 direct branch tests |
| `wizard.FetchChannels` | 60.0% | 100% | success + partial-result paths |
| `tui.sysextListCursorIdx` | 66.7% | 100% | `!ready` and `!ok` branches |
| `tui.sysextListLookup` | 75.0% | 100% | not-found → returns 0 |

**Package totals:** `install` 82.5%→87.5%, `wizard` 92.3%→93.2%, `tui` 86.6%→86.8%

**`wizard.go` change:** added `var fetchAllChannelsFn = bakery.FetchAllChannels` (1 line) — same pattern used by headless and bakery packages for test injection. No behaviour change.

## Test plan
- [ ] `go test ./internal/install/... ./internal/wizard/... ./internal/tui/...` — all pass
- [ ] `go test ./...` — no regressions
- [ ] `just cover-check` — all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for error handling and list management functions.

* **Refactor**
  * Improved code structure to enhance testability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->