### PR TITLE
Fix typo in README.md regarding Flatcar installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A modern, interactive TUI "installer" for [Flatcar Container Linux](https://www.flatcar.org/), designed for bare-metal deployments. Not a real installer because making one would be dumb. There's no reason to make a "Bluefin Server" if Bluefin just gives you a nice tool to use Flatcar. 
 
-Knuckle is a charm.sh form that makes a valid ignition file and passes it to the Flatcat installer. We're just making users not have to use ignition, with an ubuntu-server style install UX. 
+Knuckle is a charm.sh form that makes a valid ignition file and passes it to the Flatcar installer. We're just making users not have to use ignition, with an ubuntu-server style install UX. 
 
 This is also basically [Azure Container Linux (Home Edition)](https://opensource.microsoft.com/blog/2026/05/18/from-open-source-to-agentic-systems-microsoft-at-open-source-summit-north-america-2026/). 
 - [Download an ISO](https://github.com/projectbluefin/knuckle/releases) for ARM or AMD64 and install it.


### PR DESCRIPTION
<!--
Thanks for sending a PR to knuckle.

Contributors using AI agents (Claude Code, Copilot, Cursor, pi):
AGENTS.md at the repo root is the authoritative agent context for
this project. Read it before writing code, and have the agent
verify it ran `just ci` locally before opening the PR. The hive
workflow assumes agents have respected the package boundaries and
safety invariants documented there.
-->

## What
Fixes a typo in the readme

## Why
<!-- Link the issue this closes (Closes #123) or describe the motivation. -->

## How tested
<!-- Check at least one. -->
- [ ] `just ci` is green locally
- [ ] `just vm-e2e` passes (end-to-end install + boot)
- [ ] `just headless-test` passes (for headless-mode changes)
- [ ] Tested on real hardware — describe below
- [x] Doc / template / CI change only — no install path touched

## Scope check
<!-- knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64.
     Does this PR stay inside that scope? If it expands it, call out why. -->

## Notes for reviewers
<!-- Anything reviewers should know — risky areas, follow-ups, screenshots, etc. -->

---

<!-- For agents: mention what command you ran to verify, e.g.
     `just ci` exit 0, `just headless-test` exit 0. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the README's Knuckle description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->