### PR TITLE
test: cover Update spinner/progress/CtrlC and handleKey q/r/ctrl+c branches

### DIFF
--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -1,6 +1,12 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
 
 func TestMergeKeysVariadic(t *testing.T) {
 	a := []string{"ssh-ed25519 AAAA local@host"}
@@ -47,5 +53,98 @@ func TestMergeKeysPreservesManualOnGitHubFetch(t *testing.T) {
 		if !found[mk] {
 			t.Errorf("manual key %q was dropped after GitHub fetch", mk)
 		}
+	}
+}
+
+// ── handleKey: ctrl+c, q, r edge cases ───────────────────────────────────────
+
+func TestHandleKey_CtrlC_FirstPress(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	newModel, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	got := newModel.(*Model)
+	if !got.confirmQuit {
+		t.Error("first ctrl+c in handleKey should set confirmQuit")
+	}
+	if got.err == nil {
+		t.Error("expected error message for ctrl+c first press")
+	}
+}
+
+func TestHandleKey_CtrlC_SecondPress_Quits(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.confirmQuit = true
+	newModel, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	got := newModel.(*Model)
+	if !got.quitting {
+		t.Error("second ctrl+c in handleKey should set quitting")
+	}
+	if cmd == nil {
+		t.Error("expected quit cmd from second ctrl+c")
+	}
+}
+
+func TestHandleKey_Q_NoFields_FirstPress(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	m := New(w)
+	m.fields = nil // no fields → q triggers confirm-quit
+	newModel, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	got := newModel.(*Model)
+	if !got.confirmQuit {
+		t.Error("first q with no fields should set confirmQuit")
+	}
+}
+
+func TestHandleKey_Q_NoFields_SecondPress_Quits(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.fields = nil
+	m.confirmQuit = true
+	newModel, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	got := newModel.(*Model)
+	if !got.quitting {
+		t.Error("second q with no fields should set quitting")
+	}
+	if cmd == nil {
+		t.Error("expected quit cmd from second q")
+	}
+}
+
+func TestHandleKey_Q_WithFields_AppendsChar(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepStorage
+	m := New(w)
+	m.fields = []field{{label: "Disk", value: ""}}
+	m.fieldIdx = 0
+	m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if m.fields[0].value != "q" {
+		t.Errorf("q in field mode should append 'q', got %q", m.fields[0].value)
+	}
+}
+
+func TestHandleKey_R_NonDoneStep_NoFields(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome // not Done
+	m := New(w)
+	m.fields = nil // no field → r falls through to return nil
+	newModel, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if newModel == nil {
+		t.Fatal("handleKey returned nil model")
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for 'r' on non-Done step with no fields, got %v", cmd)
+	}
+}
+
+func TestHandleKey_Up_WithFields_WrapsIndex(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.fields = []field{{label: "A"}, {label: "B"}, {label: "C"}}
+	m.fieldIdx = 0 // already at top
+	m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.fieldIdx != len(m.fields)-1 {
+		t.Errorf("up at fieldIdx=0 should wrap to %d, got %d", len(m.fields)-1, m.fieldIdx)
 	}
 }

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -472,3 +472,79 @@ func TestHandleKey_EscGoesBack(t *testing.T) {
 }
 
 var errTest = fmt.Errorf("test error")
+
+// ── spinner.TickMsg and progress.FrameMsg ─────────────────────────────────────
+
+func TestUpdate_SpinnerTickMsg(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	// spinner.TickMsg is a concrete type from the bubbles/spinner package;
+	// fire it through Update and confirm the model still runs without panic.
+	tickMsg := m.spinner.Tick()
+	newModel, cmd := m.Update(tickMsg)
+	if newModel == nil {
+		t.Fatal("Update returned nil model for spinner.TickMsg")
+	}
+	if cmd == nil {
+		t.Error("expected a follow-up cmd from spinner tick")
+	}
+}
+
+func TestUpdate_ProgressFrameMsg(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	// Simulate a progress.FrameMsg by setting progress in motion then
+	// driving the animation one frame.
+	_, setCmd := m.Update(m.progress.SetPercent(0.5))
+	if setCmd == nil {
+		t.Skip("progress.SetPercent returned nil cmd, can't drive frame")
+	}
+	frameMsg := setCmd()
+	newModel, _ := m.Update(frameMsg)
+	if newModel == nil {
+		t.Fatal("Update returned nil model for progress.FrameMsg")
+	}
+}
+
+// ── WindowSizeMsg with active form ────────────────────────────────────────────
+
+func TestUpdate_WindowSizeMsg_WithActiveForm(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepNetwork
+	m := New(w)
+	m.initForm() // sets m.activeForm
+	if m.activeForm == nil {
+		t.Skip("initForm did not set activeForm for StepNetwork")
+	}
+	newModel, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
+	got := newModel.(*Model)
+	if got.width != 200 || got.height != 50 {
+		t.Errorf("size not propagated: got %dx%d", got.width, got.height)
+	}
+}
+
+// ── ctrl+c second-press quits from Update ────────────────────────────────────
+
+func TestUpdate_CtrlC_FirstPress_SetsConfirm(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	got := newModel.(*Model)
+	if !got.confirmQuit {
+		t.Error("first ctrl+c should set confirmQuit")
+	}
+}
+
+func TestUpdate_CtrlC_SecondPress_Quits(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.confirmQuit = true
+	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	got := newModel.(*Model)
+	if !got.quitting {
+		t.Error("second ctrl+c should set quitting")
+	}
+	if cmd == nil {
+		t.Error("second ctrl+c should return a quit cmd")
+	}
+}


### PR DESCRIPTION
## Summary

12 new tests covering previously-zero-hit branches in `tui.Update` and `tui.handleKey`.

| Function | Before | After |
|---|---|---|
| `Update` | 77.2% | **82.6%** |
| `handleKey` | 80.8% | **87.5%** |
| `tui` package | 88.1% | **89.2%** |

**`Update` new branches:**
- `spinner.TickMsg` → updates spinner state and returns tick cmd
- `progress.FrameMsg` → drives progress bar animation frame
- `WindowSizeMsg` when `activeForm != nil` → forwards size to form
- `ctrl+c` first press → sets `confirmQuit`
- `ctrl+c` second press → sets `quitting`, returns `tea.Quit`

**`handleKey` new branches:**
- `ctrl+c` first/second press in direct key handler
- `q` first press (no fields) → sets `confirmQuit`
- `q` second press (no fields) → quits
- `q` with fields → appends `'q'` character to field value
- `r` on non-Done step with no fields → returns nil (no-op)
- `up`/`k` with fields at `fieldIdx=0` → wraps to last field

## Test plan
- [ ] `go test ./internal/tui/...` — all pass, 89.2% coverage
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)