### PR TITLE
ci: add flaky test detection step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,26 @@ jobs:
       - name: test -race
         run: go test -race ./...
 
+      - name: flaky test detection
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          echo "Running tests 5x to detect flaky tests..."
+          flaky_detected=0
+          for i in {1..5}; do
+            echo "Run $i/5..."
+            if ! go test -count=1 ./... > /tmp/test_run_$i.log 2>&1; then
+              echo "FAIL: Run $i failed"
+              flaky_detected=1
+              tail -20 /tmp/test_run_$i.log
+            fi
+          done
+          if [[ $flaky_detected -eq 1 ]]; then
+            echo "::warning::Potential flaky tests detected — some runs failed. Check logs above."
+            exit 0  # Don't fail CI, just warn
+          fi
+          echo "✓ All 5 runs passed — no flaky tests detected"
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds automated flaky test detection to the CI pipeline (closes #241).

## Changes

Adds a new step after the main `-race` test run that executes the full test suite 5 times sequentially:

```yaml
- name: flaky test detection
  run: |
    # Runs: go test -count=1 ./... (5 times)
    # Emits warning if any run fails
    # Does NOT fail CI (flakiness may be environment-specific)
```

## Behavior

- **All 5 runs pass** → ✓ "No flaky tests detected"
- **Any run fails** → ⚠️ GitHub Actions warning with log tail for that run

This helps catch intermittent failures that single-run CI would miss, without being overly strict about environment-specific flakiness.

## Closes

- #241: Add flaky test detection to CI ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)