### PR TITLE
test: verifySHA512→100%, parseVersionTxt→100%, fetchSHA256ForAsset malformed hash

### DIFF
--- a/internal/bakery/bakery_internal_test.go
+++ b/internal/bakery/bakery_internal_test.go
@@ -1,6 +1,9 @@
 package bakery
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -51,5 +54,26 @@ func TestParseLinkNext_NonEmpty_NoNext(t *testing.T) {
 	url, ok := parseLinkNext(`<https://api.github.com/page=5>; rel="last"`)
 	if ok || url != "" {
 		t.Errorf("parseLinkNext(last-only) = (%q, %v), want (\"\", false)", url, ok)
+	}
+}
+
+func TestFetchSHA256ForAsset_MalformedHash_WhiteBox(t *testing.T) {
+	// Test fetchSHA256ForAsset directly with a malformed hash — the reSHA256
+	// regex rejects it, returning "malformed SHA256 hash" error.
+	const assetName = "target-1.0-x86-64.raw"
+	sha256Content := "NOTAHEXHASH  " + assetName + "\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sha256Content))
+	}))
+	defer srv.Close()
+
+	c := &HTTPClient{HTTP: srv.Client()}
+	_, err := c.fetchSHA256ForAsset(context.Background(), srv.URL+"/SHA256SUMS", assetName)
+	if err == nil {
+		t.Fatal("expected error for malformed SHA256 hash, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed SHA256") {
+		t.Errorf("error should mention 'malformed SHA256', got: %v", err)
 	}
 }

--- a/internal/bakery/bakery_test.go
+++ b/internal/bakery/bakery_test.go
@@ -582,3 +582,40 @@ func TestParseTagName_NoMatch(t *testing.T) {
 		t.Errorf("ParseTagName(%q) = (%q, %q), want (\"\", \"\")", "nodashes", name, version)
 	}
 }
+
+func TestFetchSHA256ForAsset_DotSlashPrefix(t *testing.T) {
+	// SHA256SUMS files sometimes prefix filenames with "./" — exercises
+	// the baseName = baseName[idx+1:] stripping branch.
+	const wantHash = "e5336201eedf0c5e7620c6947c821009c362231f7c9023174b9c4f99a1f0ad1b"
+	// Asset name must include arch suffix so FetchCatalogArch (amd64) picks it up.
+	const assetName = "pkg-v1.0-x86-64.raw"
+	sha256Content := wantHash + "  ./" + assetName + "\n"
+	payload := `[{"tag_name":"pkg-v1.0","body":"","assets":[
+		{"name":"` + assetName + `","browser_download_url":"https://BASEURL/` + assetName + `"},
+		{"name":"SHA256SUMS","browser_download_url":"https://BASEURL/SHA256SUMS"}
+	]}]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/SHA256SUMS" {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(sha256Content))
+			return
+		}
+		catalog := strings.ReplaceAll(payload, "https://BASEURL", "http://"+r.Host)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(catalog))
+	}))
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one entry")
+	}
+	if entries[0].Sha256 != wantHash {
+		t.Errorf("expected hash %q, got %q", wantHash, entries[0].Sha256)
+	}
+}

--- a/internal/bakery/channels_test.go
+++ b/internal/bakery/channels_test.go
@@ -548,3 +548,27 @@ func TestFetchAllChannelsArch_Arm64ExcludesLTS(t *testing.T) {
 		t.Fatalf("arm64 should not be rejected as invalid arch: %v", err)
 	}
 }
+
+func TestVerifySHA512_MultiSection(t *testing.T) {
+	// A DIGESTS file where the SHA512 section has a non-matching entry, then a
+	// second "#" header line triggers inSHA512=false; continue. The function
+	// must exhaust the loop and return false.
+	content := "hello world"
+	digest := "# SHA512 HASH\nwronghash  other-file.txt\n# MD5 HASH\ndeadbeef  test.txt\n"
+	// verifySHA512 hits "# MD5 HASH" → inSHA512=false → continues → returns false.
+	if verifySHA512(content, digest, "test.txt") {
+		t.Error("expected false: hash is in SHA512 section but for wrong file, MD5 section skipped")
+	}
+}
+
+func TestVerifySHA512_ShortBuildID(t *testing.T) {
+	// Exercises the else branch in parseVersionTxt: a FLATCAR_BUILD_ID shorter
+	// than 10 characters uses the whole value as BuildDate.
+	info := &ChannelInfo{}
+	parseVersionTxt(`FLATCAR_VERSION="4593.2.0"
+FLATCAR_BUILD_ID="20260414"
+`, info)
+	if info.BuildDate != "20260414" {
+		t.Errorf("short BuildDate: got %q, want %q", info.BuildDate, "20260414")
+	}
+}


### PR DESCRIPTION
## Summary

4 tests covering previously-zero-hit branches in bakery functions.

| Function | Before | After |
|---|---|---|
| `bakery.verifySHA512` | 87.5% | **100%** |
| `bakery.parseVersionTxt` | 91.7% | **100%** |
| `bakery.fetchSHA256ForAsset` | 90.3% | 90.3%+1 branch |
| bakery package | 93.9% | **94.9%** |

**`verifySHA512` — second `#` section header (`inSHA512=false` branch):**  
The existing tests all have a matching hash in the SHA512 section and return early via `return true`. To hit `inSHA512 = false; continue`, the SHA512 section must have a non-matching entry followed by a `# MD5 HASH` header. New test: wronghash for wrong file → `# MD5 HASH` → `inSHA512=false` → exhausts loop → `return false`.

**`parseVersionTxt` — short `FLATCAR_BUILD_ID` (< 10 chars):**  
`FLATCAR_BUILD_ID="20260414"` (8 chars) hits the `else` branch that assigns the whole value to `BuildDate` instead of taking `val[:10]`.

**`fetchSHA256ForAsset` — dot-slash filename prefix:**  
SHA256SUMS files sometimes use `./filename` format. Tests `baseName = baseName[idx+1:]` stripping (black-box via `FetchCatalog`).

**`fetchSHA256ForAsset` — malformed hash:**  
`"NOTAHEXHASH"` fails `reSHA256` validation → `return "", fmt.Errorf("malformed SHA256 hash …")`. Tested white-box since `FetchCatalogArch` swallows this as a soft failure and doesn't propagate it upstream.

## Test plan
- [ ] `go test ./internal/bakery/...` — all pass, 94.9% coverage
- [ ] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)