### PR TITLE
test: validateNetwork/Tailscale/User edge cases → 100% each

### DIFF
--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2010,3 +2010,65 @@ func TestValidateUser_InvalidHostname(t *testing.T) {
 		t.Fatal("expected error for invalid hostname, got nil")
 	}
 }
+
+// ── validateTailscale: valid key success path ─────────────────────────────────
+
+func TestValidateTailscale_ValidKeyNonSubnetRouter(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.CurrentStep = model.StepTailscale
+	w.State.Config.Sysexts = []model.SysextEntry{{Name: "tailscale", Selected: true}}
+	w.State.Config.Tailscale.AuthKey = "tskey-auth-kSomeID12345-SomeSecretThatIsLongEnough1234"
+	w.State.Config.Tailscale.Mode = model.TailscaleModeConnect
+	if err := w.ValidateCurrentStep(); err != nil {
+		t.Errorf("valid tailscale key with connect mode should pass, got: %v", err)
+	}
+}
+
+// ── validateNetwork: gateway and DNS error paths ──────────────────────────────
+
+func TestValidateNetwork_InvalidGateway(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.CurrentStep = model.StepNetwork
+	w.State.Config.Network = model.NetworkConfig{
+		Mode:      model.NetworkStatic,
+		Interface: "eth0",
+		Address:   "192.168.1.10/24",
+		Gateway:   "not-an-ip",
+	}
+	err := w.ValidateCurrentStep()
+	if err == nil {
+		t.Fatal("expected error for invalid gateway, got nil")
+	}
+}
+
+func TestValidateNetwork_InvalidDNSServer(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.CurrentStep = model.StepNetwork
+	w.State.Config.Network = model.NetworkConfig{
+		Mode:      model.NetworkStatic,
+		Interface: "eth0",
+		Address:   "192.168.1.10/24",
+		Gateway:   "192.168.1.1",
+		DNS:       []string{"not-a-dns-ip"},
+	}
+	err := w.ValidateCurrentStep()
+	if err == nil {
+		t.Fatal("expected error for invalid DNS server, got nil")
+	}
+}
+
+// ── validateUser: invalid global SSHKey ──────────────────────────────────────
+
+func TestValidateUser_InvalidGlobalSSHKey(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.CurrentStep = model.StepUser
+	w.State.Config.Users = []model.UserConfig{
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 ok"}},
+	}
+	// Config-level SSHKeys (separate from per-user) with an invalid entry.
+	w.State.Config.SSHKeys = []string{"not-a-valid-key"}
+	err := w.ValidateCurrentStep()
+	if err == nil {
+		t.Fatal("expected error for invalid global SSH key, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

4 tests covering the last uncovered statements in three `wizard` validation functions.

| Function | Before | After |
|---|---|---|
| `validateTailscale` | 88.9% | **100%** |
| `validateNetwork` | 83.3% | **100%** |
| `validateUser` | 86.7% | **100%** |
| `wizard` package | 94.1% | **96.4%** |

**`validateTailscale`:** Valid auth key + `connect` mode hits the success `return nil` at the bottom — previously only the empty-key, invalid-key, and subnet-router-error paths were tested.

**`validateNetwork`:** Two error returns were zero-hit — invalid gateway IP (`"not-an-ip"`) and invalid DNS server (`"not-a-dns-ip"`) in static mode. The interface and CIDR error paths were already covered.

**`validateUser`:** The `for _, key := range w.State.Config.SSHKeys` loop (global config-level keys, separate from per-user keys) had no test for the invalid-key error return.

## Test plan
- [ ] `go test ./internal/wizard/...` — all pass, 96.4% coverage
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded validation test coverage for wizard configuration scenarios, including Tailscale authentication, network settings, and SSH key validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->