### PR TITLE
test: cover onFormComplete StepWelcome+IgnitionURL and StepTailscale branches

### DIFF
--- a/internal/tui/formcomplete_test.go
+++ b/internal/tui/formcomplete_test.go
@@ -237,3 +237,87 @@ func TestOnFormComplete_AdvanceFails_ShowsError(t *testing.T) {
 		}
 	}
 }
+
+func TestOnFormComplete_Welcome_WithIgnitionURL_JumpsToStorage(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	w.State.Config.Channel = "stable"
+	w.State.Config.IgnitionURL = "https://example.com/config.ign"
+	m := New(w)
+
+	_ = m.onFormComplete()
+
+	if m.err != nil {
+		t.Errorf("expected no error, got: %v", m.err)
+	}
+	if m.Wizard.State.CurrentStep != model.StepStorage {
+		t.Errorf("expected jump to StepStorage, got %v", m.Wizard.State.CurrentStep)
+	}
+}
+
+func TestOnFormComplete_Tailscale_EmptyKey_Advances(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepTailscale
+	w.State.Config.Sysexts = []model.SysextEntry{
+		{Name: "tailscale", Selected: true},
+	}
+	w.State.Config.Users = []model.UserConfig{
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
+	}
+	m := New(w)
+	m.tailscaleAuthKeyIn = "" // empty key is valid (skip tailscale)
+
+	_ = m.onFormComplete()
+
+	if m.err != nil {
+		t.Errorf("expected no error for empty tailscale key, got: %v", m.err)
+	}
+	if m.Wizard.State.CurrentStep == model.StepTailscale {
+		t.Error("expected to advance past StepTailscale")
+	}
+}
+
+func TestOnFormComplete_Tailscale_InvalidKey_ShowsError(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepTailscale
+	w.State.Config.Sysexts = []model.SysextEntry{
+		{Name: "tailscale", Selected: true},
+	}
+	w.State.Config.Users = []model.UserConfig{
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
+	}
+	m := New(w)
+	m.tailscaleAuthKeyIn = "not-a-valid-tskey"
+
+	_ = m.onFormComplete()
+
+	if m.err == nil {
+		t.Fatal("expected error for invalid tailscale key, got nil")
+	}
+	if m.Wizard.State.CurrentStep != model.StepTailscale {
+		t.Errorf("expected to stay on StepTailscale, got %v", m.Wizard.State.CurrentStep)
+	}
+}
+
+func TestOnFormComplete_Tailscale_ValidKey_Advances(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepTailscale
+	w.State.Config.Sysexts = []model.SysextEntry{
+		{Name: "tailscale", Selected: true},
+	}
+	w.State.Config.Users = []model.UserConfig{
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
+	}
+	m := New(w)
+	m.tailscaleAuthKeyIn = "tskey-auth-kSomeID12345-SomeSecretThatIsLongEnough1234"
+	m.tailscaleModeIn = model.TailscaleModeConnect
+
+	_ = m.onFormComplete()
+
+	if m.err != nil {
+		t.Errorf("expected no error for valid tailscale key, got: %v", m.err)
+	}
+	if m.Wizard.State.CurrentStep == model.StepTailscale {
+		t.Error("expected to advance past StepTailscale with valid key")
+	}
+}


### PR DESCRIPTION
## Summary

Four new tests covering previously-zero-hit branches in `onFormComplete()`:

| Scenario | Branch covered |
|---|---|
| Welcome + non-empty `IgnitionURL` | `GoToStep(StepStorage)` jump (lines 71–81) |
| Tailscale empty auth key | valid skip path — advances |
| Tailscale invalid auth key | `m.err` set, stays on `StepTailscale` |
| Tailscale valid auth key | advances past `StepTailscale` |

**Coverage:** `onFormComplete` 67.1% → **79.5%**, `tui` package 88.1% → **88.9%**

The entire `case model.StepTailscale` block (lines 112–126) had zero test coverage. The `StepWelcome + IgnitionURL` fast-path also had no test.

## Test plan
- [ ] `go test ./internal/tui/... -run TestOnFormComplete` — all pass
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)