### PR TITLE
fix: qa-test-pr.sh complexity gate and undefined function

### DIFF
--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -78,7 +78,7 @@ WF_CHANGED=$(gh pr diff "$PR" --repo projectbluefin/knuckle --name-only 2>/dev/n
   | grep -c "^\.github/workflows/" || true)
 
 # ── 2. Complexity gate ────────────────────────────────────────────────────────
-if [[ "$SIZE" == "size:XL" ]] || [[ $DOMAIN_COUNT -gt 4 ]] || [[ $WF_CHANGED -gt 0 ]]; then
+if [[ "$SIZE" == "size:XL" || "$SIZE" == "size:XXL" ]] || [[ $DOMAIN_COUNT -gt 4 ]] || [[ $WF_CHANGED -gt 0 ]]; then
   log "SKIP: complexity gate (size=${SIZE} domains=${DOMAIN_COUNT} wf=${WF_CHANGED})"
   cat > "$REPORT" << EOF
 ## 🧪 Ghost Testlab — PR #${PR} SKIPPED
@@ -219,7 +219,7 @@ _ghost "
   done
   [ \$ok -eq 1 ] || { echo BOOT_TIMEOUT; tail -10 ${WORK_REMOTE}/serial-installer.log >&2; exit 1; }
 " || {
-  _ghost_logs_to_rundir
+  _fetch_artifacts
   { echo "### Installer VM Boot"; echo "**⛔ BOOT TIMEOUT**"; echo; echo "**Verdict: ❌ FAIL**"; } >> "$REPORT"
   cat "$REPORT"; exit 1
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in scripts/qa-test-pr.sh discovered during QA workflow analysis.

## Issues Addressed

### #259: Complexity gate misses size:XXL
- **Bug**: Line 81 checks for `size:XL` but not `size:XXL`
- **Impact**: 1000+ line PRs bypass the manual VM-test skip, wasting test resources
- **Fix**: Added `|| "$SIZE" == "size:XXL"` to the complexity gate condition

### #258: Undefined _ghost_logs_to_rundir function
- **Bug**: Line 222 calls undefined function in boot-timeout error handler
- **Impact**: With `set -euo pipefail`, undefined function causes immediate exit before diagnostic output
- **Fix**: Replaced `_ghost_logs_to_rundir` with existing `_fetch_artifacts` function

## Testing

```bash
# Syntax check
bash -n scripts/qa-test-pr.sh
# All changes are in shell script conditionals
```

Closes #259, #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)