### PR TITLE
feat(qa): migrate PR test VMs from QEMU to KubeVirt k8s API

### DIFF
--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -87,19 +87,31 @@ YAML
 }
 
 # kv_inject_ssh_key <name>
-# Stop VM, poll until VMI is gone (B3 FIX), mount ROOT p9, inject authorized_keys.
+# Stop VM, poll until VMI is gone, mount ROOT p9, inject authorized_keys.
 # Flatcar reads ignition via fw_cfg — cloudInitNoCloud silently ignored.
 # Flatcar core UID=500. ROOT = partition 9, offset 6513754112.
+# TIMING: wait for VMI to exist before stopping (it may still be Scheduling),
+# then wait up to 60s for VMI to disappear before mounting disk.
 kv_inject_ssh_key() {
   local name="$1"
   local img="/var/tmp/knuckle-test/${name}-raw.img"
   local key; key=$(ssh $GOPTS "$GHOST" "cat ~/.ssh/id_ed25519.pub")
-  _vc "stop ${name}" 2>/dev/null || true
-  local deadline=$(( $(date +%s) + 30 ))
-  while ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
-    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop"; return 1; }
+
+  # Phase 1: wait for VMI to appear (KubeVirt controller creates it asynchronously)
+  local deadline=$(( $(date +%s) + 60 ))
+  until _kube "get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI ${name} never appeared before inject"; return 1; }
     sleep 2
   done
+
+  # Phase 2: stop VM and wait for VMI to be gone (safe to mount disk only then)
+  _vc "stop ${name}" 2>/dev/null || true
+  deadline=$(( $(date +%s) + 60 ))
+  while _kube "get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI ${name} did not stop for key injection"; return 1; }
+    sleep 2
+  done
+
   ssh $GOPTS "$GHOST" "
     sudo mkdir -p /mnt/flatcar-root
     sudo mount -o loop,offset=6513754112 '${img}' /mnt/flatcar-root
@@ -201,9 +213,17 @@ kv_scp_to_vm() {
 kv_swap_to_target() {
   local name="$1"
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
+
+  # Wait for running VMI before stopping (may still be Scheduling)
+  local deadline=$(( $(date +%s) + 60 ))
+  until _kube "get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI ${name} never appeared before swap"; return 1; }
+    sleep 2
+  done
+
   _vc "stop ${name}" 2>/dev/null || true
-  local deadline=$(( $(date +%s) + 30 ))
-  while ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
+  deadline=$(( $(date +%s) + 60 ))
+  while _kube "get vmi ${name}" &>/dev/null 2>&1; do
     [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop before swap"; return 1; }
     sleep 2
   done

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -133,30 +133,66 @@ kv_wait_ready() {
 }
 
 # kv_ip <name>
-# B1 FIX: masquerade networking — .status.interfaces[0].ipAddress is the guest-internal
-# NAT address (10.0.2.2), not routable from ghost. Use the virt-launcher pod IP instead.
+# B1 FIX: masquerade networking. Uses $GOPTS so IdentitiesOnly is enforced.
 kv_ip() {
   local name="$1"
-  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get pod -l kubevirt.io/vm=${name} \
+  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get pod -l kubevirt.io/vm=${name} \
     -o jsonpath='{.items[0].status.podIP}'"
+}
+
+# kv_ip <name>
+# B1 FIX: masquerade networking — .status.interfaces[0].ipAddress is the guest-internal
+# NAT address (10.0.2.2), not routable from ghost. Use the virt-launcher pod IP instead.
+# NOTE: uses $GOPTS explicitly so IdentitiesOnly forces the right SSH key.
+kv_ip() {
+  local name="$1"
+  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get pod -l kubevirt.io/vm=${name} \
+    -o jsonpath='{.items[0].status.podIP}'"
+}
+
+# kv_wait_ssh <name> [timeout]
+# Poll until SSH inside the VM is actually accepting connections (not just VMI Ready).
+# KubeVirt condition:Ready fires when the QEMU process starts, not when the guest
+# OS has booted. Flatcar needs ~30-60s after VM start to boot and open sshd.
+# Also gives the CNI (flannel) time to set up routes to the pod IP.
+kv_wait_ssh() {
+  local name="$1"
+  local timeout="${2:-120}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local ip; ip=$(kv_ip "$name")
+  echo "Waiting for SSH in VM ${name} at ${ip}..."
+  until ssh $GOPTS "$GHOST" \
+      "ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+           -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 core@${ip} true" &>/dev/null 2>&1; do
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "TIMEOUT: SSH never ready in VM ${name} (pod IP ${ip})"
+      return 1
+    fi
+    sleep 5
+  done
+  echo "SSH ready in VM ${name} at ${ip}"
 }
 
 # kv_ssh <name> <cmd>
 # Run cmd on VM via ghost → pod-network SSH.
+# Both the ghost hop and the inner VM SSH use GOPTS (IdentitiesOnly enforced).
 kv_ssh() {
   local name="$1"; shift
   local ip; ip=$(kv_ip "$name")
-  ssh "$GHOST" "ssh $GOPTS -i ~/.ssh/id_ed25519 core@${ip} '$*'"
+  ssh $GOPTS "$GHOST" "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 core@${ip} '$*'"
 }
 
 # kv_scp_to_vm <name> <local_src> <remote_dst>
 # SCP from dev machine into VM via ghost.
+# GOPTS applied to both hops (dev→ghost, ghost→VM).
 kv_scp_to_vm() {
   local name="$1" src="$2" dst="$3"
   local ip; ip=$(kv_ip "$name")
   local tmp="/tmp/_kv_upload_${$}_${name}"
   scp $GOPTS "$src" "${GHOST}:${tmp}"
-  ssh "$GHOST" "scp $GOPTS -i ~/.ssh/id_ed25519 ${tmp} core@${ip}:${dst}; rm -f ${tmp}"
+  ssh $GOPTS "$GHOST" "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 ${tmp} core@${ip}:${dst}; rm -f ${tmp}"
 }
 
 # kv_swap_to_target <name>

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -207,29 +207,60 @@ kv_scp_to_vm() {
     -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 ${tmp} core@${ip}:${dst}; rm -f ${tmp}"
 }
 
-# kv_swap_to_target <name>
-# Stop installer VM, patch spec so rootdisk → target disk, restart.
-# The installed Flatcar is now on target.img; booting it verifies the install.
-kv_swap_to_target() {
+# kv_boot_installed <name>
+# Delete the installer VM and create a fresh boot-only VM from the target disk.
+# This mirrors the original QEMU approach: kill installer, boot installed disk alone.
+# Patching the live VM spec in-place causes KubeVirt reconciler race conditions;
+# a clean VM object with only the installed disk is more reliable.
+kv_boot_installed() {
   local name="$1"
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
 
-  # Wait for running VMI before stopping (may still be Scheduling)
-  local deadline=$(( $(date +%s) + 60 ))
-  until _kube "get vmi ${name}" &>/dev/null 2>&1; do
-    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI ${name} never appeared before swap"; return 1; }
-    sleep 2
-  done
+  # Delete the installer VM (VMI + VM object) — kv_delete handles --wait=false
+  kv_delete "${name}"
 
-  _vc "stop ${name}" 2>/dev/null || true
-  deadline=$(( $(date +%s) + 60 ))
-  while _kube "get vmi ${name}" &>/dev/null 2>&1; do
-    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop before swap"; return 1; }
-    sleep 2
-  done
-  # Patch rootdisk path to the target (installed) disk
-  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} patch vm ${name} --type=json -p='
-    [{\"op\":\"replace\",\"path\":\"/spec/template/spec/volumes/0/hostDisk/path\",\"value\":\"${tgt_path}\"}]'"
+  # Brief pause for KubeVirt controller to fully release the disk
+  sleep 5
+
+  # Create a new minimal VM: only the installed target disk, no installer disk
+  ssh $GOPTS "$GHOST" kubectl apply -f - << YAML
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ${name}
+  namespace: ${KUBEVIRT_NS}
+spec:
+  runStrategy: Manual
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: ${name}
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        memory:
+          guest: 2Gi
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        machine:
+          type: q35
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: rootdisk
+          hostDisk:
+            path: ${tgt_path}
+            type: Disk
+YAML
   _vc "start ${name}"
 }
 

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -216,8 +216,10 @@ kv_boot_installed() {
   local name="$1"
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
 
-  # Delete the installer VM (VMI + VM object) — kv_delete handles --wait=false
-  kv_delete "${name}"
+  # Delete the installer VM object ONLY — NOT the disk files.
+  # kv_delete removes both disks; we must preserve target.img (installed Flatcar).
+  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} delete vm ${name} \
+    --ignore-not-found --wait=false" 2>/dev/null || true
 
   # Brief pause for KubeVirt controller to fully release the disk
   sleep 5

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -105,11 +105,13 @@ kv_inject_ssh_key() {
   done
 
   # Phase 2: stop VM and wait for VMI to be gone (safe to mount disk only then)
+  # Allow 5s for the stop request to be processed before polling.
   _vc "stop ${name}" 2>/dev/null || true
-  deadline=$(( $(date +%s) + 60 ))
+  sleep 5
+  deadline=$(( $(date +%s) + 120 ))
   while _kube "get vmi ${name}" &>/dev/null 2>&1; do
     [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI ${name} did not stop for key injection"; return 1; }
-    sleep 2
+    sleep 3
   done
 
   ssh $GOPTS "$GHOST" "

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# KubeVirt VM helpers — sourced by qa-test-pr.sh
+# All operations run on ghost via SSH. kubectl/virtctl only — no QEMU process management.
+# Requires: GHOST, GOPTS, KUBEVIRT_NS (defaults to knuckle-test)
+set -euo pipefail
+
+KUBEVIRT_NS="${KUBEVIRT_NS:-knuckle-test}"
+FLATCAR_BASE="${QA_FLATCAR_BASE:-/var/tmp/knuckle-test/flatcar_base.img}"
+
+_kube() { ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} $*"; }
+_vc()   { ssh "$GHOST" "virtctl -n ${KUBEVIRT_NS} $*"; }
+
+# kv_prepare_disk <name>
+# Expand flatcar_base.img to a named raw disk on ghost.
+# B2 FIX: declare paths in outer function scope — never 'local' inside SSH heredoc.
+kv_prepare_disk() {
+  local name="$1"
+  local dst="/var/tmp/knuckle-test/${name}-raw.img"
+  local tgt="/var/tmp/knuckle-test/${name}-target.img"
+  ssh "$GHOST" "
+    if [[ ! -f '${dst}' ]]; then
+      sudo qemu-img convert -p -f qcow2 -O raw '${FLATCAR_BASE}' '${dst}'
+      sudo chown qemu:qemu '${dst}' && sudo chmod 664 '${dst}'
+      sudo chcon -t container_file_t '${dst}'
+    fi
+    if [[ ! -f '${tgt}' ]]; then
+      sudo qemu-img create -f raw '${tgt}' 20G
+      sudo chown qemu:qemu '${tgt}' && sudo chmod 664 '${tgt}'
+      sudo chcon -t container_file_t '${tgt}'
+    fi
+  "
+}
+
+# kv_apply_vm <name>
+# Apply VirtualMachine to cluster and start it.
+# B3 FIX: runStrategy:Manual prevents controller auto-restart during disk mount.
+kv_apply_vm() {
+  local name="$1"
+  local root_path="/var/tmp/knuckle-test/${name}-raw.img"
+  local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
+  ssh "$GHOST" kubectl apply -f - << YAML
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ${name}
+  namespace: ${KUBEVIRT_NS}
+spec:
+  runStrategy: Manual
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: ${name}
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        memory:
+          guest: 2Gi
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk:
+                bus: virtio
+            - name: targetdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+        machine:
+          type: q35
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: rootdisk
+          hostDisk:
+            path: ${root_path}
+            type: Disk
+        - name: targetdisk
+          hostDisk:
+            path: ${tgt_path}
+            type: Disk
+YAML
+  _vc "start ${name}"
+}
+
+# kv_inject_ssh_key <name>
+# Stop VM, poll until VMI is gone (B3 FIX), mount ROOT p9, inject authorized_keys.
+# Flatcar reads ignition via fw_cfg — cloudInitNoCloud silently ignored.
+# Flatcar core UID=500. ROOT = partition 9, offset 6513754112.
+kv_inject_ssh_key() {
+  local name="$1"
+  local img="/var/tmp/knuckle-test/${name}-raw.img"
+  local key; key=$(ssh "$GHOST" "cat ~/.ssh/id_ed25519.pub")
+  _vc "stop ${name}" 2>/dev/null || true
+  local deadline=$(( $(date +%s) + 30 ))
+  while ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop"; return 1; }
+    sleep 2
+  done
+  ssh "$GHOST" "
+    sudo mkdir -p /mnt/flatcar-root
+    sudo mount -o loop,offset=6513754112 '${img}' /mnt/flatcar-root
+    sudo mkdir -p /mnt/flatcar-root/home/core/.ssh
+    printf '%s\n' '${key}' | sudo tee /mnt/flatcar-root/home/core/.ssh/authorized_keys >/dev/null
+    sudo chown -R 500:500 /mnt/flatcar-root/home/core/.ssh
+    sudo chmod 700 /mnt/flatcar-root/home/core/.ssh
+    sudo chmod 600 /mnt/flatcar-root/home/core/.ssh/authorized_keys
+    sudo umount /mnt/flatcar-root
+  "
+  _vc "start ${name}"
+}
+
+# kv_wait_ready <name> [timeout]
+# B4 FIX: poll for VMI creation before kubectl wait (wait exits immediately if resource missing).
+kv_wait_ready() {
+  local name="$1"
+  local timeout="${2:-120}"
+  local deadline=$(( $(date +%s) + timeout ))
+  until _kube "get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && {
+      echo "TIMEOUT: VMI ${name} never created"
+      _kube "describe vm ${name}" 2>/dev/null || true
+      return 1
+    }
+    sleep 2
+  done
+  local remaining=$(( deadline - $(date +%s) ))
+  [[ $remaining -le 5 ]] && remaining=5
+  _kube "wait vmi ${name} --for=condition=Ready --timeout=${remaining}s"
+}
+
+# kv_ip <name>
+# B1 FIX: masquerade networking — .status.interfaces[0].ipAddress is the guest-internal
+# NAT address (10.0.2.2), not routable from ghost. Use the virt-launcher pod IP instead.
+kv_ip() {
+  local name="$1"
+  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get pod -l kubevirt.io/vm=${name} \
+    -o jsonpath='{.items[0].status.podIP}'"
+}
+
+# kv_ssh <name> <cmd>
+# Run cmd on VM via ghost → pod-network SSH.
+kv_ssh() {
+  local name="$1"; shift
+  local ip; ip=$(kv_ip "$name")
+  ssh "$GHOST" "ssh $GOPTS -i ~/.ssh/id_ed25519 core@${ip} '$*'"
+}
+
+# kv_scp_to_vm <name> <local_src> <remote_dst>
+# SCP from dev machine into VM via ghost.
+kv_scp_to_vm() {
+  local name="$1" src="$2" dst="$3"
+  local ip; ip=$(kv_ip "$name")
+  local tmp="/tmp/_kv_upload_${$}_${name}"
+  scp $GOPTS "$src" "${GHOST}:${tmp}"
+  ssh "$GHOST" "scp $GOPTS -i ~/.ssh/id_ed25519 ${tmp} core@${ip}:${dst}; rm -f ${tmp}"
+}
+
+# kv_swap_to_target <name>
+# Stop installer VM, patch spec so rootdisk → target disk, restart.
+# The installed Flatcar is now on target.img; booting it verifies the install.
+kv_swap_to_target() {
+  local name="$1"
+  local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
+  _vc "stop ${name}" 2>/dev/null || true
+  local deadline=$(( $(date +%s) + 30 ))
+  while ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
+    [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop before swap"; return 1; }
+    sleep 2
+  done
+  # Patch rootdisk path to the target (installed) disk
+  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} patch vm ${name} --type=json -p='
+    [{\"op\":\"replace\",\"path\":\"/spec/template/spec/volumes/0/hostDisk/path\",\"value\":\"${tgt_path}\"}]'"
+  _vc "start ${name}"
+}
+
+# kv_delete <name>
+# Delete VM and disk files. B5 FIX: --wait=false avoids 60s block during crash cleanup.
+kv_delete() {
+  local name="$1"
+  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} delete vm ${name} \
+    --ignore-not-found --wait=false" 2>/dev/null || true
+  ssh "$GHOST" "
+    sudo rm -f /var/tmp/knuckle-test/${name}-raw.img  2>/dev/null || true
+    sudo rm -f /var/tmp/knuckle-test/${name}-target.img 2>/dev/null || true
+  " 2>/dev/null || true
+}

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 KUBEVIRT_NS="${KUBEVIRT_NS:-knuckle-test}"
 FLATCAR_BASE="${QA_FLATCAR_BASE:-/var/tmp/knuckle-test/flatcar_base.img}"
 
-_kube() { ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} $*"; }
-_vc()   { ssh "$GHOST" "virtctl -n ${KUBEVIRT_NS} $*"; }
+_kube() { ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} $*"; }
+_vc()   { ssh $GOPTS "$GHOST" "virtctl -n ${KUBEVIRT_NS} $*"; }
 
 # kv_prepare_disk <name>
 # Expand flatcar_base.img to a named raw disk on ghost.
@@ -17,7 +17,7 @@ kv_prepare_disk() {
   local name="$1"
   local dst="/var/tmp/knuckle-test/${name}-raw.img"
   local tgt="/var/tmp/knuckle-test/${name}-target.img"
-  ssh "$GHOST" "
+  ssh $GOPTS "$GHOST" "
     if [[ ! -f '${dst}' ]]; then
       sudo qemu-img convert -p -f qcow2 -O raw '${FLATCAR_BASE}' '${dst}'
       sudo chown qemu:qemu '${dst}' && sudo chmod 664 '${dst}'
@@ -38,7 +38,7 @@ kv_apply_vm() {
   local name="$1"
   local root_path="/var/tmp/knuckle-test/${name}-raw.img"
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
-  ssh "$GHOST" kubectl apply -f - << YAML
+  ssh $GOPTS "$GHOST" kubectl apply -f - << YAML
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -93,14 +93,14 @@ YAML
 kv_inject_ssh_key() {
   local name="$1"
   local img="/var/tmp/knuckle-test/${name}-raw.img"
-  local key; key=$(ssh "$GHOST" "cat ~/.ssh/id_ed25519.pub")
+  local key; key=$(ssh $GOPTS "$GHOST" "cat ~/.ssh/id_ed25519.pub")
   _vc "stop ${name}" 2>/dev/null || true
   local deadline=$(( $(date +%s) + 30 ))
-  while ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
+  while ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
     [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop"; return 1; }
     sleep 2
   done
-  ssh "$GHOST" "
+  ssh $GOPTS "$GHOST" "
     sudo mkdir -p /mnt/flatcar-root
     sudo mount -o loop,offset=6513754112 '${img}' /mnt/flatcar-root
     sudo mkdir -p /mnt/flatcar-root/home/core/.ssh
@@ -203,12 +203,12 @@ kv_swap_to_target() {
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
   _vc "stop ${name}" 2>/dev/null || true
   local deadline=$(( $(date +%s) + 30 ))
-  while ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
+  while ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} get vmi ${name}" &>/dev/null 2>&1; do
     [[ $(date +%s) -ge $deadline ]] && { echo "TIMEOUT: VMI stop before swap"; return 1; }
     sleep 2
   done
   # Patch rootdisk path to the target (installed) disk
-  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} patch vm ${name} --type=json -p='
+  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} patch vm ${name} --type=json -p='
     [{\"op\":\"replace\",\"path\":\"/spec/template/spec/volumes/0/hostDisk/path\",\"value\":\"${tgt_path}\"}]'"
   _vc "start ${name}"
 }
@@ -217,9 +217,9 @@ kv_swap_to_target() {
 # Delete VM and disk files. B5 FIX: --wait=false avoids 60s block during crash cleanup.
 kv_delete() {
   local name="$1"
-  ssh "$GHOST" "kubectl -n ${KUBEVIRT_NS} delete vm ${name} \
+  ssh $GOPTS "$GHOST" "kubectl -n ${KUBEVIRT_NS} delete vm ${name} \
     --ignore-not-found --wait=false" 2>/dev/null || true
-  ssh "$GHOST" "
+  ssh $GOPTS "$GHOST" "
     sudo rm -f /var/tmp/knuckle-test/${name}-raw.img  2>/dev/null || true
     sudo rm -f /var/tmp/knuckle-test/${name}-target.img 2>/dev/null || true
   " 2>/dev/null || true

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -219,6 +219,11 @@ kv_wait_ready "$VM_NAME" 120 || {
   cat "$REPORT"; exit 1
 }
 
+kv_wait_ssh "$VM_NAME" 120 || {
+  { echo "### Installer VM Boot"; echo "**⛔ SSH TIMEOUT — Flatcar did not finish booting**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
+  cat "$REPORT"; exit 1
+}
+
 INSTALLER_IP=$(kv_ip "$VM_NAME")
 log "Installer VM ready at ${INSTALLER_IP}"
 
@@ -434,6 +439,12 @@ kv_swap_to_target "$VM_NAME"
 kv_wait_ready "$VM_NAME" 180 || {
   { echo "### Installed System Boot"; echo "**⛔ INSTALLED SYSTEM DID NOT BOOT**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
   _file_issue_on_fail "$REPORT" "$RUNDIR" "Installed Flatcar did not boot" || true
+  cat "$REPORT"; exit 1
+}
+
+kv_wait_ssh "$VM_NAME" 180 || {
+  { echo "### Installed System Boot"; echo "**⛔ SSH TIMEOUT — installed Flatcar did not come up**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
+  _file_issue_on_fail "$REPORT" "$RUNDIR" "Installed Flatcar SSH never ready" || true
   cat "$REPORT"; exit 1
 }
 log "Installed system online"

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -18,7 +18,6 @@ PR=${1:?usage: qa-test-pr.sh <PR_NUMBER>}
 # See docs/GHOST-LAB.md for lab setup instructions.
 GHOST=${QA_HOST:-localhost}
 GOPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-BASE_IMG="${QA_FLATCAR_BASE:-/var/tmp/knuckle-test/flatcar_base.img}"
 WORK_REMOTE="/var/tmp/knuckle-qa-pr-${PR}"
 RUN_ID="pr-${PR}-$(date +%Y%m%d-%H%M%S)"
 RUNDIR=".qa/runs/${RUN_ID}"
@@ -50,7 +49,7 @@ _file_issue_on_fail() {
 ### Failing output
 
 \`\`\`
-$(grep -A3 "FAIL\|\u274c" "$report" | head -30)
+$(grep -A3 "FAIL\|❌" "$report" | head -30)
 \`\`\`
 
 ### To reproduce
@@ -60,6 +59,19 @@ just qa-pr ${PR}
 ISSUE_EOF
   log "Issue body: ${issue_file}"
 }
+
+# Source KubeVirt helpers
+# shellcheck source=scripts/lib/vm-kubevirt.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/vm-kubevirt.sh"
+
+VM_NAME=""  # set when VM is allocated; trap uses this
+_cleanup_kv() {
+  local exit_code=$?
+  [[ -n "${VM_NAME:-}" ]] && kv_delete "${VM_NAME}" 2>/dev/null || true
+  exit "$exit_code"
+}
+trap '_cleanup_kv' EXIT INT TERM
 
 mkdir -p "$RUNDIR"
 
@@ -184,51 +196,35 @@ fi
   cat "$REPORT"; exit 0
 }
 
-# ── 7. Allocate port + boot installer VM ─────────────────────────────────────
-log "Setting up installer VM on ghost..."
+# ── 7. Create KubeVirt installer VM ──────────────────────────────────────────
+log "Setting up KubeVirt installer VM..."
+VM_NAME="qa-pr-${PR}-$(date +%s)"
+
 _ghost "mkdir -p ${WORK_REMOTE}"
-_scp_to $GOPTS bin/knuckle "$GHOST:${WORK_REMOTE}/knuckle"
 
 HOST_KEY=$(_ghost "cat ~/.ssh/id_ed25519.pub")
-PORT=$(_ghost "for p in \$(seq 2300 2315); do ss -tln | grep -q \":\${p} \" || { echo \$p; exit 0; }; done; echo NONE")
-[[ "$PORT" == "NONE" ]] && { echo "**⛔ No free port on ghost.**" >> "$REPORT"; cat "$REPORT"; exit 1; }
-log "Port ${PORT}"
 
-_ghost "
-  rm -f ${WORK_REMOTE}/boot.qcow2 ${WORK_REMOTE}/target.qcow2 \
-        ${WORK_REMOTE}/serial-installer.log ${WORK_REMOTE}/knuckle-install.log
-  qemu-img create -f qcow2 -b ${BASE_IMG} -F qcow2 ${WORK_REMOTE}/boot.qcow2 >/dev/null
-  qemu-img create -f qcow2 ${WORK_REMOTE}/target.qcow2 20G >/dev/null
-  printf '{\"ignition\":{\"version\":\"3.4.0\"},\"passwd\":{\"users\":[{\"name\":\"core\",\"sshAuthorizedKeys\":[\"%s\"]}]},\"systemd\":{\"units\":[{\"name\":\"sshd.service\",\"enabled\":true}]}}\n' '${HOST_KEY}' > ${WORK_REMOTE}/installer.ign
-  qemu-system-x86_64 \
-    -m 2048 -smp 2 -enable-kvm -cpu host \
-    -drive if=virtio,file=${WORK_REMOTE}/boot.qcow2,format=qcow2 \
-    -drive if=virtio,file=${WORK_REMOTE}/target.qcow2,format=qcow2 \
-    -fw_cfg name=opt/org.flatcar-linux/config,file=${WORK_REMOTE}/installer.ign \
-    -net nic,model=virtio -net user,hostfwd=tcp::${PORT}-:22 \
-    -display none -daemonize -pidfile ${WORK_REMOTE}/qemu-installer.pid \
-    -serial file:${WORK_REMOTE}/serial-installer.log >/dev/null 2>&1
-"
+log "Preparing disks..."
+kv_prepare_disk "$VM_NAME"
 
-log "Waiting for installer VM SSH..."
-_ghost "
-  ok=0
-  for i in \$(seq 1 20); do
-    ssh $GOPTS -o ConnectTimeout=2 -p ${PORT} core@127.0.0.1 true 2>/dev/null && ok=1 && break
-    sleep 2
-  done
-  [ \$ok -eq 1 ] || { echo BOOT_TIMEOUT; tail -10 ${WORK_REMOTE}/serial-installer.log >&2; exit 1; }
-" || {
-  _ghost_logs_to_rundir
+log "Applying VM to cluster..."
+kv_apply_vm "$VM_NAME"
+
+log "Injecting SSH key..."
+kv_inject_ssh_key "$VM_NAME"
+
+log "Waiting for installer VM ready..."
+kv_wait_ready "$VM_NAME" 120 || {
   { echo "### Installer VM Boot"; echo "**⛔ BOOT TIMEOUT**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
   cat "$REPORT"; exit 1
 }
 
-_ghost "
-  scp $GOPTS -P ${PORT} ${WORK_REMOTE}/knuckle core@127.0.0.1:/tmp/knuckle
-  ssh $GOPTS -p ${PORT} core@127.0.0.1 'chmod +x /tmp/knuckle'
-"
-log "Installer VM ready"
+INSTALLER_IP=$(kv_ip "$VM_NAME")
+log "Installer VM ready at ${INSTALLER_IP}"
+
+kv_scp_to_vm "$VM_NAME" bin/knuckle /tmp/knuckle
+kv_ssh "$VM_NAME" 'chmod +x /tmp/knuckle'
+log "Binary deployed"
 
 # ── 8. Tier 1 — tool check + dry-run ─────────────────────────────────────────
 log "Tier 1: tool check + dry-run..."
@@ -265,14 +261,13 @@ json.dump(d, open(p, "w"))
 PYEOF
 fi
 
-# SCP config to ghost, then ghost SCPs it into the VM
+# SCP config to ghost for artifact storage, then directly into the VM
 _scp_to $GOPTS "${QA_CONFIG_FILE}" "$GHOST:${WORK_REMOTE}/qa.json"
-_ghost "scp $GOPTS -P ${PORT} ${WORK_REMOTE}/qa.json core@127.0.0.1:/tmp/qa.json"
+kv_scp_to_vm "$VM_NAME" "${QA_CONFIG_FILE}" /tmp/qa.json
 
-T1=$(_ghost "
-  ssh $GOPTS -p ${PORT} core@127.0.0.1 '
+T1=$(kv_ssh "$VM_NAME" '
     echo --- os ---
-    grep -E \"VERSION_ID|PRETTY_NAME\" /etc/os-release
+    grep -E "VERSION_ID|PRETTY_NAME" /etc/os-release
     echo --- util-linux ---
     sfdisk --version
     wipefs --version
@@ -281,16 +276,15 @@ T1=$(_ghost "
     echo --- headless --dry-run ---
     sudo /tmp/knuckle --headless --dry-run --config /tmp/qa.json --log-file /tmp/knuckle-dryrun.log 2>&1
     echo --- progress steps ---
-    sudo cat /tmp/knuckle-dryrun.log 2>/dev/null | grep -o \"\\\"msg\\\":\\\"[^\\\"]*\\\"\" | head -12
-  '
-" 2>&1) || T1="DRY_RUN_ERROR"
+    sudo cat /tmp/knuckle-dryrun.log 2>/dev/null | grep -o "\"msg\":\"[^\"]*\"" | head -12
+' 2>&1) || T1="DRY_RUN_ERROR"
 
 DRY_OK=$(echo "$T1" | grep -c "Installation complete" || true)
 # Also check for JSON parse errors — indicates config was malformed
 JSON_ERR=$(echo "$T1" | grep -c "parsing config JSON\|invalid character" || true)
 [[ $JSON_ERR -gt 0 ]] && DRY_OK=0
 {
-  echo "### Tier 1 — Installer VM: tool check + dry-run (port ${PORT})"
+  echo "### Tier 1 — Installer VM: tool check + dry-run (VM ${VM_NAME})"
   echo
   echo '```'
   echo "$T1"
@@ -301,7 +295,6 @@ JSON_ERR=$(echo "$T1" | grep -c "parsing config JSON\|invalid character" || true
 } >> "$REPORT"
 
 if [[ $DRY_OK -eq 0 ]]; then
-  _ghost "kill \$(cat ${WORK_REMOTE}/qemu-installer.pid 2>/dev/null) 2>/dev/null || true"
   echo "**Verdict: ❌ FAIL — dry-run did not complete**" >> "$REPORT"
   _fetch_artifacts
   _file_issue_on_fail "$REPORT" "$RUNDIR" "Dry-run failed" || true
@@ -362,9 +355,9 @@ exit $FAIL
 SECSCRIPT
 
   _scp_to $GOPTS /tmp/qa-sec-tests-${PR}.sh "$GHOST:${WORK_REMOTE}/sec-tests.sh"
-  _ghost "scp $GOPTS -P ${PORT} ${WORK_REMOTE}/sec-tests.sh core@127.0.0.1:/tmp/sec-tests.sh"
+  kv_scp_to_vm "$VM_NAME" "/tmp/qa-sec-tests-${PR}.sh" /tmp/sec-tests.sh
 
-  SEC=$(_ghost "ssh $GOPTS -p ${PORT} core@127.0.0.1 'bash /tmp/sec-tests.sh 2>&1'" 2>&1) || SEC_OK=0
+  SEC=$(kv_ssh "$VM_NAME" 'bash /tmp/sec-tests.sh 2>&1' 2>&1) || SEC_OK=0
   SEC_OK=$(echo "$SEC" | grep -c "SECURITY_TESTS_DONE fail_count=0" || true)
 
   {
@@ -379,7 +372,6 @@ SECSCRIPT
   } >> "$REPORT"
 
   if [[ $SEC_OK -eq 0 ]]; then
-    _ghost "kill \$(cat ${WORK_REMOTE}/qemu-installer.pid 2>/dev/null) 2>/dev/null || true"
     echo "**Verdict: ❌ FAIL — security regression**" >> "$REPORT"
     _fetch_artifacts
     _file_issue_on_fail "$REPORT" "$RUNDIR" "Security regression: bad input accepted" || true
@@ -397,13 +389,11 @@ fi
 # ── 10. Tier 3 — real headless install ───────────────────────────────────────
 log "Tier 3: real headless install..."
 
-INSTALL_OUT=$(_ghost "
-  ssh $GOPTS -p ${PORT} core@127.0.0.1 '
-    sudo /tmp/knuckle --headless --config /tmp/qa.json \
-      --log-file /tmp/knuckle-install.log 2>&1
-    echo INSTALL_EXIT_CODE=\$?
-  '
-" 2>&1) || true
+INSTALL_OUT=$(kv_ssh "$VM_NAME" '
+  sudo /tmp/knuckle --headless --config /tmp/qa.json \
+    --log-file /tmp/knuckle-install.log 2>&1
+  echo INSTALL_EXIT_CODE=$?
+' 2>&1) || true
 INSTALL_DONE=$(echo "$INSTALL_OUT" | grep -c "INSTALL_EXIT_CODE=0" || true)
 
 {
@@ -415,8 +405,8 @@ INSTALL_DONE=$(echo "$INSTALL_OUT" | grep -c "INSTALL_EXIT_CODE=0" || true)
   echo
 } >> "$REPORT"
 
-# Retrieve install log from VM before killing it
-_ghost "ssh $GOPTS -p ${PORT} core@127.0.0.1 'sudo cat /tmp/knuckle-install.log 2>/dev/null'" \
+# Retrieve install log from VM
+kv_ssh "$VM_NAME" 'sudo cat /tmp/knuckle-install.log 2>/dev/null' \
   > "${RUNDIR}/knuckle-install.log" 2>/dev/null || true
 {
   echo "<details><summary>knuckle-install.log</summary>"
@@ -431,8 +421,6 @@ _ghost "ssh $GOPTS -p ${PORT} core@127.0.0.1 'sudo cat /tmp/knuckle-install.log 
   echo
 } >> "$REPORT"
 
-_ghost "kill \$(cat ${WORK_REMOTE}/qemu-installer.pid 2>/dev/null) 2>/dev/null || true; sleep 2"
-
 if [[ $INSTALL_DONE -eq 0 ]]; then
   _fetch_artifacts
   echo "**Verdict: ❌ FAIL — install did not complete**" >> "$REPORT"
@@ -441,27 +429,9 @@ if [[ $INSTALL_DONE -eq 0 ]]; then
 fi
 
 # ── 11. Boot installed Flatcar ────────────────────────────────────────────────
-log "Booting installed system..."
-
-_ghost "
-  rm -f ${WORK_REMOTE}/serial-installed.log ${WORK_REMOTE}/qemu-installed.pid
-  qemu-system-x86_64 \
-    -m 2048 -smp 2 -enable-kvm -cpu host \
-    -drive if=virtio,file=${WORK_REMOTE}/target.qcow2,format=qcow2 \
-    -net nic,model=virtio -net user,hostfwd=tcp::${PORT}-:22 \
-    -display none -daemonize -pidfile ${WORK_REMOTE}/qemu-installed.pid \
-    -serial file:${WORK_REMOTE}/serial-installed.log >/dev/null 2>&1
-"
-
-_ghost "
-  ok=0
-  for i in \$(seq 1 30); do
-    ssh $GOPTS -o ConnectTimeout=3 -p ${PORT} core@127.0.0.1 true 2>/dev/null && ok=1 && break
-    sleep 5
-  done
-  [ \$ok -eq 1 ] || { echo INSTALLED_BOOT_TIMEOUT; tail -10 ${WORK_REMOTE}/serial-installed.log >&2; exit 1; }
-" || {
-  _fetch_artifacts
+log "Booting installed Flatcar (swapping rootdisk to target)..."
+kv_swap_to_target "$VM_NAME"
+kv_wait_ready "$VM_NAME" 180 || {
   { echo "### Installed System Boot"; echo "**⛔ INSTALLED SYSTEM DID NOT BOOT**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
   _file_issue_on_fail "$REPORT" "$RUNDIR" "Installed Flatcar did not boot" || true
   cat "$REPORT"; exit 1
@@ -648,11 +618,10 @@ fi
 exit $FAIL
 FINAL
 
-# SCP assertion script to ghost, then into the VM
+# SCP assertion script to ghost for artifact storage, then directly into the VM
 _scp_to $GOPTS "$ASSERT_SCRIPT" "$GHOST:${WORK_REMOTE}/assert.sh" || true
-_ghost "scp $GOPTS -P ${PORT} ${WORK_REMOTE}/assert.sh core@127.0.0.1:/tmp/assert.sh" || true
-
-ASSERT_OUT=$(_ghost "ssh $GOPTS -p ${PORT} core@127.0.0.1 'bash /tmp/assert.sh 2>&1'" 2>&1) || true
+kv_scp_to_vm "$VM_NAME" "$ASSERT_SCRIPT" /tmp/assert.sh 2>/dev/null || true
+ASSERT_OUT=$(kv_ssh "$VM_NAME" 'bash /tmp/assert.sh 2>&1' 2>&1) || true
 ASSERT_OK=$(echo "$ASSERT_OUT" | grep -c "ALL_ASSERTIONS_PASS" || true)
 ASSERT_FAILS=$(echo "$ASSERT_OUT" | grep -c "^FAIL:" || true)
 
@@ -671,8 +640,7 @@ ASSERT_FAILS=$(echo "$ASSERT_OUT" | grep -c "^FAIL:" || true)
   echo
 } >> "$REPORT"
 
-# Cleanup installed VM
-_ghost "kill \$(cat ${WORK_REMOTE}/qemu-installed.pid 2>/dev/null) 2>/dev/null || true" 2>/dev/null || true
+# Cleanup handled by trap (_cleanup_kv calls kv_delete)
 
 # Fetch all artifacts from ghost
 _fetch_artifacts
@@ -697,4 +665,3 @@ fi
 log "Artifacts: ${RUNDIR}/"
 cat "$REPORT"
 [[ $ASSERT_OK -gt 0 ]] && exit 0 || exit 1
-

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -434,8 +434,8 @@ if [[ $INSTALL_DONE -eq 0 ]]; then
 fi
 
 # ── 11. Boot installed Flatcar ────────────────────────────────────────────────
-log "Booting installed Flatcar (swapping rootdisk to target)..."
-kv_swap_to_target "$VM_NAME"
+log "Booting installed Flatcar (delete installer VM, boot-only)..."
+kv_boot_installed "$VM_NAME"
 kv_wait_ready "$VM_NAME" 180 || {
   { echo "### Installed System Boot"; echo "**⛔ INSTALLED SYSTEM DID NOT BOOT**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
   _file_issue_on_fail "$REPORT" "$RUNDIR" "Installed Flatcar did not boot" || true

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -17,7 +17,7 @@ PR=${1:?usage: qa-test-pr.sh <PR_NUMBER>}
 # Example: export QA_HOST=jorge@192.168.1.102
 # See docs/GHOST-LAB.md for lab setup instructions.
 GHOST=${QA_HOST:-localhost}
-GOPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+GOPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_ed25519"
 WORK_REMOTE="/var/tmp/knuckle-qa-pr-${PR}"
 RUN_ID="pr-${PR}-$(date +%Y%m%d-%H%M%S)"
 RUNDIR=".qa/runs/${RUN_ID}"


### PR DESCRIPTION
## Summary

Replaces the direct QEMU process management in `scripts/qa-test-pr.sh` with KubeVirt `VirtualMachine` CRDs on the k3s cluster running on ghost (192.168.1.102).

### Before → After

| Before | After |
|---|---|
| `qemu-system-x86_64` process via SSH | `kubectl apply` VirtualMachine CRD |
| Port 2300–2315 allocated per-PR, `hostfwd` | Pod-network IP (10.42.0.x), no ports |
| SSH from dev → ghost → `127.0.0.1:PORT` | SSH from dev → ghost → pod IP |
| QEMU PID files, manual kill on cleanup | K8s EXIT trap calls `kv_delete` |
| Parallel runs cause `index.lock` conflicts | Each VM is a named k8s object |

### New files
- `scripts/lib/vm-kubevirt.sh` — KubeVirt helper library (`kv_prepare_disk`, `kv_apply_vm`, `kv_inject_ssh_key`, `kv_wait_ready`, `kv_wait_ssh`, `kv_ip`, `kv_ssh`, `kv_scp_to_vm`, `kv_boot_installed`, `kv_delete`)

### Key implementation notes
- **runStrategy: Manual** — prevents controller auto-restart during disk mount
- **kv_ip** queries virt-launcher pod label, not VMI status (masquerade NAT returns guest-internal 10.0.2.2)
- **kv_wait_ssh** polls actual SSH availability; KubeVirt condition:Ready fires when QEMU starts, not when Flatcar boots
- **kv_boot_installed** deletes installer VM object only (not disks), creates fresh boot-only VM from target disk
- **GOPTS** (IdentitiesOnly=yes) applied to every ghost SSH hop to avoid MaxAuthTries failure
- **EXIT trap** wires kv_delete for leak-free cleanup on any failure

### Verified
- ✅ Tier 0 (just ci): passing on dev machine
- ✅ Tier 1 (domain:tui PR #236): Flatcar 4593.2.1 booted, dry-run completed
- ✅ Tier 3 (domain:headless PR #231): install completed (32s), installed system booted, `ALL_ASSERTIONS_PASS`

Assisted-by: claude-sonnet-4-5 via pi