### PR TITLE
fix(ci): add size:XXL to qa-test-pr.sh complexity gate

### DIFF
--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -90,7 +90,7 @@ WF_CHANGED=$(gh pr diff "$PR" --repo projectbluefin/knuckle --name-only 2>/dev/n
   | grep -c "^\.github/workflows/" || true)
 
 # ── 2. Complexity gate ────────────────────────────────────────────────────────
-if [[ "$SIZE" == "size:XL" ]] || [[ $DOMAIN_COUNT -gt 4 ]] || [[ $WF_CHANGED -gt 0 ]]; then
+if [[ "$SIZE" == "size:XL" || "$SIZE" == "size:XXL" ]] || [[ $DOMAIN_COUNT -gt 4 ]] || [[ $WF_CHANGED -gt 0 ]]; then
   log "SKIP: complexity gate (size=${SIZE} domains=${DOMAIN_COUNT} wf=${WF_CHANGED})"
   cat > "$REPORT" << EOF
 ## 🧪 Ghost Testlab — PR #${PR} SKIPPED


### PR DESCRIPTION
## Summary

The complexity gate in `scripts/qa-test-pr.sh` only skipped PRs labeled `size:XL`. PRs labeled `size:XXL` (>500 lines, common for hanthor coverage batches that accumulate upstream changes on stale worktrees) were not caught.

## Root cause

In this session, PRs #250 and #257 were both `size:XXL` and would have been fed to the VM test harness if run through the script — wasting time and producing unreliable results.

## Fix

One-line change to the gate condition:
```bash
# Before:
if [[ "$SIZE" == "size:XL" ]] ...
# After:
if [[ "$SIZE" == "size:XL" || "$SIZE" == "size:XXL" ]] ...
```

## Testing
- `just ci` ✅
- Fix applies cleanly to both current `qa-test-pr.sh` (QEMU) and the post-#251 KubeVirt version (identical gate line)

Closes #258 (identified by hanthor in PR #260)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QA testing gate conditions to skip certain automated test runs for larger pull requests, improving testing efficiency for oversized submissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->