### PR TITLE
fix(#224): qa assertion script exits on hostname mismatch, truncating Tier 3 report

### DIFF
--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -478,7 +478,10 @@ cat > "$ASSERT_SCRIPT" << ASSERT_SCRIPT_EOF
 #!/bin/bash
 # Domain assertions for PR #${PR}: ${TITLE}
 # Run inside the booted installed Flatcar (not the installer).
-set -euo pipefail
+# Note: -e is intentionally omitted so all assertions run even when one fails.
+# The FAIL counter tracks failures; set -e would exit on the first mismatch
+# and truncate the report before recording later evidence.
+set -uo pipefail
 FAIL=0
 
 check() {
@@ -509,8 +512,15 @@ grep -E "VERSION_ID|PRETTY_NAME" /etc/os-release
 echo ""
 
 echo "=== BASELINE: hostname matches config ==="
-hostname
-[ "\$(hostname)" = "qa-pr-${PR}" ] || { echo "FAIL: expected qa-pr-${PR}, got \$(hostname)"; FAIL=1; }
+ACTUAL_HOST=\$(hostname)
+echo "\${ACTUAL_HOST}"
+if [ "\${ACTUAL_HOST}" != "qa-pr-${PR}" ]; then
+  echo "FAIL: hostname mismatch: got '\${ACTUAL_HOST}', want 'qa-pr-${PR}'"
+  echo "  (Ignition hostname field may not have propagated — check knuckle-install.log)"
+  FAIL=1
+else
+  echo "ok"
+fi
 echo ""
 
 echo "=== BASELINE: core user SSH key (Ignition applied) ==="
@@ -639,8 +649,8 @@ exit $FAIL
 FINAL
 
 # SCP assertion script to ghost, then into the VM
-_scp_to $GOPTS "$ASSERT_SCRIPT" "$GHOST:${WORK_REMOTE}/assert.sh"
-_ghost "scp $GOPTS -P ${PORT} ${WORK_REMOTE}/assert.sh core@127.0.0.1:/tmp/assert.sh"
+_scp_to $GOPTS "$ASSERT_SCRIPT" "$GHOST:${WORK_REMOTE}/assert.sh" || true
+_ghost "scp $GOPTS -P ${PORT} ${WORK_REMOTE}/assert.sh core@127.0.0.1:/tmp/assert.sh" || true
 
 ASSERT_OUT=$(_ghost "ssh $GOPTS -p ${PORT} core@127.0.0.1 'bash /tmp/assert.sh 2>&1'" 2>&1) || true
 ASSERT_OK=$(echo "$ASSERT_OUT" | grep -c "ALL_ASSERTIONS_PASS" || true)


### PR DESCRIPTION
## Summary

Three changes to `scripts/qa-test-pr.sh` that prevent the assertion script from exiting early and truncating the Tier 3 section of the QA report.

### Root cause

The assertion script had `set -euo pipefail`. When the hostname check failed (e.g., VM reported `localhost` instead of `qa-pr-208`), the `|| { echo "FAIL"; FAIL=1; }` compound is supposed to suppress `set -e` — but this is fragile and bash-version-dependent. In practice the script exited before all assertions ran, producing a truncated report with no Tier 3 evidence.

Two additional unprotected SCP commands in the outer script (section 12) could also cause early exit via the outer `set -euo pipefail` if the ghost→VM copy failed transiently.

### Changes

**1. Remove `-e` from assertion script (`set -euo pipefail` → `set -uo pipefail`)**  
The `FAIL` counter already tracks every failure. `-e` only caused silent early exits that dropped evidence. `-u` and `-o pipefail` are kept.

**2. Explicit `if/else` hostname check with clear diagnostic**  
```
FAIL: hostname mismatch: got 'localhost', want 'qa-pr-208'
  (Ignition hostname field may not have propagated — check knuckle-install.log)
```
Unambiguous even in a truncated report.

**3. `|| true` on the two SCP commands in section 12**  
These were the only unprotected commands in section 12 — a transient SSH hiccup would have exited the outer script before `ASSERT_OUT` was collected.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)