### PR TITLE
test(#270): sysext helpers and channel cards coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something in knuckle is broken — install fails, TUI freezes, ISO won't boot, etc.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in as much as you can — installer
+        bugs are very environment-specific (firmware, disk model, channel), and
+        we cannot reproduce what we cannot see.
+
+        **For contributors using AI agents (Claude Code, Copilot, Cursor, pi):**
+        `AGENTS.md` at the repo root is the authoritative agent context for
+        this project. Point your agent at it before asking it to triage or
+        fix this issue. The hive workflow expects agents to read
+        `AGENTS.md` → run `just ci` → respect the safety invariants
+        documented there.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what went wrong.
+      placeholder: "Install fails on a SATA SSD with `flatcar-install` returning exit code 1 — stderr lost."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Smallest sequence that reliably reproduces the bug. Include the headless JSON config if you have one.
+      placeholder: |
+        1. Boot installer ISO on bare metal (Lenovo M75q-1)
+        2. Pick `stable` channel
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Install completes and the system reboots into Flatcar."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste TUI output, `flatcar-install` stderr, and any kernel messages. Use code fences.
+    validations:
+      required: true
+
+  - type: input
+    id: knuckle-version
+    attributes:
+      label: knuckle version
+      description: Output of `knuckle --version`, or the ISO filename.
+      placeholder: "v0.6.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Architecture
+      options:
+        - x86_64
+        - arm64
+    validations:
+      required: true
+
+  - type: dropdown
+    id: env
+    attributes:
+      label: Where did you run knuckle?
+      options:
+        - Bare metal
+        - QEMU/KVM
+        - Other VM (Proxmox, VMware, Hyper-V, etc.)
+        - Cloud VM
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware / VM details
+      description: CPU, disk model+size, NIC, firmware mode (UEFI/BIOS). For VMs, the launch command if you have it.
+      placeholder: |
+        Lenovo M75q-1, AMD Ryzen 5 PRO 3400GE
+        500GB Samsung 870 EVO (SATA AHCI)
+        Realtek RTL8111H
+        UEFI
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / config / dmesg
+      description: |
+        Attach any of: installer log (`/var/log/knuckle-install.log` if present),
+        rendered Ignition JSON from the Review screen, `dmesg | tail -200`, or a
+        screen capture of the failure. Redact any tokens or passwords.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Flatcar Discord
+    url: https://flatcar.org/discord
+    about: General Flatcar questions and chat — not knuckle-specific.
+  - name: Flatcar documentation
+    url: https://www.flatcar.org/docs/
+    about: Upstream Flatcar setup, Ignition, and bare-metal install docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a new feature, wizard step, or sysext integration.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new features (e.g. "add Tailscale step", "support LUKS").
+        For bugs use the bug report template.
+
+        **Contributors using AI agents:** read `AGENTS.md` first. This file is
+        the authoritative agent context for the project — it lists package
+        boundaries, the runner abstraction, safety invariants, and the
+        `just ci` gate every change must pass. The hive workflow expects
+        agents to consult it before writing code.
+
+        Small features that already match an existing pattern (NVIDIA, sysexts,
+        update strategy) are great candidates for the `copilot-ready` label.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Who asks for it?
+      placeholder: "Tailscale is the most common first thing people set up on a new Flatcar node..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed design
+      description: How should this look in the wizard / headless config / Ignition output?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope check
+      description: |
+        knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64. Does this
+        feature stay inside that scope, or does it expand it?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for sending a PR to knuckle.
+
+Contributors using AI agents (Claude Code, Copilot, Cursor, pi):
+AGENTS.md at the repo root is the authoritative agent context for
+this project. Read it before writing code, and have the agent
+verify it ran `just ci` locally before opening the PR. The hive
+workflow assumes agents have respected the package boundaries and
+safety invariants documented there.
+-->
+
+## What
+<!-- One or two sentences. What does this change? -->
+
+## Why
+<!-- Link the issue this closes (Closes #123) or describe the motivation. -->
+
+## How tested
+<!-- Check at least one. -->
+- [ ] `just ci` is green locally
+- [ ] `just vm-e2e` passes (end-to-end install + boot)
+- [ ] `just headless-test` passes (for headless-mode changes)
+- [ ] Tested on real hardware — describe below
+- [ ] Doc / template / CI change only — no install path touched
+
+## Scope check
+<!-- knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64.
+     Does this PR stay inside that scope? If it expands it, call out why. -->
+
+## Notes for reviewers
+<!-- Anything reviewers should know — risky areas, follow-ups, screenshots, etc. -->
+
+---
+
+<!-- For agents: mention what command you ran to verify, e.g.
+     `just ci` exit 0, `just headless-test` exit 0. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,42 @@
+# GitHub auto-generated release notes config.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Groups merged PRs by label into sections in the release body.
+# Keep this list short and aligned with the labels used on issues.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+    authors:
+      - dependabot
+      - renovate-bot
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Security
+      labels:
+        - security
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: Refactors
+      labels:
+        - refactor
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI & infrastructure
+      labels:
+        - ci
+        - infra
+    - title: Other changes
+      labels:
+        - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 # Go
 vendor/
 
-# IDE
+# IDE / Claude
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to knuckle are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Each
+release also has a GitHub Release with auto-generated PR-level notes — this
+file is the curated, human-readable history.
+
+## [Unreleased]
+
+### Added
+- Flatcar Discord community links on the welcome and install-done screens
+  (#117).
+- `.github/release.yml` to group auto-generated release notes by label
+  (Features, Bug fixes, Security, etc.) (#116).
+
+## [0.6.2] - 2026-05-19
+
+### Fixed
+- `Shift+Tab` now goes back a wizard step instead of incorrectly moving the
+  cursor up.
+
+## [0.6.1] - 2026-05-18
+
+### Fixed
+- Use `/dev/console` in the installer systemd unit so the TUI renders correctly
+  when booting over serial.
+
+### Added
+- Tests for GitHub SSH key-fetch error handling and no-auth guard on
+  `StepUser`.
+
+## [0.6.0] - 2026-05-17
+
+### Fixed
+- Password-only auth in headless mode now propagates to `InstallConfig`.
+
+## [0.5.1] - 2026-05-16
+
+### Added
+- CNCF supply-chain stack: Syft SBOMs, cosign keyless signing, ORAS push to
+  GHCR, SLSA build provenance attestations.
+
+## [0.5.0] - 2026-05-15
+
+### Fixed
+- External Ignition URL path bypasses auth/channel consistency checks.
+
+## [0.4.0] - 2026-05-14
+
+### Fixed
+- CI: use the correct arm64 runner label (`ubuntu-24.04-arm`).
+
+## [0.3.0] - 2026-05-13
+
+### Fixed
+- `justfile`: escape Go template braces in the `vm-e2e` docker check.
+
+## [0.2.1] - 2026-05-12
+
+### Fixed
+- ISO: inject `knuckle` into `usr.squashfs` for reliable live boot.
+
+## [0.2.0] - 2026-05-11
+
+### Security
+- Real Flatcar GPG verification via ProtonMail/go-crypto (security baseline
+  B1).
+
+## [0.1.0] - 2026-05-10
+
+### Added
+- First working ISO build with GRUB and `boot-iso` justfile recipes.
+
+[Unreleased]: https://github.com/projectbluefin/knuckle/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/projectbluefin/knuckle/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/projectbluefin/knuckle/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/projectbluefin/knuckle/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/projectbluefin/knuckle/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/projectbluefin/knuckle/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/projectbluefin/knuckle/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/projectbluefin/knuckle/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/projectbluefin/knuckle/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/projectbluefin/knuckle/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/projectbluefin/knuckle/releases/tag/v0.1.0

--- a/Justfile
+++ b/Justfile
@@ -19,6 +19,7 @@ default:
     @echo "Quickstart:"
     @echo "  just vm        — install in a VM, boots into installed system after"
     @echo "  just vm-e2e    — automated: headless install → boot → verify SSH"
+    @echo "  just hardware-repro — boot installer ISO in a hardware-like VM and capture install logs"
     @echo "  just e2e       — full end-to-end: build ISO → boot → install → verify"
     @echo ""
     @echo "Pre-release (requires network):"
@@ -708,7 +709,9 @@ e2e:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -763,7 +766,9 @@ boot-iso:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -802,7 +807,9 @@ boot-iso-ssh:
         )
     else
         OVMF_CANDIDATES=(
+            /usr/share/OVMF/OVMF_CODE_4M.fd
             /usr/share/OVMF/OVMF_CODE.fd
+            /usr/share/edk2/ovmf/OVMF_CODE_4M.fd
             /usr/share/edk2/ovmf/OVMF_CODE.fd
         )
         for f in /home/linuxbrew/.linuxbrew/Cellar/qemu/*/share/qemu/edk2-x86_64-code.fd; do
@@ -827,6 +834,133 @@ boot-iso-ssh:
     done
     echo "VM ready."
     exec ssh -t {{SSH_OPTS}} -p 2222 core@127.0.0.1
+
+# Boot the installer ISO in a hardware-like VM and capture install failure artifacts.
+hardware-repro:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PIDFILE=.vm/qemu.pid
+    cleanup() {
+        if [ -f "$PIDFILE" ]; then
+            sudo -n kill "$(sudo -n cat "$PIDFILE")" 2>/dev/null || true
+            sudo -n rm -f "$PIDFILE" 2>/dev/null || true
+            rm -f "$PIDFILE" 2>/dev/null || true
+        fi
+    }
+    trap cleanup EXIT
+    [ "{{KNUCKLE_ARCH}}" = "amd64" ] || { echo "hardware-repro currently supports amd64 only"; exit 1; }
+    just build
+    ISO="output/knuckle-installer-stable-{{KNUCKLE_ARCH}}.iso"
+    if [ ! -f "$ISO" ]; then
+        just iso
+    else
+        echo "using existing ISO: $ISO"
+    fi
+    just _kill-vm
+    mkdir -p .vm
+    rm -f .vm/hardware-target.qcow2 .vm/hardware-installer-serial.log .vm/hardware-install-output.log \
+        .vm/hardware-knuckle.log .vm/hardware-journal.log .vm/hardware-disk-inventory.log \
+        .vm/hardware-ovmf-vars.fd .vm/hardware-installer.ign .vm/hardware_key .vm/hardware_key.pub
+    qemu-img create -f qcow2 .vm/hardware-target.qcow2 20G >/dev/null
+    ssh-keygen -t ed25519 -f .vm/hardware_key -N "" -C "knuckle-hardware-repro" -q
+    HARDWARE_PUB=$(cat .vm/hardware_key.pub)
+    printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+        "$HARDWARE_PUB" > .vm/hardware-installer.ign
+
+    OVMF_CODE=""
+    OVMF_VARS=""
+    for candidate in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE_4M.fd /usr/share/edk2/ovmf/OVMF_CODE.fd; do
+        [ -f "$candidate" ] && OVMF_CODE="$candidate" && break
+    done
+    for candidate in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd /usr/share/edk2/ovmf/OVMF_VARS_4M.fd /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+        [ -f "$candidate" ] && OVMF_VARS="$candidate" && break
+    done
+    [ -n "$OVMF_CODE" ] || { echo "OVMF firmware code image not found — install ovmf"; exit 1; }
+    [ -n "$OVMF_VARS" ] || { echo "OVMF firmware vars image not found — install ovmf"; exit 1; }
+    cp "$OVMF_VARS" .vm/hardware-ovmf-vars.fd
+
+    QEMU_CMD=({{QEMU}})
+    QEMU_ACCEL=(-enable-kvm -cpu host)
+    if [ ! -r /dev/kvm ] || [ ! -w /dev/kvm ]; then
+        if sudo -n test -r /dev/kvm && sudo -n test -w /dev/kvm; then
+            echo "using sudo for KVM access"
+            QEMU_CMD=(sudo -n {{QEMU}})
+        else
+        echo "warning: /dev/kvm is not accessible; falling back to TCG emulation"
+        QEMU_ACCEL=(-accel tcg,thread=multi -cpu max)
+        fi
+    fi
+
+    "${QEMU_CMD[@]}" \
+        -machine q35 -m 4096 -smp 2 "${QEMU_ACCEL[@]}" \
+        -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+        -drive if=pflash,format=raw,file=.vm/hardware-ovmf-vars.fd \
+        -device ich9-ahci,id=sata0 \
+        -drive if=none,id=installeriso,file="$ISO",format=raw,readonly=on \
+        -device ide-cd,drive=installeriso,bus=sata0.0 \
+        -drive if=none,id=target,file=.vm/hardware-target.qcow2,format=qcow2 \
+        -device ide-hd,drive=target,bus=sata0.1,serial=target-disk \
+        -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/hardware-installer.ign \
+        -netdev user,id=n0,hostfwd=tcp::2222-:22 \
+        -device e1000e,netdev=n0 \
+        -display none -daemonize -pidfile "$PIDFILE" \
+        -serial file:.vm/hardware-installer-serial.log
+
+    HARDWARE_SSH="ssh {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -p 2222 core@127.0.0.1"
+    HARDWARE_SCP="scp {{SSH_OPTS}} -o BatchMode=yes -i .vm/hardware_key -P 2222"
+
+    ok=0
+    for i in $(seq 1 120); do
+        $HARDWARE_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break
+        sleep 5
+    done
+    if [ "$ok" != "1" ]; then
+        echo "❌ installer ISO never came up (serial log below)"
+        tail -40 .vm/hardware-installer-serial.log 2>/dev/null || true
+        exit 1
+    fi
+    echo "✓ installer ISO ready over SSH"
+
+    TARGET_DEV=$($HARDWARE_SSH "lsblk -dnpo PATH,TYPE | awk '\$2 == \"disk\" { print \$1; exit }'")
+    [ -n "$TARGET_DEV" ] || { echo "❌ failed to detect target disk"; exit 1; }
+    TARGET_BY_ID=$($HARDWARE_SSH "for p in /dev/disk/by-id/*; do [ -e \"\$p\" ] || continue; [ \"\$(readlink -f \"\$p\")\" = \"$TARGET_DEV\" ] && case \"\$p\" in *-part*) ;; *) echo \"\$p\"; break ;; esac; done")
+    [ -n "$TARGET_BY_ID" ] || TARGET_BY_ID="$TARGET_DEV"
+
+    echo "target disk: $TARGET_BY_ID"
+    $HARDWARE_SSH "printf '=== lsblk ===\n'; lsblk -o NAME,PATH,TYPE,SIZE,MODEL,SERIAL,TRAN,RM,MOUNTPOINT; printf '\n=== /dev/disk/by-id ===\n'; ls -l /dev/disk/by-id" \
+        | tee .vm/hardware-disk-inventory.log
+
+    printf '{"channel":"stable","hostname":"hardware-repro","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"%s","update_strategy":"off","reboot":false}\n' \
+        "$HARDWARE_PUB" "$TARGET_BY_ID" > .vm/hardware-repro.json
+    $HARDWARE_SCP .vm/hardware-repro.json core@127.0.0.1:/tmp/hardware-repro.json >/dev/null
+
+    set +e
+    $HARDWARE_SSH "timeout 15m sudo /usr/bin/knuckle --headless --config /tmp/hardware-repro.json --log-file /tmp/knuckle.log" 2>&1 \
+        | tee .vm/hardware-install-output.log
+    rc=${PIPESTATUS[0]}
+    set -e
+
+    $HARDWARE_SSH "sudo cat /tmp/knuckle.log" 2>/dev/null | tee .vm/hardware-knuckle.log >/dev/null || true
+    $HARDWARE_SSH "sudo journalctl -b --no-pager -u sshd.service -u systemd-networkd.service -u systemd-udevd.service" 2>/dev/null \
+        | tee .vm/hardware-journal.log >/dev/null || true
+
+    echo ""
+    echo "artifacts:"
+    echo "  .vm/hardware-install-output.log"
+    echo "  .vm/hardware-knuckle.log"
+    echo "  .vm/hardware-journal.log"
+    echo "  .vm/hardware-disk-inventory.log"
+    echo "  .vm/hardware-installer-serial.log"
+
+    if [ "$rc" -ne 0 ]; then
+        echo ""
+        echo "❌ hardware-like install repro failed"
+        echo "   see .vm/hardware-install-output.log and .vm/hardware-knuckle.log"
+        exit "$rc"
+    fi
+
+    echo ""
+    echo "✅ hardware-like install completed"
 
 # Stop running VM
 stop:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **System extensions** — architecture-aware sysext catalog fetched via TLS from [flatcar/sysext-bakery](https://github.com/flatcar/sysext-bakery) GitHub Releases API (not yet cryptographically verified — see [docs/SECURITY.md](docs/SECURITY.md))
 - **Update strategy** — reboot, off, or etcd-lock options
 - **Review screen** — full Butane YAML preview before install
-- **Install step** — progress bar, wraps `flatcar-install` for disk provisioning
+- **Install step** — progress bar, wipes stale disk signatures, then wraps `flatcar-install` for disk provisioning
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
 - **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)
@@ -88,7 +88,8 @@ just headless-test  # build + canned JSON config (CI gate, runs on host)
 
 ```bash
 just vm           # real install in QEMU → auto-boots installed system after
-just vm-e2e       # automated: headless install → boot → verify SSH + hostname (3 passes)
+just vm-e2e       # automated: headless install → boot → verify SSH + hostname (4 passes)
+just hardware-repro # installer ISO in a hardware-like VM, captures install failure artifacts
 just boot-iso     # build ISO → boot in QEMU GTK window
 just e2e          # build ISO → boot → interactive install
 just ssh          # SSH into running VM
@@ -96,7 +97,9 @@ just ssh          # SSH into running VM
 
 `just vm` downloads a Flatcar stable QEMU image, boots a VM with two disks (boot + target), SCPs the binary in, and launches knuckle over SSH. After install completes, it kills the installer VM and boots from the installed target disk to verify SSH works.
 
-`just vm-e2e` is fully automated — runs 3 passes (DHCP, static network, docker sysext), verifying hostname, OS version, update strategy, and sysext activation on each.
+`just vm-e2e` is fully automated — runs 4 passes (DHCP, static network, docker sysext, NVIDIA), verifying hostname, OS version, update strategy, and sysext activation on each.
+
+`just hardware-repro` boots the installer ISO with `q35`, UEFI, a SATA target disk, and an `e1000e` NIC so the VM looks more like a generic physical machine than a paravirtualized guest. It then runs the same `internal/install` path via `--headless` and saves the useful artifacts under `.vm/` (`hardware-install-output.log`, `hardware-knuckle.log`, `hardware-journal.log`, `hardware-disk-inventory.log`, `hardware-installer-serial.log`).
 
 ARM64 VM testing: `KNUCKLE_ARCH=arm64 just vm` (requires native arm64 hardware or QEMU TCG).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ internal/wizard/     → step state machine, navigation, validation gates
 - **Security** (`security.yml`) — CodeQL (Go), OSSF Scorecard, dependency-review
 - **Release** (`release.yml`) — triggered on `v*` tags; builds amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`; produces binaries + installer ISOs + cosign bundles
 
+## Community
+
+- [Flatcar on Discord](https://flatcar.org/discord) — chat with the Flatcar community
+- [Flatcar docs](https://www.flatcar.org/docs/) — official documentation
+- [knuckle issues](https://github.com/projectbluefin/knuckle/issues) — file bugs and ideas
+
 ## License
 
 Apache 2.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **Install step** — progress bar, wipes stale disk signatures, runs `flatcar-install`, then relocates the backup GPT header for larger target disks
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
-- **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)
+- **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64), with `systemd.gpt_auto=0` set in both boot entries to avoid GPT auto-generator hangs when the ISO is written to larger USB media
 - **Config validation** — consistency checks before install
 - **Dry-run mode** — `--dry-run` flag skips all disk writes
 - **Ctrl+C double-press** — confirmation before quitting

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Perfect for home servers, NAS builds, k8s cluster setups, you name it. The [Flat
 - **System extensions** — architecture-aware sysext catalog fetched via TLS from [flatcar/sysext-bakery](https://github.com/flatcar/sysext-bakery) GitHub Releases API (not yet cryptographically verified — see [docs/SECURITY.md](docs/SECURITY.md))
 - **Update strategy** — reboot, off, or etcd-lock options
 - **Review screen** — full Butane YAML preview before install
-- **Install step** — progress bar, wipes stale disk signatures, then wraps `flatcar-install` for disk provisioning
+- **Install step** — progress bar, wipes stale disk signatures, runs `flatcar-install`, then relocates the backup GPT header for larger target disks
 - **Ignition generation** — produces valid Ignition JSON via in-process Butane compilation (Flatcar variant, no CLI dependency)
 - **Headless mode** — `--headless --config <file.json>` for automated installs (CI/CD friendly)
 - **Installer ISO** — UEFI-bootable ISO with systemd-boot (amd64 + arm64)

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -147,6 +147,28 @@ The static pass uses QEMU's slirp NAT subnet so SSH port-forwarding still works
 even with a static IP configured inside the VM. Interface name is currently
 hardcoded to `ens3` — may need `eth0` on some Flatcar versions (open issue).
 
+## Hardware-like Repro
+
+`just hardware-repro` is the closest local reproduction path for "boot the
+installer ISO, then fail inside `flatcar-install`" without needing bare metal.
+It boots the built installer ISO with:
+
+- `q35` machine type
+- UEFI (`OVMF_CODE.fd` + writable `OVMF_VARS.fd`)
+- SATA target disk (`ide-hd`, serial `target-disk`)
+- `e1000e` NIC
+- QEMU `fw_cfg` Ignition so SSH is available in the live installer
+
+The recipe runs `knuckle --headless` inside that live ISO environment so it
+exercises the same `internal/install` handoff as the TUI, while making failure
+capture deterministic. On every run it writes:
+
+- `.vm/hardware-install-output.log` — CLI output from the headless install run
+- `.vm/hardware-knuckle.log` — `/tmp/knuckle.log` from the live installer
+- `.vm/hardware-journal.log` — selected system journal from the live boot
+- `.vm/hardware-disk-inventory.log` — `lsblk` plus `/dev/disk/by-id` inventory
+- `.vm/hardware-installer-serial.log` — VM serial console output
+
 ## Roadmap
 
 Tracked in `docs/REVIEW-2026-05-19.md` (passes 1-2) and session notes from

--- a/docs/HIVE-DEPLOYMENT.md
+++ b/docs/HIVE-DEPLOYMENT.md
@@ -1,0 +1,61 @@
+# Deploying a Hive Container on Flatcar
+
+This guide covers the host-side prerequisites for running a knuckle/hive
+container on Flatcar Container Linux.
+
+## TL;DR — add swap before starting agents
+
+Flatcar Container Linux ships with **no swap configured**. Without swap, the
+kernel OOM killer fires the moment multiple agent processes try to start in
+parallel — `claude-code` is ~236 MB resident per agent and a 4 GiB VM with no
+swap goes red within seconds.
+
+### One-time setup
+
+Run these once on the Flatcar host *before* you start the hive container:
+
+```bash
+sudo fallocate -l 512M /var/swapfile
+sudo chmod 600 /var/swapfile
+sudo mkswap /var/swapfile
+sudo swapon /var/swapfile
+echo '/var/swapfile swap swap defaults 0 0' | sudo tee -a /etc/fstab
+```
+
+Verify:
+
+```bash
+swapon --show
+free -h
+```
+
+### Sizing
+
+| Host RAM | Swap |
+|----------|------|
+| ≤ 4 GiB  | 512 MiB (matches the certus reference deployment that runs without OOM kills on 4.83) |
+| 4–16 GiB | 1–2 GiB |
+| > 16 GiB | 4 GiB |
+
+512 MiB is the minimum that has been observed to keep concurrent agent startup
+stable. Going larger does no harm.
+
+## Why not just provision it via knuckle?
+
+If you install Flatcar **with knuckle ≥ v0.7.0**, swap is enabled by default
+([#95](https://github.com/projectbluefin/knuckle/issues/95)) — you don't need
+the manual steps above on fresh installs. The instructions above exist for:
+
+- Hosts installed with knuckle ≤ v0.6.x.
+- Hosts where someone passed `--swap=false` (or `{"swap":{"enabled":false}}`
+  via headless config) and now wants to add swap back.
+- Hosts installed via stock `flatcar-install` / cloud images, which never
+  provision swap.
+
+## Context
+
+- **4.83 (certus, working):** 4 GiB RAM + 512 MiB swap — concurrent agents
+  start cleanly.
+- **4.85 (knuckle ≤ v0.6.x, broken):** 3.8 GiB RAM + no swap → agents killed
+  (exit 137) at startup.
+- **4.85 (knuckle ≥ v0.7.0):** 3.8 GiB RAM + 4 GiB swap (default) → fine.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ This document covers each.
 | Asset                         | Threat                                              | Mitigation                                                                       |
 | ----------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Target disk contents          | Wrong-disk wipe                                     | `/dev/disk/by-id` paths; boot disk auto-filtered in `internal/probe`              |
-| Target disk contents          | TOCTOU between probe and `flatcar-install`          | `flatcar-install` re-probes; knuckle does not pre-format                         |
+| Target disk contents          | Stale signatures / partition tables block install   | `wipefs --all --force` runs on the selected target before `flatcar-install`     |
 | Ignition file (SSH keys, pw)  | World-readable temp file                            | `os.CreateTemp` (O_EXCL) + `chmod 0600` + deferred unlink                        |
 | Sysext download               | Tampered binary in transit                          | TLS via Go stdlib; SHA512 verified for Flatcar SBOM (display-only today)         |
 | Sysext catalog                | Malicious release injected into `flatcar/sysext-bakery` | GitHub Releases API only; *no* signature verification — see Known Gaps          |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ This document covers each.
 | Asset                         | Threat                                              | Mitigation                                                                       |
 | ----------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Target disk contents          | Wrong-disk wipe                                     | `/dev/disk/by-id` paths; boot disk auto-filtered in `internal/probe`              |
-| Target disk contents          | Stale signatures / partition tables block install   | `wipefs --all --force` runs on the selected target before `flatcar-install`     |
+| Target disk contents          | Stale signatures / misplaced GPT backup header      | `wipefs --all --force` runs before install; `sfdisk --relocate gpt-bak-std` runs after imaging |
 | Ignition file (SSH keys, pw)  | World-readable temp file                            | `os.CreateTemp` (O_EXCL) + `chmod 0600` + deferred unlink                        |
 | Sysext download               | Tampered binary in transit                          | TLS via Go stdlib; SHA512 verified for Flatcar SBOM (display-only today)         |
 | Sysext catalog                | Malicious release injected into `flatcar/sysext-bakery` | GitHub Releases API only; *no* signature verification — see Known Gaps          |

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -30,10 +30,19 @@ type Config struct {
 	Disk                string        `json:"disk"`
 	Sysexts             []string      `json:"sysexts,omitempty"`
 	NvidiaDriverVersion string        `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
+	Swap                *SwapConfig   `json:"swap,omitempty"`                  // nil = default-on (4 GiB); pass {"enabled":false} to disable
 	UpdateStrategy      string        `json:"update_strategy"`
 	IgnitionURL         string        `json:"ignition_url,omitempty"`
 	Reboot              bool          `json:"reboot"`
 	DryRun              bool          `json:"dry_run,omitempty"`
+}
+
+// SwapConfig for JSON input. Default (nil) ⇒ enabled with default size.
+// Pass {"enabled": false} to disable, or {"enabled": true, "size_mb": 8192}
+// for an explicit size.
+type SwapConfig struct {
+	Enabled bool `json:"enabled"`
+	SizeMB  int  `json:"size_mb,omitempty"` // 0 = use model.DefaultSwapSizeMB
 }
 
 // NetworkConfig for JSON input.
@@ -116,6 +125,13 @@ func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
 
 	// NVIDIA kernel driver series (empty = no NVIDIA setup)
 	cfg.NvidiaDriverVersion = c.NvidiaDriverVersion
+
+	// Swap: nil = default-on (matches wizard New() default).
+	if c.Swap == nil {
+		cfg.Swap = model.SwapConfig{Enabled: true, SizeMB: 0}
+	} else {
+		cfg.Swap = model.SwapConfig{Enabled: c.Swap.Enabled, SizeMB: c.Swap.SizeMB}
+	}
 
 	// Users
 	for _, u := range c.Users {
@@ -270,6 +286,11 @@ func (c *Config) Validate() error {
 	validStrategies := map[string]bool{"reboot": true, "off": true, "etcd-lock": true, "": true}
 	if !validStrategies[c.UpdateStrategy] {
 		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
+	}
+
+	// Swap size must be non-negative if explicit
+	if c.Swap != nil && c.Swap.SizeMB < 0 {
+		return fmt.Errorf("swap.size_mb: must be ≥ 0 (got %d)", c.Swap.SizeMB)
 	}
 
 	// NVIDIA driver version must be a known series

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -20,20 +20,30 @@ import (
 // Config is the JSON schema for headless install configuration.
 // It maps closely to model.InstallConfig but uses simpler types for JSON.
 type Config struct {
-	Arch                string        `json:"arch,omitempty"` // "amd64" or "arm64"; defaults to "amd64"
-	Channel             string        `json:"channel"`
-	Version             string        `json:"version,omitempty"`
-	Hostname            string        `json:"hostname"`
-	Timezone            string        `json:"timezone,omitempty"`
-	Network             NetworkConfig `json:"network"`
-	Users               []UserConfig  `json:"users"`
-	Disk                string        `json:"disk"`
-	Sysexts             []string      `json:"sysexts,omitempty"`
-	NvidiaDriverVersion string        `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
-	UpdateStrategy      string        `json:"update_strategy"`
-	IgnitionURL         string        `json:"ignition_url,omitempty"`
-	Reboot              bool          `json:"reboot"`
-	DryRun              bool          `json:"dry_run,omitempty"`
+	Arch                string          `json:"arch,omitempty"` // "amd64" or "arm64"; defaults to "amd64"
+	Channel             string          `json:"channel"`
+	Version             string          `json:"version,omitempty"`
+	Hostname            string          `json:"hostname"`
+	Timezone            string          `json:"timezone,omitempty"`
+	Network             NetworkConfig   `json:"network"`
+	Users               []UserConfig    `json:"users"`
+	Disk                string          `json:"disk"`
+	Sysexts             []string        `json:"sysexts,omitempty"`
+	NvidiaDriverVersion string          `json:"nvidia_driver_version,omitempty"` // e.g. "570-open"; empty = no NVIDIA kernel driver
+	Tailscale           TailscaleConfig `json:"tailscale,omitempty"`
+	UpdateStrategy      string          `json:"update_strategy"`
+	IgnitionURL         string          `json:"ignition_url,omitempty"`
+	Reboot              bool            `json:"reboot"`
+	DryRun              bool            `json:"dry_run,omitempty"`
+}
+
+// TailscaleConfig for JSON input. Empty AuthKey skips the integration.
+type TailscaleConfig struct {
+	AuthKey string `json:"auth_key,omitempty"`
+	// Mode: "connect" (default), "exit-node", or "subnet-router".
+	Mode string `json:"mode,omitempty"`
+	// Routes: comma-separated CIDRs, only used when mode == "subnet-router".
+	Routes string `json:"routes,omitempty"`
 }
 
 // NetworkConfig for JSON input.
@@ -116,6 +126,19 @@ func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
 
 	// NVIDIA kernel driver series (empty = no NVIDIA setup)
 	cfg.NvidiaDriverVersion = c.NvidiaDriverVersion
+
+	// Tailscale (empty AuthKey skips provisioning)
+	if c.Tailscale.AuthKey != "" {
+		mode := c.Tailscale.Mode
+		if mode == "" {
+			mode = model.TailscaleModeConnect
+		}
+		cfg.Tailscale = model.TailscaleConfig{
+			AuthKey: c.Tailscale.AuthKey,
+			Mode:    mode,
+			Routes:  c.Tailscale.Routes,
+		}
+	}
 
 	// Users
 	for _, u := range c.Users {
@@ -270,6 +293,25 @@ func (c *Config) Validate() error {
 	validStrategies := map[string]bool{"reboot": true, "off": true, "etcd-lock": true, "": true}
 	if !validStrategies[c.UpdateStrategy] {
 		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
+	}
+
+	// Tailscale
+	if c.Tailscale.AuthKey != "" {
+		if err := validate.TailscaleAuthKey(c.Tailscale.AuthKey); err != nil {
+			return fmt.Errorf("tailscale auth_key: %w", err)
+		}
+		switch c.Tailscale.Mode {
+		case "", model.TailscaleModeConnect, model.TailscaleModeExitNode, model.TailscaleModeSubnetRouter:
+			// ok
+		default:
+			return fmt.Errorf("tailscale mode: must be %q, %q, or %q (got %q)",
+				model.TailscaleModeConnect, model.TailscaleModeExitNode, model.TailscaleModeSubnetRouter, c.Tailscale.Mode)
+		}
+		if c.Tailscale.Mode == model.TailscaleModeSubnetRouter {
+			if err := validate.TailscaleRoutes(c.Tailscale.Routes); err != nil {
+				return fmt.Errorf("tailscale routes: %w", err)
+			}
+		}
 	}
 
 	// NVIDIA driver version must be a known series

--- a/internal/ignition/builder.go
+++ b/internal/ignition/builder.go
@@ -1,0 +1,145 @@
+package ignition
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// Builder assembles a Butane YAML document from named sections.
+//
+// Why this exists: the original Butane generator was a single multi-hundred-line
+// raw string template. Every new conditional block (NVIDIA, Tailscale, swap…)
+// had to be hand-indented into the central template, which made the surface
+// fragile as features grew (#88).
+//
+// Builder lets each feature contribute a typed section. Sections are rendered
+// in a stable order and joined into a single Butane document; the document is
+// still compiled to Ignition by CompileToIgnition.
+//
+// The builder is intentionally narrow: it produces YAML strings, not Butane
+// Go types. That keeps the dependency surface small (no need to track Butane
+// Go-type API drift across releases) while still giving us a structured
+// assembly point.
+type Builder struct {
+	cfg *model.InstallConfig
+
+	// Each map slot is rendered in this order. Keep the slice sorted by the
+	// order the YAML keys appear in a Butane document.
+	storageFiles    []string // YAML fragments under storage.files
+	storageLinks    []string // YAML fragments under storage.links
+	systemdUnits    []string // YAML fragments under systemd.units
+	passwdUsersYAML string   // entire passwd.users block (mutually exclusive contents)
+}
+
+// NewBuilder returns a Builder seeded with cfg.
+func NewBuilder(cfg *model.InstallConfig) *Builder {
+	return &Builder{cfg: cfg}
+}
+
+// AddStorageFile appends a YAML fragment that will be placed under
+// `storage.files`. The fragment must be valid Butane YAML for a single file
+// entry; the builder takes care of leading-dash alignment.
+func (b *Builder) AddStorageFile(fragment string) {
+	b.storageFiles = append(b.storageFiles, fragment)
+}
+
+// AddStorageLink appends a YAML fragment placed under `storage.links`.
+func (b *Builder) AddStorageLink(fragment string) {
+	b.storageLinks = append(b.storageLinks, fragment)
+}
+
+// AddSystemdUnit appends a YAML fragment placed under `systemd.units`.
+func (b *Builder) AddSystemdUnit(fragment string) {
+	b.systemdUnits = append(b.systemdUnits, fragment)
+}
+
+// SetPasswdUsers sets the rendered passwd.users block. Calling twice
+// overwrites the previous value (the wizard only ever produces one).
+func (b *Builder) SetPasswdUsers(fragment string) {
+	b.passwdUsersYAML = fragment
+}
+
+// Build assembles the final Butane YAML document.
+func (b *Builder) Build() string {
+	var doc strings.Builder
+	doc.WriteString("variant: flatcar\nversion: 1.1.0\n")
+
+	if len(b.storageFiles) > 0 || len(b.storageLinks) > 0 {
+		doc.WriteString("storage:\n")
+		if len(b.storageFiles) > 0 {
+			doc.WriteString("  files:\n")
+			for _, f := range b.storageFiles {
+				doc.WriteString(indentFragment(f, 4))
+			}
+		}
+		if len(b.storageLinks) > 0 {
+			doc.WriteString("  links:\n")
+			for _, l := range b.storageLinks {
+				doc.WriteString(indentFragment(l, 4))
+			}
+		}
+	}
+
+	if len(b.systemdUnits) > 0 {
+		doc.WriteString("systemd:\n  units:\n")
+		for _, u := range b.systemdUnits {
+			doc.WriteString(indentFragment(u, 4))
+		}
+	}
+
+	if b.passwdUsersYAML != "" {
+		doc.WriteString("passwd:\n  users:\n")
+		doc.WriteString(indentFragment(b.passwdUsersYAML, 4))
+	}
+
+	return doc.String()
+}
+
+// indentFragment ensures every line of fragment is at least baseIndent spaces
+// from column zero (preserves relative indentation between lines).
+func indentFragment(fragment string, baseIndent int) string {
+	pad := strings.Repeat(" ", baseIndent)
+	lines := strings.Split(strings.TrimRight(fragment, "\n"), "\n")
+	var out strings.Builder
+	for _, l := range lines {
+		if l == "" {
+			out.WriteString("\n")
+			continue
+		}
+		out.WriteString(pad)
+		out.WriteString(l)
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+
+// renderTemplate is a small helper to evaluate a sub-template against data
+// with the same FuncMap the main template uses.
+func renderTemplate(name, body string, data any) (string, error) {
+	tmpl, err := template.New(name).Funcs(builderFuncMap).Parse(body)
+	if err != nil {
+		return "", fmt.Errorf("parsing %s: %w", name, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing %s: %w", name, err)
+	}
+	return buf.String(), nil
+}
+
+// builderFuncMap is shared by every section template so YAML escaping is
+// consistent across features.
+var builderFuncMap = template.FuncMap{
+	"yamlEscape": func(s string) string {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		s = strings.ReplaceAll(s, `"`, `\"`)
+		s = strings.ReplaceAll(s, "\n", `\n`)
+		s = strings.ReplaceAll(s, "\r", `\r`)
+		s = strings.ReplaceAll(s, "\t", `\t`)
+		return s
+	},
+}

--- a/internal/ignition/builder_test.go
+++ b/internal/ignition/builder_test.go
@@ -1,0 +1,96 @@
+package ignition
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestBuilderEmptyDocumentIsValid(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	got := b.Build()
+	wantPrefix := "variant: flatcar\nversion: 1.1.0\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected document to start with %q, got %q", wantPrefix, got)
+	}
+	if strings.Contains(got, "storage:") {
+		t.Error("empty builder must not emit a storage: block")
+	}
+	if strings.Contains(got, "systemd:") {
+		t.Error("empty builder must not emit a systemd: block")
+	}
+}
+
+func TestBuilderStorageSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddStorageFile(`- path: /etc/hostname
+  mode: 0644
+  contents:
+    inline: "demo"`)
+	got := b.Build()
+	if !strings.Contains(got, "storage:\n  files:\n    - path: /etc/hostname") {
+		t.Errorf("expected storage.files block with /etc/hostname, got:\n%s", got)
+	}
+	if !strings.Contains(got, "      mode: 0644") {
+		t.Errorf("expected mode key indented under file entry, got:\n%s", got)
+	}
+}
+
+func TestBuilderSystemdSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddSystemdUnit(`- name: foo.service
+  enabled: true`)
+	got := b.Build()
+	if !strings.Contains(got, "systemd:\n  units:\n    - name: foo.service") {
+		t.Errorf("expected systemd.units block, got:\n%s", got)
+	}
+}
+
+func TestBuilderPasswdSection(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.SetPasswdUsers(`- name: "core"
+  ssh_authorized_keys:
+    - "ssh-ed25519 AAAA"`)
+	got := b.Build()
+	if !strings.Contains(got, "passwd:\n  users:\n    - name: \"core\"") {
+		t.Errorf("expected passwd.users block, got:\n%s", got)
+	}
+}
+
+func TestBuilderRenderTemplate(t *testing.T) {
+	out, err := renderTemplate("hostname", `- path: /etc/hostname
+  contents:
+    inline: "{{.Hostname | yamlEscape}}"`, struct{ Hostname string }{Hostname: `name"with\quotes`})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+	if !strings.Contains(out, `name\"with\\quotes`) {
+		t.Errorf("expected escaped quotes/backslashes, got:\n%s", out)
+	}
+}
+
+func TestBuilderEndToEndProducesValidButane(t *testing.T) {
+	// Build a minimal document via the Builder and then run it through the
+	// real CompileToIgnition path to prove the builder output is real
+	// Butane that the compiler accepts. This is the regression guard for
+	// future section migrations.
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddStorageFile(`- path: /etc/hostname
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: "builder-demo"`)
+	b.SetPasswdUsers(`- name: "core"
+  ssh_authorized_keys:
+    - "ssh-ed25519 AAAA demo@key"`)
+	doc := b.Build()
+
+	ign, err := CompileToIgnition(doc)
+	if err != nil {
+		t.Fatalf("builder output failed butane compile:\n--- doc ---\n%s\n--- err ---\n%v", doc, err)
+	}
+	if !strings.Contains(ign, "/etc/hostname") {
+		t.Errorf("compiled Ignition missing /etc/hostname entry, got:\n%s", ign)
+	}
+}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -64,6 +64,11 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		}
 	}
 
+	swapSize := cfg.Swap.SizeMB
+	if cfg.Swap.Enabled && swapSize <= 0 {
+		swapSize = model.DefaultSwapSizeMB
+	}
+
 	data := templateData{
 		Hostname:            cfg.Hostname,
 		Timezone:            cfg.Timezone,
@@ -75,6 +80,8 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		RebootStrategy:      rebootStrategy,
 		HasPassword:         hasPassword,
 		NvidiaDriverVersion: cfg.NvidiaDriverVersion,
+		SwapEnabled:         cfg.Swap.Enabled,
+		SwapSizeMB:          swapSize,
 	}
 
 	var buf bytes.Buffer
@@ -96,6 +103,8 @@ type templateData struct {
 	RebootStrategy      string
 	HasPassword         bool
 	NvidiaDriverVersion string // e.g. "570-open"; empty = no NVIDIA kernel driver setup
+	SwapEnabled         bool
+	SwapSizeMB          int // effective swap size in MiB when SwapEnabled
 }
 
 func filterSelected(sysexts []model.SysextEntry) []model.SysextEntry {
@@ -164,6 +173,12 @@ storage:
         inline: |
           nvidia-drivers-{{.NvidiaDriverVersion | yamlEscape}}
 {{- end}}
+{{- if .SwapEnabled}}
+    - path: /var/swapfile
+      mode: 0600
+      contents:
+        source: "data:,"
+{{- end}}
 {{- if .Timezone}}
   links:
     - path: /etc/localtime
@@ -178,6 +193,39 @@ systemd:
 {{- end}}
     - name: update-engine.service
       enabled: true
+{{- if .SwapEnabled}}
+    - name: knuckle-create-swapfile.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Create the /var/swapfile (knuckle, {{.SwapSizeMB}} MiB)
+        Before=var-swapfile.swap
+        ConditionPathExists=!/var/lib/knuckle/.swap-created
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/fallocate -l {{.SwapSizeMB}}M /var/swapfile
+        ExecStart=/usr/bin/chmod 0600 /var/swapfile
+        ExecStart=/usr/sbin/mkswap /var/swapfile
+        ExecStartPost=/bin/sh -c 'install -m 0644 -D /dev/null /var/lib/knuckle/.swap-created'
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: var-swapfile.swap
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Activate /var/swapfile
+        Requires=knuckle-create-swapfile.service
+        After=knuckle-create-swapfile.service
+
+        [Swap]
+        What=/var/swapfile
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end}}
 passwd:
   users:
 {{- if .Users}}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -75,6 +75,10 @@ func (g *Generator) GenerateButane(cfg *model.InstallConfig) (string, error) {
 		RebootStrategy:      rebootStrategy,
 		HasPassword:         hasPassword,
 		NvidiaDriverVersion: cfg.NvidiaDriverVersion,
+		Tailscale:           cfg.Tailscale,
+		TailscaleEnabled:    cfg.Tailscale.AuthKey != "",
+		TailscaleForwarding: cfg.Tailscale.AuthKey != "" && (cfg.Tailscale.Mode == model.TailscaleModeExitNode || cfg.Tailscale.Mode == model.TailscaleModeSubnetRouter),
+		TailscaleExtraArgs:  tailscaleExtraArgs(cfg.Tailscale),
 	}
 
 	var buf bytes.Buffer
@@ -96,6 +100,27 @@ type templateData struct {
 	RebootStrategy      string
 	HasPassword         bool
 	NvidiaDriverVersion string // e.g. "570-open"; empty = no NVIDIA kernel driver setup
+	Tailscale           model.TailscaleConfig
+	TailscaleEnabled    bool   // AuthKey is set, i.e. user filled the step
+	TailscaleForwarding bool   // exit-node or subnet-router → need sysctl ip_forward=1
+	TailscaleExtraArgs  string // value of TS_EXTRA_ARGS in tailscale.env
+}
+
+// tailscaleExtraArgs builds the TS_EXTRA_ARGS value for /etc/tailscale/tailscale.env
+// based on the selected mode.
+func tailscaleExtraArgs(ts model.TailscaleConfig) string {
+	switch ts.Mode {
+	case model.TailscaleModeExitNode:
+		return "--advertise-exit-node"
+	case model.TailscaleModeSubnetRouter:
+		routes := strings.ReplaceAll(strings.TrimSpace(ts.Routes), " ", "")
+		if routes == "" {
+			return ""
+		}
+		return "--advertise-routes=" + routes
+	default:
+		return ""
+	}
 }
 
 func filterSelected(sysexts []model.SysextEntry) []model.SysextEntry {
@@ -164,6 +189,27 @@ storage:
         inline: |
           nvidia-drivers-{{.NvidiaDriverVersion | yamlEscape}}
 {{- end}}
+{{- if .TailscaleEnabled}}
+    - path: /etc/tailscale/tailscale.env
+      mode: 0600
+      overwrite: true
+      contents:
+        inline: |
+          TS_AUTHKEY={{.Tailscale.AuthKey | yamlEscape}}
+          TS_AUTH_ONCE=true
+{{- if .TailscaleExtraArgs}}
+          TS_EXTRA_ARGS={{.TailscaleExtraArgs | yamlEscape}}
+{{- end}}
+{{- if .TailscaleForwarding}}
+    - path: /etc/sysctl.d/99-tailscale.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          net.ipv4.ip_forward = 1
+          net.ipv6.conf.all.forwarding = 1
+{{- end}}
+{{- end}}
 {{- if .Timezone}}
   links:
     - path: /etc/localtime
@@ -178,6 +224,29 @@ systemd:
 {{- end}}
     - name: update-engine.service
       enabled: true
+{{- if .TailscaleEnabled}}
+    - name: tailscaled.service
+      enabled: true
+    - name: knuckle-tailscale-up.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Bring up Tailscale with the auth key provisioned by knuckle
+        Requires=tailscaled.service network-online.target
+        After=tailscaled.service network-online.target
+        ConditionPathExists=/etc/tailscale/tailscale.env
+        ConditionPathExists=!/var/lib/tailscale/.knuckle-up-done
+
+        [Service]
+        Type=oneshot
+        EnvironmentFile=/etc/tailscale/tailscale.env
+        ExecStart=/usr/bin/tailscale up --auth-key=$${TS_AUTHKEY} $${TS_EXTRA_ARGS}
+        ExecStartPost=/bin/sh -c 'install -m 0600 /dev/null /var/lib/tailscale/.knuckle-up-done'
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end}}
 passwd:
   users:
 {{- if .Users}}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1,6 +1,24 @@
 // Package ignition generates Butane YAML configs from InstallConfig.
 // The generated YAML is Flatcar variant, spec 1.1.0, compiled to Ignition
 // JSON via the coreos/butane Go library (not the CLI, which isn't on Flatcar).
+//
+// # Adding a new conditional section
+//
+// Historical state: a single multi-hundred-line raw string template held every
+// section (storage, systemd, passwd). New features had to be hand-indented in
+// the right place, and template errors only surfaced at render time (#88).
+//
+// Going forward: new features should use the [Builder] in builder.go.
+// Each feature contributes its YAML fragment via [Builder.AddStorageFile],
+// [Builder.AddStorageLink], or [Builder.AddSystemdUnit]; the Builder takes
+// care of indentation and assembly. The Builder is end-to-end tested against
+// [CompileToIgnition] so fragments that aren't valid Butane fail at unit-test
+// time.
+//
+// [GenerateButane] still uses the legacy butaneTemplate for the existing
+// surface (network, sysexts, NVIDIA, swap, Tailscale) — those will migrate
+// in follow-up changes as the surrounding code is touched. New surface should
+// be added via the Builder, not by extending butaneTemplate.
 package ignition
 
 import (

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -721,3 +721,66 @@ func TestGenerateButaneNvidiaDriverVersionEscaped(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateButaneSwapEnabledDefault(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "swap-default",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 0},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "/var/swapfile") {
+		t.Error("expected /var/swapfile in output")
+	}
+	if !strings.Contains(out, "fallocate -l 4096M") {
+		t.Errorf("expected default 4096 MiB swap, got:\n%s", out)
+	}
+	if !strings.Contains(out, "var-swapfile.swap") {
+		t.Error("expected var-swapfile.swap unit")
+	}
+	if !strings.Contains(out, "knuckle-create-swapfile.service") {
+		t.Error("expected knuckle-create-swapfile.service")
+	}
+}
+
+func TestGenerateButaneSwapExplicitSize(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "swap-8g",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 8192},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "fallocate -l 8192M") {
+		t.Errorf("expected 8192 MiB swap, got:\n%s", out)
+	}
+}
+
+func TestGenerateButaneSwapDisabled(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "no-swap",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: false},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "/var/swapfile") {
+		t.Error("/var/swapfile must not appear when Swap.Enabled = false")
+	}
+	if strings.Contains(out, "var-swapfile.swap") {
+		t.Error("swap unit must not appear when Swap.Enabled = false")
+	}
+}

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -721,3 +721,112 @@ func TestGenerateButaneNvidiaDriverVersionEscaped(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateButaneTailscaleAuthKey(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-node",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeConnect,
+		},
+	}
+
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "/etc/tailscale/tailscale.env") {
+		t.Error("expected /etc/tailscale/tailscale.env in Butane output")
+	}
+	if !strings.Contains(out, "TS_AUTHKEY=tskey-auth-") {
+		t.Error("expected TS_AUTHKEY in tailscale.env contents")
+	}
+	if !strings.Contains(out, "TS_AUTH_ONCE=true") {
+		t.Error("expected TS_AUTH_ONCE=true in tailscale.env")
+	}
+	if !strings.Contains(out, "tailscaled.service") {
+		t.Error("expected tailscaled.service enabled")
+	}
+	if !strings.Contains(out, "knuckle-tailscale-up.service") {
+		t.Error("expected knuckle-tailscale-up.service in systemd units")
+	}
+	if strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("connect mode should not enable IP forwarding")
+	}
+	// The unit body references $${TS_EXTRA_ARGS} as an env var; the env file
+	// itself should not define TS_EXTRA_ARGS= in connect mode (empty → expands
+	// to an empty string).
+	if strings.Contains(out, "TS_EXTRA_ARGS=") {
+		t.Error("connect mode should not set TS_EXTRA_ARGS= in tailscale.env")
+	}
+}
+
+func TestGenerateButaneTailscaleExitNode(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-exit",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeExitNode,
+		},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "--advertise-exit-node") {
+		t.Error("expected --advertise-exit-node in TS_EXTRA_ARGS")
+	}
+	if !strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("expected IP forwarding sysctl for exit node")
+	}
+}
+
+func TestGenerateButaneTailscaleSubnetRouter(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname: "ts-subnet",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abcdefghij0-secret-secret-secret-secret-1",
+			Mode:    model.TailscaleModeSubnetRouter,
+			Routes:  "10.0.0.0/24,192.168.1.0/24",
+		},
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "--advertise-routes=10.0.0.0/24,192.168.1.0/24") {
+		t.Errorf("expected --advertise-routes in TS_EXTRA_ARGS, got:\n%s", out)
+	}
+	if !strings.Contains(out, "net.ipv4.ip_forward = 1") {
+		t.Error("expected IP forwarding sysctl for subnet router")
+	}
+}
+
+func TestGenerateButaneTailscaleSkippedWhenNoAuthKey(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		Hostname:  "ts-skip",
+		Network:   model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:     []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{}, // no auth key
+	}
+	out, err := g.GenerateButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "tailscale.env") {
+		t.Error("tailscale.env should not appear when AuthKey is empty")
+	}
+	if strings.Contains(out, "tailscaled.service") {
+		t.Error("tailscaled.service should not be force-enabled when AuthKey is empty")
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -37,7 +38,8 @@ func NewFlatcarInstaller(r runner.Runner, logger *slog.Logger) *FlatcarInstaller
 // Install performs the Flatcar installation:
 // 1. Generate Butane YAML (or use external IgnitionURL)
 // 2. Compile Butane → Ignition JSON via coreos/butane Go library
-// 3. Run flatcar-install with the target disk, channel, and ignition config
+// 3. Wipe stale filesystem/partition signatures from the target disk
+// 4. Run flatcar-install with the target disk, channel, and ignition config
 func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
 	if cfg == nil {
 		return fmt.Errorf("install config cannot be nil")
@@ -73,6 +75,14 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 		defer i.cleanupIgnitionFile()
 	}
 
+	diskPath := installDiskPath(cfg)
+	progress("Wiping target disk signatures...")
+	i.Logger.Info("wiping target disk signatures", "disk", diskPath)
+	wipeResult, err := i.Runner.Run(ctx, "wipefs", "--all", "--force", diskPath)
+	if err != nil || (wipeResult != nil && wipeResult.ExitCode != 0) {
+		return formatCommandError("wiping target disk", wipeResult, err)
+	}
+
 	// Build flatcar-install command args
 	args := buildInstallArgs(cfg, i.ignitionPath)
 
@@ -81,23 +91,39 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 	i.Logger.Info("executing flatcar-install", "args", args)
 
 	result, err := i.Runner.Run(ctx, "flatcar-install", args...)
-	if err != nil {
-		return fmt.Errorf("flatcar-install: %w", err)
-	}
-	if result.ExitCode != 0 {
-		return fmt.Errorf("flatcar-install failed (exit %d): %s", result.ExitCode, result.Stderr)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatFlatcarInstallError(result, err)
 	}
 
 	progress("Installation complete!")
 	return nil
 }
 
-func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
-	// Prefer /dev/disk/by-id path for stable identification
-	diskPath := cfg.Disk.Path
-	if diskPath == "" {
-		diskPath = cfg.Disk.DevPath
+func formatCommandError(action string, result *runner.Result, err error) error {
+	if result != nil {
+		stderr := strings.TrimSpace(result.Stderr)
+		if stderr != "" {
+			return fmt.Errorf("%s (exit %d): %s", action, result.ExitCode, stderr)
+		}
+		if result.ExitCode != 0 {
+			if err != nil {
+				return fmt.Errorf("%s (exit %d): %w", action, result.ExitCode, err)
+			}
+			return fmt.Errorf("%s (exit %d)", action, result.ExitCode)
+		}
 	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return fmt.Errorf("%s failed", action)
+}
+
+func formatFlatcarInstallError(result *runner.Result, err error) error {
+	return formatCommandError("flatcar-install failed", result, err)
+}
+
+func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
 	args := []string{
 		"-d", diskPath,
 		"-C", cfg.Channel,
@@ -118,6 +144,14 @@ func buildInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
 	}
 
 	return args
+}
+
+func installDiskPath(cfg *model.InstallConfig) string {
+	// Prefer /dev/disk/by-id path for stable identification
+	if cfg.Disk.Path != "" {
+		return cfg.Disk.Path
+	}
+	return cfg.Disk.DevPath
 }
 
 // WriteIgnitionFile writes the Ignition JSON to a secure temp file.

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -40,6 +40,7 @@ func NewFlatcarInstaller(r runner.Runner, logger *slog.Logger) *FlatcarInstaller
 // 2. Compile Butane → Ignition JSON via coreos/butane Go library
 // 3. Wipe stale filesystem/partition signatures from the target disk
 // 4. Run flatcar-install with the target disk, channel, and ignition config
+// 5. Relocate the backup GPT header to the end of the target disk
 func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
 	if cfg == nil {
 		return fmt.Errorf("install config cannot be nil")
@@ -93,6 +94,13 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 	result, err := i.Runner.Run(ctx, "flatcar-install", args...)
 	if err != nil || (result != nil && result.ExitCode != 0) {
 		return formatFlatcarInstallError(result, err)
+	}
+
+	progress("Repairing GPT backup header...")
+	i.Logger.Info("relocating backup gpt header", "disk", diskPath)
+	repairResult, err := i.Runner.Run(ctx, "sfdisk", "--relocate", "gpt-bak-std", diskPath)
+	if err != nil || (repairResult != nil && repairResult.ExitCode != 0) {
+		return formatCommandError("repairing GPT backup header", repairResult, err)
 	}
 
 	progress("Installation complete!")

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -193,8 +193,8 @@ func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(spy.Calls) < 2 {
-		t.Fatalf("expected at least wipefs and flatcar-install calls, got %v", spy.Calls)
+	if len(spy.Calls) < 3 {
+		t.Fatalf("expected wipefs, flatcar-install, and sfdisk calls, got %v", spy.Calls)
 	}
 	if spy.Calls[0].Name != "wipefs" {
 		t.Fatalf("first command = %q, want wipefs", spy.Calls[0].Name)
@@ -204,6 +204,12 @@ func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
 	}
 	if spy.Calls[1].Name != "flatcar-install" {
 		t.Fatalf("second command = %q, want flatcar-install", spy.Calls[1].Name)
+	}
+	if spy.Calls[2].Name != "sfdisk" {
+		t.Fatalf("third command = %q, want sfdisk", spy.Calls[2].Name)
+	}
+	if got, want := spy.Calls[2].Args, []string{"--relocate", "gpt-bak-std", "/dev/disk/by-id/ata-test-disk"}; strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("sfdisk args = %v, want %v", got, want)
 	}
 }
 
@@ -230,6 +236,30 @@ func TestInstallWipeFailureStopsBeforeFlatcarInstall(t *testing.T) {
 		if call.Name == "flatcar-install" {
 			t.Fatalf("flatcar-install should not run after wipefs failure: %#v", spy.Calls)
 		}
+	}
+}
+
+func TestInstallGPTRepairFailureStopsAfterFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.StubError("sfdisk --relocate gpt-bak-std /dev/sda", fmt.Errorf("permission denied"))
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "repair-fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when GPT repair fails")
+	}
+	if !strings.Contains(err.Error(), "repairing GPT backup header") {
+		t.Fatalf("error = %q, want GPT repair context", err)
+	}
+	if len(spy.Calls) < 3 || spy.Calls[1].Name != "flatcar-install" || spy.Calls[2].Name != "sfdisk" {
+		t.Fatalf("unexpected call order: %#v", spy.Calls)
 	}
 }
 
@@ -372,6 +402,7 @@ func TestProgressCallback(t *testing.T) {
 		"Writing Ignition config...",
 		"Wiping target disk signatures...",
 		"Running flatcar-install...",
+		"Repairing GPT backup header...",
 		"Installation complete!",
 	}
 

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
@@ -174,6 +175,98 @@ func TestInstallFlatcarInstallFailure(t *testing.T) {
 	}
 }
 
+func TestInstallWipesTargetDiskBeforeFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "wipe-node",
+		Disk: model.DiskInfo{
+			DevPath: "/dev/sda",
+			Path:    "/dev/disk/by-id/ata-test-disk",
+		},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spy.Calls) < 2 {
+		t.Fatalf("expected at least wipefs and flatcar-install calls, got %v", spy.Calls)
+	}
+	if spy.Calls[0].Name != "wipefs" {
+		t.Fatalf("first command = %q, want wipefs", spy.Calls[0].Name)
+	}
+	if got, want := spy.Calls[0].Args, []string{"--all", "--force", "/dev/disk/by-id/ata-test-disk"}; strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("wipefs args = %v, want %v", got, want)
+	}
+	if spy.Calls[1].Name != "flatcar-install" {
+		t.Fatalf("second command = %q, want flatcar-install", spy.Calls[1].Name)
+	}
+}
+
+func TestInstallWipeFailureStopsBeforeFlatcarInstall(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.StubError("wipefs --all --force /dev/sda", fmt.Errorf("permission denied"))
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "wipe-fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when wipefs fails")
+	}
+	if !strings.Contains(err.Error(), "wiping target disk") {
+		t.Fatalf("error = %q, want wipefs context", err)
+	}
+	for _, call := range spy.Calls {
+		if call.Name == "flatcar-install" {
+			t.Fatalf("flatcar-install should not run after wipefs failure: %#v", spy.Calls)
+		}
+	}
+}
+
+type stderrFailRunner struct{}
+
+func (stderrFailRunner) Run(ctx context.Context, name string, args ...string) (*runner.Result, error) {
+	return &runner.Result{
+		Command:  name,
+		Args:     args,
+		Stderr:   "partition table write failed: GPT headers are invalid",
+		ExitCode: 1,
+	}, fmt.Errorf("command %q exited with code 1", name)
+}
+
+func (stderrFailRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*runner.Result, error) {
+	return nil, fmt.Errorf("unexpected RunWithInput call")
+}
+
+func TestInstallFlatcarInstallFailureIncludesStderr(t *testing.T) {
+	installer := NewFlatcarInstaller(stderrFailRunner{}, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "fail-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when flatcar-install fails")
+	}
+	if !strings.Contains(err.Error(), "GPT headers are invalid") {
+		t.Fatalf("error = %q, want stderr from flatcar-install", err)
+	}
+}
+
 func TestBuildInstallArgs(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -277,6 +370,7 @@ func TestProgressCallback(t *testing.T) {
 		"Generating Butane config...",
 		"Compiling Ignition config...",
 		"Writing Ignition config...",
+		"Wiping target disk signatures...",
 		"Running flatcar-install...",
 		"Installation complete!",
 	}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -61,8 +61,22 @@ type InstallConfig struct {
 	UpdateStrategy      UpdateStrategy
 	IgnitionURL         string // external ignition URL (mutually exclusive with local gen)
 	NvidiaDriverVersion string // Flatcar NVIDIA kernel driver series, e.g. "570-open". Empty = none.
+	Swap                SwapConfig
 	DryRun              bool
 }
+
+// SwapConfig holds swap-file provisioning settings.
+// Enabled+SizeMB=0 ⇒ auto-size via min(detectedRAM, DefaultSwapSizeMB) at install time
+// (the wizard picks a sensible default for the host). Enabled=false ⇒ no swap unit.
+type SwapConfig struct {
+	Enabled bool
+	SizeMB  int // 0 = auto. Otherwise explicit MiB (e.g. 4096 for 4 GiB).
+}
+
+// DefaultSwapSizeMB is the swap size knuckle picks when Swap.Enabled = true and
+// Swap.SizeMB = 0. 4 GiB is the upstream Flatcar example and a reasonable cap
+// for home-server workloads; explicit SizeMB always overrides.
+const DefaultSwapSizeMB = 4096
 
 // UpdateStrategy holds OS update and reboot settings for Flatcar.
 type UpdateStrategy struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,7 +11,8 @@ const (
 	StepStorage
 	StepUser
 	StepSysext
-	StepNvidia // conditional: only visited when nvidia-runtime sysext is selected
+	StepNvidia    // conditional: only visited when nvidia-runtime sysext is selected
+	StepTailscale // conditional: only visited when tailscale sysext is selected
 	StepUpdate
 	StepReview
 	StepInstall
@@ -33,6 +34,8 @@ func (s WizardStep) String() string {
 		return "Sysext"
 	case StepNvidia:
 		return "GPU Setup"
+	case StepTailscale:
+		return "Tailscale"
 	case StepUpdate:
 		return "Update Strategy"
 	case StepReview:
@@ -61,8 +64,32 @@ type InstallConfig struct {
 	UpdateStrategy      UpdateStrategy
 	IgnitionURL         string // external ignition URL (mutually exclusive with local gen)
 	NvidiaDriverVersion string // Flatcar NVIDIA kernel driver series, e.g. "570-open". Empty = none.
+	Tailscale           TailscaleConfig
 	DryRun              bool
 }
+
+// TailscaleConfig holds optional Tailscale provisioning for the installed system.
+// Populated only when the tailscale sysext is selected. AuthKey is written to
+// /etc/tailscale/tailscale.env (mode 0600) and consumed by a oneshot systemd
+// unit that runs `tailscale up` at first boot.
+type TailscaleConfig struct {
+	// AuthKey is the Tailscale auth/preauth key (tskey-auth-…). Empty = step skipped.
+	AuthKey string
+	// Mode controls how the node advertises itself:
+	//   "connect"      — plain client (default)
+	//   "exit-node"    — advertise as exit node (--advertise-exit-node)
+	//   "subnet-router" — advertise routes via --advertise-routes
+	Mode string
+	// Routes is the comma-separated CIDR list advertised when Mode == "subnet-router".
+	Routes string
+}
+
+// Tailscale mode constants.
+const (
+	TailscaleModeConnect      = "connect"
+	TailscaleModeExitNode     = "exit-node"
+	TailscaleModeSubnetRouter = "subnet-router"
+)
 
 // UpdateStrategy holds OS update and reboot settings for Flatcar.
 type UpdateStrategy struct {

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -37,6 +37,14 @@ func (m *Model) initForm() {
 			m.Wizard.State.Config.Timezone = "UTC"
 		}
 		m.activeForm = m.buildUserForm()
+	case model.StepTailscale:
+		m.tailscaleAuthKeyIn = m.Wizard.State.Config.Tailscale.AuthKey
+		m.tailscaleModeIn = m.Wizard.State.Config.Tailscale.Mode
+		if m.tailscaleModeIn == "" {
+			m.tailscaleModeIn = model.TailscaleModeConnect
+		}
+		m.tailscaleRoutesIn = m.Wizard.State.Config.Tailscale.Routes
+		m.activeForm = m.buildTailscaleForm()
 	case model.StepReview:
 		m.activeForm = m.buildReviewForm()
 	default:
@@ -127,6 +135,22 @@ func (m *Model) onFormComplete() tea.Cmd {
 		// Apply timezone
 		if cfg.Timezone == "" {
 			cfg.Timezone = "UTC"
+		}
+
+	case model.StepTailscale:
+		cfg.Tailscale.AuthKey = strings.TrimSpace(m.tailscaleAuthKeyIn)
+		cfg.Tailscale.Mode = m.tailscaleModeIn
+		if cfg.Tailscale.Mode == "" {
+			cfg.Tailscale.Mode = model.TailscaleModeConnect
+		}
+		cfg.Tailscale.Routes = strings.TrimSpace(m.tailscaleRoutesIn)
+		if err := m.Wizard.ValidateCurrentStep(); err != nil {
+			m.err = err
+			m.initForm()
+			if m.activeForm != nil {
+				return m.activeForm.Init()
+			}
+			return nil
 		}
 
 	case model.StepReview:

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/projectbluefin/knuckle/internal/github"
 	"github.com/projectbluefin/knuckle/internal/model"
 	"github.com/projectbluefin/knuckle/internal/validate"
+	"github.com/projectbluefin/knuckle/internal/wizard"
 )
 
 // initForm sets up the huh form for form-based steps.
@@ -72,61 +73,32 @@ func (m *Model) onFormComplete() tea.Cmd {
 		}
 
 	case model.StepNetwork:
-		if m.dnsInput != "" {
-			cfg.Network.DNS = strings.Split(m.dnsInput, ",")
-		}
-		if m.networkModeInput == "static" {
-			cfg.Network.Mode = model.NetworkStatic
-		} else {
-			cfg.Network.Mode = model.NetworkDHCP
-		}
+		m.Wizard.ApplyNetworkStep(wizard.NetworkStepInput{
+			Mode: m.networkModeInput,
+			DNS:  m.dnsInput,
+		})
 
 	case model.StepUser:
-		// Apply username
-		if m.usernameInput != "" {
-			if len(cfg.Users) == 0 {
-				cfg.Users = append(cfg.Users, model.UserConfig{
-					Username: m.usernameInput,
-					Groups:   []string{"sudo", "docker"},
-				})
-			} else {
-				cfg.Users[0].Username = m.usernameInput
-			}
+		if err := m.Wizard.ApplyUserStep(wizard.UserStepInput{
+			Username:  m.usernameInput,
+			Password:  m.passwordInput,
+			ManualKey: m.sshKeyInput,
+			LocalKeys: detectLocalSSHKeys(),
+			Hostname:  cfg.Hostname,
+			Timezone:  cfg.Timezone,
+		}); err != nil {
+			m.err = err
+			m.initForm()
+			return m.activeForm.Init()
 		}
-		// Apply password
-		if m.passwordInput != "" && len(cfg.Users) > 0 {
-			hash, err := hashPassword(m.passwordInput)
-			if err != nil {
-				m.err = err
-				m.initForm()
-				return m.activeForm.Init()
-			}
-			cfg.Users[0].PasswordHash = hash
-		}
-		// Apply SSH key (manual input + local host keys)
-		manualKeys := splitSSHKeys(m.sshKeyInput)
-		localKeys := detectLocalSSHKeys()
-		allKeys := mergeKeys(localKeys, manualKeys)
-		if len(allKeys) > 0 {
-			cfg.SSHKeys = allKeys
-			if len(cfg.Users) > 0 {
-				cfg.Users[0].SSHKeys = allKeys
-			}
-		}
-		// Async GitHub key fetch (merges with local keys on return)
+		// Async GitHub key fetch (merges with local + manual keys on return)
 		if m.githubUserInput != "" {
 			m.fetching = true
-			username := m.githubUserInput
-			// Strip @ prefix if present
-			username = strings.TrimPrefix(username, "@")
+			username := strings.TrimPrefix(m.githubUserInput, "@")
 			return func() tea.Msg {
 				keys, err := github.FetchKeys(username)
 				return fetchKeysMsg{keys: keys, err: err}
 			}
-		}
-		// Apply timezone
-		if cfg.Timezone == "" {
-			cfg.Timezone = "UTC"
 		}
 
 	case model.StepReview:

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -451,10 +451,13 @@ func (m *Model) viewChannelCards() string {
 		b.WriteString("\n")
 	}
 
-	// Show advanced hint
+	// Show advanced hint + community link
 	b.WriteString("\n")
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
-		"  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -152,6 +152,45 @@ func (m *Model) localKeysSummary() string {
 	return fmt.Sprintf("🔑 %d local key(s) from ~/.ssh/ will be included automatically", len(keys))
 }
 
+// buildTailscaleForm creates the huh form for the Tailscale step.
+// Shown only when the tailscale sysext is selected.
+func (m *Model) buildTailscaleForm() *huh.Form {
+	modeOptions := []huh.Option[string]{
+		huh.NewOption("Just connect — plain client", model.TailscaleModeConnect),
+		huh.NewOption("Exit node — advertise as exit node", model.TailscaleModeExitNode),
+		huh.NewOption("Subnet router — advertise routes", model.TailscaleModeSubnetRouter),
+	}
+
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Tailscale").
+				Description("Optional. Paste a tailnet auth key to provision Tailscale at first boot.\nLeave the auth key blank to skip — tailscale binaries will still be installed."),
+			huh.NewInput().
+				Title("Auth Key").
+				Description("From https://login.tailscale.com/admin/settings/keys — preauth is recommended").
+				Placeholder("tskey-auth-...").
+				EchoMode(huh.EchoModePassword).
+				Value(&m.tailscaleAuthKeyIn).
+				Validate(func(s string) error {
+					if s == "" {
+						return nil
+					}
+					return validate.TailscaleAuthKey(s)
+				}),
+			huh.NewSelect[string]().
+				Title("Mode").
+				Options(modeOptions...).
+				Value(&m.tailscaleModeIn),
+			huh.NewInput().
+				Title("Advertised routes").
+				Description("Only used in Subnet router mode. Comma-separated CIDRs (e.g. 10.0.0.0/24,192.168.1.0/24)").
+				Placeholder("10.0.0.0/24").
+				Value(&m.tailscaleRoutesIn),
+		),
+	).WithTheme(huh.ThemeDracula()).WithShowHelp(true).WithWidth(80)
+}
+
 // buildReviewForm creates the huh confirm for the Review step.
 func (m *Model) buildReviewForm() *huh.Form {
 	return huh.NewForm(
@@ -194,6 +233,16 @@ func (m *Model) reviewSummary() string {
 			names[i] = s.Name
 		}
 		fmt.Fprintf(&b, "\nSysexts: %s", strings.Join(names, ", "))
+	}
+	if cfg.Tailscale.AuthKey != "" {
+		mode := cfg.Tailscale.Mode
+		if mode == "" {
+			mode = model.TailscaleModeConnect
+		}
+		fmt.Fprintf(&b, "\nTailscale: auth key set, mode=%s", mode)
+		if mode == model.TailscaleModeSubnetRouter && cfg.Tailscale.Routes != "" {
+			fmt.Fprintf(&b, " routes=%s", cfg.Tailscale.Routes)
+		}
 	}
 	return b.String()
 }

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -195,6 +195,15 @@ func (m *Model) reviewSummary() string {
 		}
 		fmt.Fprintf(&b, "\nSysexts: %s", strings.Join(names, ", "))
 	}
+	if cfg.Swap.Enabled {
+		size := cfg.Swap.SizeMB
+		if size <= 0 {
+			size = model.DefaultSwapSizeMB
+		}
+		fmt.Fprintf(&b, "\nSwap: %d MiB (/var/swapfile)", size)
+	} else {
+		b.WriteString("\nSwap: disabled")
+	}
 	return b.String()
 }
 

--- a/internal/tui/forms_test.go
+++ b/internal/tui/forms_test.go
@@ -1,0 +1,48 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+)
+
+func TestViewChannelCardsLongVersionNoPanic(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.Channel = "stable"
+	w.State.Channels = []bakery.ChannelInfo{
+		{
+			Channel: "stable",
+			Version: "99999.99.99-very-long-prerelease-tag-exceeding-width",
+			Kernel:  "6.99.0",
+		},
+	}
+	m := New(w)
+	m.cursor = 0
+
+	// This should not panic even with a very long version string
+	// Regression test for #248 (negative padding fix)
+	out := m.viewChannelCards()
+	if len(out) == 0 {
+		t.Error("viewChannelCards should render non-empty output")
+	}
+	if !strings.Contains(out, "stable") && !strings.Contains(out, "Stable") {
+		t.Errorf("viewChannelCards should contain channel name, got: %q", out)
+	}
+}
+
+func TestViewChannelCardsSelectsCurrent(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.Channel = "stable"
+	w.State.Channels = []bakery.ChannelInfo{
+		{Channel: "stable", Version: "1.0.0", Kernel: "6.1.0"},
+		{Channel: "edge", Version: "2.0.0", Kernel: "6.2.0"},
+	}
+	m := New(w)
+	m.cursor = 0
+
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "▸") {
+		t.Error("viewChannelCards should show cursor indicator for selected item")
+	}
+}

--- a/internal/tui/sysext_helpers_test.go
+++ b/internal/tui/sysext_helpers_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestRenderTierHeaderWithName(t *testing.T) {
+	out := renderTierHeader("Integrated")
+	if !strings.Contains(out, "Integrated") {
+		t.Errorf("renderTierHeader should contain tier name, got: %q", out)
+	}
+	if !strings.Contains(out, "──") {
+		t.Error("header should contain dashes for styling")
+	}
+}
+
+func TestRenderTierHeaderEmptyFallback(t *testing.T) {
+	out := renderTierHeader("")
+	if !strings.Contains(out, "Other") {
+		t.Errorf("renderTierHeader(\"\") should fallback to 'Other', got: %q", out)
+	}
+	if !strings.Contains(out, "──") {
+		t.Error("header should contain dashes for styling")
+	}
+}
+
+func TestSysextTitleNoSelection(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", Selected: false},
+		{Name: "wasmtime", Selected: false},
+	}
+	m := New(w)
+	title := m.sysextTitle()
+	if !strings.Contains(title, "0 selected") {
+		t.Errorf("sysextTitle with no selection should show '0 selected', got: %q", title)
+	}
+}
+
+func TestSysextTitleWithSelections(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", Selected: true},
+		{Name: "wasmtime", Selected: false},
+		{Name: "tailscale", Selected: true},
+	}
+	m := New(w)
+	title := m.sysextTitle()
+	if !strings.Contains(title, "2 selected") {
+		t.Errorf("sysextTitle should show '2 selected', got: %q", title)
+	}
+}
+
+func TestRefreshSysextListTitleNotReady(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.sysextListReady = false
+	m.refreshSysextListTitle() // must not panic
+}
+
+func TestRefreshSysextListTitleReady(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", SupportTier: bakery.TierIntegrated, Selected: true},
+		{Name: "wasmtime", SupportTier: bakery.TierExperimental, Selected: false},
+	}
+	m := New(w)
+	m.initSysextList()
+	if !m.sysextListReady {
+		t.Fatal("initSysextList should set sysextListReady=true")
+	}
+	if !strings.Contains(m.sysextList.Title, "1 selected") {
+		t.Errorf("initial title should show '1 selected', got: %q", m.sysextList.Title)
+	}
+	w.State.Sysexts[1].Selected = true
+	m.refreshSysextListTitle()
+	if !strings.Contains(m.sysextList.Title, "2 selected") {
+		t.Errorf("refreshSysextListTitle should update count to '2 selected', got: %q", m.sysextList.Title)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -14,8 +14,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/projectbluefin/knuckle/internal/bakery"
 	"github.com/projectbluefin/knuckle/internal/github"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -189,23 +187,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = fmt.Errorf("%w — edit the username and press Enter to retry, or clear it and add an SSH key or password instead", msg.err)
 			return m, nil
 		}
-		cfg := &m.Wizard.State.Config
-		// Merge GitHub keys with local host keys AND manual keys (deduped)
-		allKeys := mergeKeys(detectLocalSSHKeys(), splitSSHKeys(m.sshKeyInput), msg.keys)
-		cfg.SSHKeys = allKeys
-		if len(cfg.Users) > 0 {
-			cfg.Users[0].SSHKeys = allKeys
-		}
-		// Guard: don't advance if we have no authentication method at all.
-		// This catches the case where GitHub returned 0 keys and no other auth is set.
-		hasAuth := len(allKeys) > 0
-		for _, u := range cfg.Users {
-			if u.PasswordHash != "" {
-				hasAuth = true
-				break
-			}
-		}
-		if !hasAuth {
+		m.Wizard.ApplyGitHubKeys(msg.keys, detectLocalSSHKeys(), m.sshKeyInput)
+		if !m.Wizard.HasAnyAuthentication() {
 			m.err = fmt.Errorf("no SSH keys found — add a key manually, set a password, or use a GitHub user with public keys")
 			return m, nil
 		}
@@ -1264,30 +1247,12 @@ func Run(w *wizard.Wizard, rebootFn func(context.Context) error) error {
 	return err
 }
 
-// hashPassword generates a bcrypt hash suitable for Ignition passwd field.
-func hashPassword(plain string) (string, error) {
-	if len(plain) > 72 {
-		return "", fmt.Errorf("password too long (max 72 bytes for bcrypt)")
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
-	if err != nil {
-		return "", fmt.Errorf("hashing password: %w", err)
-	}
-	return string(hash), nil
-}
+// hashPassword is a thin wrapper around wizard.HashPassword kept so existing
+// TUI tests/usages don't churn; new code should call wizard.HashPassword.
+func hashPassword(plain string) (string, error) { return wizard.HashPassword(plain) }
 
-// splitSSHKeys splits SSH keys by semicolons and trims whitespace.
-func splitSSHKeys(input string) []string {
-	parts := strings.Split(input, ";")
-	var keys []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			keys = append(keys, p)
-		}
-	}
-	return keys
-}
+// splitSSHKeys is a thin wrapper around wizard.SplitSSHKeys.
+func splitSSHKeys(input string) []string { return wizard.SplitSSHKeys(input) }
 
 // detectLocalSSHKeys finds SSH public keys on the installer host.
 // Checks ~/.ssh/*.pub for common key types.
@@ -1315,17 +1280,5 @@ func detectLocalSSHKeys() []string {
 	return keys
 }
 
-// mergeKeys combines two key slices, deduplicating by key content.
-func mergeKeys(sources ...[]string) []string {
-	seen := make(map[string]bool)
-	var result []string
-	for _, src := range sources {
-		for _, k := range src {
-			if !seen[k] {
-				seen[k] = true
-				result = append(result, k)
-			}
-		}
-	}
-	return result
-}
+// mergeKeys is a thin wrapper around wizard.MergeSSHKeys.
+func mergeKeys(sources ...[]string) []string { return wizard.MergeSSHKeys(sources...) }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1245,6 +1245,13 @@ func (m *Model) viewDone() string {
 		b.WriteString(dimStyle.Render("    docker run --rm --gpus all nvidia/cuda:12.6.3-base-ubuntu22.04 nvidia-smi") + "\n")
 	}
 
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("Community & help:") + "\n")
+	b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
+	b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+
 	b.WriteString("\n")
 	if cfg.DryRun {
 		b.WriteString("Press q to exit.\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -59,14 +59,17 @@ type Model struct {
 	fieldIdx      int
 
 	// huh form state
-	activeForm       *huh.Form
-	dnsInput         string
-	networkModeInput string
-	usernameInput    string
-	passwordInput    string
-	githubUserInput  string
-	sshKeyInput      string
-	showAdvanced     bool
+	activeForm         *huh.Form
+	dnsInput           string
+	networkModeInput   string
+	usernameInput      string
+	passwordInput      string
+	githubUserInput    string
+	sshKeyInput        string
+	tailscaleAuthKeyIn string
+	tailscaleModeIn    string
+	tailscaleRoutesIn  string
+	showAdvanced       bool
 
 	// Sysext list (bubbles/list)
 	sysextList      list.Model

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -17,6 +17,9 @@ var (
 	reTimezone      = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_/+-]*$`)
 	reGroupName     = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 	reInterfaceName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	// Tailscale auth keys: tskey-auth-<id12>-<secret32+>; tskey-client- variant also accepted.
+	// See https://tailscale.com/kb/1085/auth-keys for the format.
+	reTailscaleAuthKey = regexp.MustCompile(`^tskey-(auth|client)-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}$`)
 )
 
 // Hostname validates a Linux hostname (RFC 1123).
@@ -259,6 +262,36 @@ func CheckConsistency(cfg *model.InstallConfig) error {
 		}
 	}
 
+	return nil
+}
+
+// TailscaleAuthKey validates a Tailscale auth key (tskey-auth-… or tskey-client-…).
+// Rejects obviously malformed input early — the real check is Tailscale's API at
+// `tailscale up` time, but failing here gives the user immediate feedback in the TUI.
+func TailscaleAuthKey(s string) error {
+	if s == "" {
+		return fmt.Errorf("auth key cannot be empty")
+	}
+	if !reTailscaleAuthKey.MatchString(s) {
+		return fmt.Errorf("auth key must start with %q or %q and contain an id and secret", "tskey-auth-", "tskey-client-")
+	}
+	return nil
+}
+
+// TailscaleRoutes validates a comma-separated list of CIDRs for --advertise-routes.
+func TailscaleRoutes(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("at least one route is required for subnet router mode")
+	}
+	for _, raw := range strings.Split(s, ",") {
+		r := strings.TrimSpace(raw)
+		if r == "" {
+			continue
+		}
+		if err := CIDR(r); err != nil {
+			return fmt.Errorf("route %q: %w", r, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/wizard/apply.go
+++ b/internal/wizard/apply.go
@@ -1,0 +1,179 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// UserStepInput is the raw collected input from the User step form.
+// LocalKeys are SSH public keys already discovered on the installer host
+// (the TUI calls detectLocalSSHKeys()); the wizard merges them with the
+// user-pasted ManualKey and applies the result to InstallConfig.
+type UserStepInput struct {
+	Username     string
+	Password     string // plaintext; bcrypted inside ApplyUserStep
+	ManualKey    string // semicolon-separated paste from the SSH Public Key input
+	LocalKeys    []string
+	Hostname     string
+	Timezone     string
+	GroupsForNew []string // groups applied if the user record is being created
+}
+
+// NetworkStepInput is the raw collected input from the Network step form.
+type NetworkStepInput struct {
+	Mode string // "static" or "dhcp" (anything else ⇒ DHCP)
+	DNS  string // comma-separated DNS list from the form
+}
+
+// ApplyNetworkStep mutates Config.Network from raw form input.
+// Pure state transition — no I/O, no validation (validation happens via
+// ValidateCurrentStep at step-transition time).
+func (w *Wizard) ApplyNetworkStep(in NetworkStepInput) {
+	cfg := &w.State.Config
+	if dns := strings.TrimSpace(in.DNS); dns != "" {
+		parts := strings.Split(dns, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		cfg.Network.DNS = out
+	} else {
+		cfg.Network.DNS = nil
+	}
+	if in.Mode == "static" {
+		cfg.Network.Mode = model.NetworkStatic
+	} else {
+		cfg.Network.Mode = model.NetworkDHCP
+	}
+}
+
+// ApplyUserStep mutates Config.{Users,SSHKeys,Hostname,Timezone} from raw
+// form input. Hashes the password if set. Returns an error only on bcrypt
+// failure (e.g. password > 72 bytes).
+//
+// LocalKeys + ManualKey are merged (deduped, order preserved). Async GitHub
+// keys are applied later via ApplyGitHubKeys once the fetch returns.
+func (w *Wizard) ApplyUserStep(in UserStepInput) error {
+	cfg := &w.State.Config
+
+	if in.Hostname != "" {
+		cfg.Hostname = in.Hostname
+	}
+	if in.Timezone != "" {
+		cfg.Timezone = in.Timezone
+	} else if cfg.Timezone == "" {
+		cfg.Timezone = "UTC"
+	}
+
+	if in.Username != "" {
+		groups := in.GroupsForNew
+		if len(groups) == 0 {
+			groups = []string{"sudo", "docker"}
+		}
+		if len(cfg.Users) == 0 {
+			cfg.Users = append(cfg.Users, model.UserConfig{
+				Username: in.Username,
+				Groups:   groups,
+			})
+		} else {
+			cfg.Users[0].Username = in.Username
+		}
+	}
+
+	if in.Password != "" && len(cfg.Users) > 0 {
+		hash, err := HashPassword(in.Password)
+		if err != nil {
+			return err
+		}
+		cfg.Users[0].PasswordHash = hash
+	}
+
+	manual := SplitSSHKeys(in.ManualKey)
+	merged := MergeSSHKeys(in.LocalKeys, manual)
+	if len(merged) > 0 {
+		cfg.SSHKeys = merged
+		if len(cfg.Users) > 0 {
+			cfg.Users[0].SSHKeys = merged
+		}
+	}
+	return nil
+}
+
+// ApplyGitHubKeys merges asynchronously-fetched GitHub keys with the local
+// host keys and the user's manual paste, replacing Config.SSHKeys with the
+// deduped union.
+func (w *Wizard) ApplyGitHubKeys(githubKeys []string, localKeys []string, manualKey string) {
+	cfg := &w.State.Config
+	merged := MergeSSHKeys(localKeys, SplitSSHKeys(manualKey), githubKeys)
+	cfg.SSHKeys = merged
+	if len(cfg.Users) > 0 {
+		cfg.Users[0].SSHKeys = merged
+	}
+}
+
+// HasAnyAuthentication reports whether the current Config has at least one
+// authentication method (SSH key or user password hash) set. Used by the
+// User step to gate the post-fetch advance when GitHub returns 0 keys.
+func (w *Wizard) HasAnyAuthentication() bool {
+	cfg := &w.State.Config
+	if len(cfg.SSHKeys) > 0 {
+		return true
+	}
+	for _, u := range cfg.Users {
+		if u.PasswordHash != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HashPassword generates a bcrypt hash suitable for the Ignition `passwd`
+// field. Fails when the password exceeds bcrypt's 72-byte limit.
+func HashPassword(plain string) (string, error) {
+	if len(plain) > 72 {
+		return "", fmt.Errorf("password too long (max 72 bytes for bcrypt)")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("hashing password: %w", err)
+	}
+	return string(hash), nil
+}
+
+// SplitSSHKeys splits a semicolon-separated SSH key paste and trims each.
+func SplitSSHKeys(input string) []string {
+	parts := strings.Split(input, ";")
+	keys := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			keys = append(keys, p)
+		}
+	}
+	return keys
+}
+
+// MergeSSHKeys merges multiple key lists, dedupes by exact string match, and
+// preserves first-seen order.
+func MergeSSHKeys(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, list := range lists {
+		for _, k := range list {
+			if k == "" {
+				continue
+			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/internal/wizard/apply_test.go
+++ b/internal/wizard/apply_test.go
@@ -1,0 +1,155 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func newApplyWizard() *Wizard {
+	return &Wizard{State: &State{Config: model.InstallConfig{}}}
+}
+
+func TestApplyNetworkStepStatic(t *testing.T) {
+	w := newApplyWizard()
+	w.ApplyNetworkStep(NetworkStepInput{Mode: "static", DNS: "1.1.1.1, 8.8.8.8 ,"})
+	if w.State.Config.Network.Mode != model.NetworkStatic {
+		t.Errorf("mode: got %v want static", w.State.Config.Network.Mode)
+	}
+	want := []string{"1.1.1.1", "8.8.8.8"}
+	got := w.State.Config.Network.DNS
+	if len(got) != len(want) {
+		t.Fatalf("DNS: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DNS[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestApplyNetworkStepDHCPClearsDNS(t *testing.T) {
+	w := newApplyWizard()
+	w.State.Config.Network.DNS = []string{"1.1.1.1"}
+	w.ApplyNetworkStep(NetworkStepInput{Mode: "dhcp", DNS: ""})
+	if w.State.Config.Network.Mode != model.NetworkDHCP {
+		t.Errorf("mode: got %v want dhcp", w.State.Config.Network.Mode)
+	}
+	if len(w.State.Config.Network.DNS) != 0 {
+		t.Errorf("DNS should be cleared, got %v", w.State.Config.Network.DNS)
+	}
+}
+
+func TestApplyUserStepCreatesUserAndHashesPassword(t *testing.T) {
+	w := newApplyWizard()
+	err := w.ApplyUserStep(UserStepInput{
+		Username:  "alice",
+		Password:  "hunter2",
+		ManualKey: "ssh-ed25519 AAAA alice@laptop",
+		LocalKeys: []string{"ssh-ed25519 BBBB alice@host"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	cfg := w.State.Config
+	if len(cfg.Users) != 1 || cfg.Users[0].Username != "alice" {
+		t.Errorf("expected user alice, got %+v", cfg.Users)
+	}
+	if cfg.Users[0].PasswordHash == "" {
+		t.Error("expected bcrypt password hash")
+	}
+	if !strings.HasPrefix(cfg.Users[0].PasswordHash, "$2") {
+		t.Errorf("expected bcrypt $2 prefix, got %q", cfg.Users[0].PasswordHash)
+	}
+	wantKeys := []string{"ssh-ed25519 BBBB alice@host", "ssh-ed25519 AAAA alice@laptop"}
+	if got := cfg.SSHKeys; len(got) != 2 || got[0] != wantKeys[0] || got[1] != wantKeys[1] {
+		t.Errorf("SSH keys: got %v want %v", got, wantKeys)
+	}
+	groups := cfg.Users[0].Groups
+	hasDocker := false
+	hasSudo := false
+	for _, g := range groups {
+		if g == "docker" {
+			hasDocker = true
+		}
+		if g == "sudo" {
+			hasSudo = true
+		}
+	}
+	if !hasDocker || !hasSudo {
+		t.Errorf("expected default groups sudo+docker, got %v", groups)
+	}
+}
+
+func TestApplyUserStepRejectsLongPassword(t *testing.T) {
+	w := newApplyWizard()
+	err := w.ApplyUserStep(UserStepInput{
+		Username: "bob",
+		Password: strings.Repeat("a", 73),
+	})
+	if err == nil {
+		t.Fatal("expected error for >72 byte password")
+	}
+}
+
+func TestApplyGitHubKeysDedupes(t *testing.T) {
+	w := newApplyWizard()
+	w.State.Config.Users = []model.UserConfig{{Username: "carol"}}
+	w.ApplyGitHubKeys(
+		[]string{"ssh-ed25519 GH carol@github"},
+		[]string{"ssh-ed25519 LOCAL carol@host"},
+		"ssh-ed25519 LOCAL carol@host;ssh-ed25519 MANUAL carol@laptop",
+	)
+	cfg := w.State.Config
+	if len(cfg.SSHKeys) != 3 {
+		t.Errorf("expected 3 deduped keys, got %d: %v", len(cfg.SSHKeys), cfg.SSHKeys)
+	}
+	if len(cfg.Users[0].SSHKeys) != 3 {
+		t.Errorf("user SSH keys should mirror cfg.SSHKeys, got %v", cfg.Users[0].SSHKeys)
+	}
+}
+
+func TestHasAnyAuthentication(t *testing.T) {
+	w := newApplyWizard()
+	if w.HasAnyAuthentication() {
+		t.Error("empty config should have no auth")
+	}
+	w.State.Config.Users = []model.UserConfig{{Username: "x"}}
+	if w.HasAnyAuthentication() {
+		t.Error("user without password/keys should have no auth")
+	}
+	w.State.Config.Users[0].PasswordHash = "hash"
+	if !w.HasAnyAuthentication() {
+		t.Error("password-only should count as auth")
+	}
+	w.State.Config = model.InstallConfig{SSHKeys: []string{"ssh-x"}}
+	if !w.HasAnyAuthentication() {
+		t.Error("SSH-key-only should count as auth")
+	}
+}
+
+func TestSplitSSHKeys(t *testing.T) {
+	got := SplitSSHKeys("  ssh-rsa AAA  ;  ;ssh-ed25519 BBB ; ")
+	want := []string{"ssh-rsa AAA", "ssh-ed25519 BBB"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("SplitSSHKeys: got %v want %v", got, want)
+	}
+}
+
+func TestMergeSSHKeysPreservesOrder(t *testing.T) {
+	got := MergeSSHKeys(
+		[]string{"a", "b"},
+		[]string{"b", "c"},
+		[]string{"a", "d"},
+	)
+	want := []string{"a", "b", "c", "d"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("at %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -73,6 +73,9 @@ func New(prober probe.Prober, bakeryClient bakery.Client, installer install.Inst
 				Arch:           runtime.GOARCH,
 				Channel:        "stable",
 				UpdateStrategy: model.UpdateStrategy{RebootStrategy: "reboot"},
+				// Default to enabling swap (issue #95). Sized at render time —
+				// 0 SizeMB means "use DefaultSwapSizeMB".
+				Swap: model.SwapConfig{Enabled: true, SizeMB: 0},
 			},
 		},
 		Prober:    prober,

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -93,6 +93,10 @@ func (w *Wizard) Next() error {
 		if w.State.CurrentStep == model.StepNvidia && !w.isNvidiaSelected() {
 			w.State.CurrentStep++
 		}
+		// StepTailscale is conditional — only visit it when tailscale is selected.
+		if w.State.CurrentStep == model.StepTailscale && !w.isTailscaleSelected() {
+			w.State.CurrentStep++
+		}
 	}
 	return nil
 }
@@ -101,6 +105,10 @@ func (w *Wizard) Next() error {
 func (w *Wizard) Previous() {
 	if w.State.CurrentStep > model.StepWelcome {
 		w.State.CurrentStep--
+		// StepTailscale is conditional — skip back over it when tailscale is not selected.
+		if w.State.CurrentStep == model.StepTailscale && !w.isTailscaleSelected() {
+			w.State.CurrentStep--
+		}
 		// StepNvidia is conditional — skip back over it when nvidia-runtime is not selected.
 		if w.State.CurrentStep == model.StepNvidia && !w.isNvidiaSelected() {
 			w.State.CurrentStep--
@@ -118,11 +126,25 @@ func (w *Wizard) isNvidiaSelected() bool {
 	return false
 }
 
+// isTailscaleSelected returns true when the tailscale sysext is toggled on.
+func (w *Wizard) isTailscaleSelected() bool {
+	for _, s := range w.State.Sysexts {
+		if s.Name == "tailscale" && s.Selected {
+			return true
+		}
+	}
+	return false
+}
+
 // GoToStep jumps to a specific step (for review screen navigation)
 func (w *Wizard) GoToStep(step model.WizardStep) {
 	if step >= model.StepWelcome && step <= model.StepDone {
 		// StepNvidia is conditional — refuse jump when nvidia-runtime not selected.
 		if step == model.StepNvidia && !w.isNvidiaSelected() {
+			return
+		}
+		// StepTailscale is conditional — refuse jump when tailscale not selected.
+		if step == model.StepTailscale && !w.isTailscaleSelected() {
 			return
 		}
 		w.State.CurrentStep = step
@@ -144,6 +166,8 @@ func (w *Wizard) ValidateCurrentStep() error {
 		return nil // sysext selection is optional
 	case model.StepNvidia:
 		return nil // driver series has a safe default; no validation needed
+	case model.StepTailscale:
+		return w.validateTailscale()
 	case model.StepUpdate:
 		return nil // update strategy selection is optional (defaults to "reboot")
 	case model.StepReview:
@@ -198,6 +222,23 @@ func (w *Wizard) validateStorage() error {
 		}
 	}
 	return validate.DiskPath(w.State.Config.Disk.DevPath)
+}
+
+func (w *Wizard) validateTailscale() error {
+	ts := w.State.Config.Tailscale
+	if ts.AuthKey == "" {
+		// Empty auth key is allowed: user skips the step, no provisioning.
+		return nil
+	}
+	if err := validate.TailscaleAuthKey(ts.AuthKey); err != nil {
+		return fmt.Errorf("tailscale auth key: %w", err)
+	}
+	if ts.Mode == model.TailscaleModeSubnetRouter {
+		if err := validate.TailscaleRoutes(ts.Routes); err != nil {
+			return fmt.Errorf("tailscale routes: %w", err)
+		}
+	}
+	return nil
 }
 
 func (w *Wizard) validateUser() error {

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -386,8 +386,8 @@ func TestIsFirstAndLastStep(t *testing.T) {
 
 func TestStepCount(t *testing.T) {
 	count := StepCount()
-	if count != 10 {
-		t.Errorf("expected 10 steps (added StepNvidia), got %d", count)
+	if count != 11 {
+		t.Errorf("expected 11 steps (added StepTailscale), got %d", count)
 	}
 }
 

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -253,11 +253,11 @@ printf 'default knuckle\ntimeout 5\neditor no\n' \
 
 # Primary entry: VGA console (tty0 is listed last so /dev/console -> tty0)
 # Serial output is still mirrored to ttyS0 for diagnostics.
-printf 'title   Knuckle \xe2\x80\x93 Install Flatcar Container Linux\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 console=tty0\n' \
+printf 'title   Knuckle \xe2\x80\x93 Install Flatcar Container Linux\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 console=tty0 systemd.gpt_auto=0\n' \
     | mcopy -i "$EFI_IMG" - ::/loader/entries/knuckle.conf
 
 # Alternate entry: serial only (headless servers)
-printf 'title   Knuckle \xe2\x80\x93 Install Flatcar (serial console)\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8\n' \
+printf 'title   Knuckle \xe2\x80\x93 Install Flatcar (serial console)\nlinux   /vmlinuz\ninitrd  /initrd.img\noptions console=ttyS0,115200n8 systemd.gpt_auto=0\n' \
     | mcopy -i "$EFI_IMG" - ::/loader/entries/knuckle-serial.conf
 
 mcopy -i "$EFI_IMG" "$KERNEL"          ::/vmlinuz


### PR DESCRIPTION
## Summary

Add test coverage for sysext helper functions and regression test for channel cards padding.

## Tests Added

**sysext_helpers_test.go:**
- `TestRenderTierHeaderWithName` — verifies tier name rendering
- `TestRenderTierHeaderEmptyFallback` — verifies empty string defaults to "Other"
- `TestSysextTitleNoSelection` — verifies "0 selected" count
- `TestSysextTitleWithSelections` — verifies correct count formatting
- `TestRefreshSysextListTitleNotReady` — verifies no-op when list not initialized
- `TestRefreshSysextListTitleReady` — verifies title updates on selection change

**forms_test.go:**
- `TestViewChannelCardsLongVersionNoPanic` — regression test for #248 (long version padding)
- `TestViewChannelCardsSelectsCurrent` — verifies cursor indicator rendering

## Coverage

Brings functions to 100% coverage:
- `renderTierHeader` — 100%
- `sysextTitle` — 100%
- `refreshSysextListTitle` — 100%
- `viewChannelCards` — 96.4%

TUI package coverage: 76.3% → 77.7%

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hardware-like reproduction workflow for testing installer failures in QEMU without bare metal hardware.
  * Added Tailscale provisioning with multiple modes (exit-node, subnet-router) and configurable routes.
  * Added configurable swap file sizing with sensible defaults.
  * Added community links (Discord, documentation) to help section.

* **Bug Fixes**
  * Fixed stale disk signature handling before installation.
  * Fixed GPT backup header relocation after installation.
  * Improved UEFI boot compatibility with 4M OVMF firmware variants.

* **Documentation**
  * New Flatcar Container Linux deployment guide for Hive.
  * Updated security threat model documentation.
  * Enhanced CI and testing guidance.

* **Chores**
  * Added GitHub issue templates for bug reports and feature requests.
  * Automated release notes configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->