### PR TITLE
test: MergeSSHKeys→100%, ProbeHardware→100%, runSystemChecks→100%; renderDetailPanel branches

### DIFF
--- a/internal/tui/tui_coverage_test.go
+++ b/internal/tui/tui_coverage_test.go
@@ -450,3 +450,40 @@ func TestDetectLocalSSHKeys_UnreadableFile(t *testing.T) {
 		t.Errorf("unreadable .pub file should be skipped, got %d keys", len(keys))
 	}
 }
+
+// ── renderDetailPanel branches ────────────────────────────────────────────────
+
+func TestRenderDetailPanel_NarrowTerminal_ReturnsEmpty(t *testing.T) {
+	m := New(newTestWizard())
+	m.width = 50 // effectiveWidth=50 < 60 → early return ""
+	ext := model.SysextEntry{Name: "docker", Version: "24.0", Category: "container"}
+	out := m.renderDetailPanel(ext)
+	if out != "" {
+		t.Errorf("narrow terminal should return empty string, got: %q", out)
+	}
+}
+
+func TestRenderDetailPanel_EmptyFieldDefaults(t *testing.T) {
+	m := New(newTestWizard())
+	m.width = 120 // wide enough to render the panel
+	// No category, tier, or version set — each should default to placeholder.
+	ext := model.SysextEntry{Name: "unknown-ext", Version: "", Category: ""}
+	out := m.renderDetailPanel(ext)
+	if !strings.Contains(out, "unknown") {
+		t.Errorf("empty version should show 'unknown' in panel: %q", out)
+	}
+	if !strings.Contains(out, "Other") {
+		t.Errorf("empty category should default to 'Other' in panel: %q", out)
+	}
+}
+
+func TestRenderDetailPanel_WithCaveats(t *testing.T) {
+	m := New(newTestWizard())
+	m.width = 120
+	// "bird" is in the curated catalog with a caveat about manual config files.
+	ext := model.SysextEntry{Name: "bird", Version: "2.0.0", Category: "networking"}
+	out := m.renderDetailPanel(ext)
+	if !strings.Contains(out, "!") {
+		t.Errorf("sysext with caveats should show '!' prefix: %q", out)
+	}
+}

--- a/internal/wizard/apply_test.go
+++ b/internal/wizard/apply_test.go
@@ -153,3 +153,16 @@ func TestMergeSSHKeysPreservesOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeSSHKeys_FiltersEmptyStrings(t *testing.T) {
+	// The k == "" → continue branch is only hit when an empty string appears in a list.
+	result := MergeSSHKeys([]string{"ssh-ed25519 AAAA key1", "", "ssh-ed25519 AAAA key2"})
+	if len(result) != 2 {
+		t.Errorf("expected 2 keys (empty string filtered), got %d: %v", len(result), result)
+	}
+	for _, k := range result {
+		if k == "" {
+			t.Error("empty string should be filtered out by MergeSSHKeys")
+		}
+	}
+}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2072,3 +2072,54 @@ func TestValidateUser_InvalidGlobalSSHKey(t *testing.T) {
 		t.Fatal("expected error for invalid global SSH key, got nil")
 	}
 }
+func TestRunSystemChecks_SysextsAvailable(t *testing.T) {
+	// Covers the len(Sysexts) > 0 → "ok" branch in runSystemChecks.
+	p := &mockProber{
+		disks:  []model.DiskInfo{{DevPath: "/dev/sda"}},
+		ifaces: []model.NetworkInterface{{Name: "eth0", IPv4Addrs: []string{"10.0.0.1"}}},
+	}
+	w := New(p, &mockBakery{}, &mockInstaller{})
+	w.State.Sysexts = []model.SysextEntry{{Name: "docker"}} // pre-populate before ProbeHardware
+
+	if err := w.ProbeHardware(context.Background()); err != nil {
+		t.Fatalf("ProbeHardware: %v", err)
+	}
+	var catalogCheck *SystemCheck
+	for i := range w.State.SystemChecks {
+		if w.State.SystemChecks[i].Name == "Sysext Catalog" {
+			catalogCheck = &w.State.SystemChecks[i]
+		}
+	}
+	if catalogCheck == nil {
+		t.Fatal("expected Sysext Catalog check")
+	}
+	if catalogCheck.Status != "ok" {
+		t.Errorf("Sysext Catalog status = %q, want %q", catalogCheck.Status, "ok")
+	}
+}
+
+type diskOkNetFailProber struct {
+	disks []model.DiskInfo
+}
+
+func (p *diskOkNetFailProber) ListDisks(ctx context.Context) ([]model.DiskInfo, error) {
+	return p.disks, nil
+}
+
+func (p *diskOkNetFailProber) ListNetworkInterfaces(ctx context.Context) ([]model.NetworkInterface, error) {
+	return nil, fmt.Errorf("network probe failed")
+}
+
+func TestProbeHardware_NetworkError(t *testing.T) {
+	// Covers return fmt.Errorf("probing network: %w", err) in ProbeHardware.
+	// ListDisks succeeds, ListNetworkInterfaces fails.
+	p := &diskOkNetFailProber{disks: []model.DiskInfo{{DevPath: "/dev/sda"}}}
+	w := New(p, &mockBakery{}, &mockInstaller{})
+	err := w.ProbeHardware(context.Background())
+	if err == nil {
+		t.Fatal("expected error from ProbeHardware when network probe fails")
+	}
+	if !strings.Contains(err.Error(), "probing network") {
+		t.Errorf("error should mention 'probing network', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

6 tests covering zero-hit branches across `wizard` and `tui`.

| Function | Before | After |
|---|---|---|
| `wizard.MergeSSHKeys` | 90.9% | **100%** |
| `wizard.ProbeHardware` | 92.3% | **100%** |
| `wizard.runSystemChecks` | 93.8% | **100%** |
| `tui.renderDetailPanel` | 91.5% | 93.6% |
| `wizard` package | 94.1% | **95.5%** |

**`MergeSSHKeys` — empty string filter:**  
`k == ""` → `continue` was never exercised. Added a list with an empty string; 2 valid keys are returned, empty skipped.

**`ProbeHardware` — network probe error:**  
`TestProbeHardwareError` sets a single `err` field that fails BOTH `ListDisks` and `ListNetworkInterfaces`, so only the disk-error path was covered. Added `diskOkNetFailProber` that succeeds on disk but fails on network → covers `return fmt.Errorf("probing network: %w", err)`.

**`runSystemChecks` — sysext catalog "ok" branch:**  
Tests always had `State.Sysexts = nil` going into `ProbeHardware`, so the `len(Sysexts) > 0 → "ok"` branch was never hit. Pre-populated `State.Sysexts` before the call.

**`renderDetailPanel` — narrow terminal, empty fields, caveats:**  
- `m.width = 50` → `effectiveWidth = 50 < 60` → early `return ""`
- Sysext with empty `Category`/`Version` → defaults to `"Other"`/`"unknown"`
- `"bird"` sysext has a catalog caveat → `! <caveat>` lines rendered

## Test plan
- [ ] `go test ./internal/wizard/... ./internal/tui/...` — all pass
- [ ] `go test ./... -short` — no regressions (excludes real-network tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the detail panel display functionality, verifying proper handling of narrow terminal widths and default placeholder values for missing fields.
  * Added test validation for SSH key filtering to ensure empty entries are properly removed.
  * Enhanced wizard system-check and hardware-probing test coverage to verify correct behavior in error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->