### PR TITLE
test(#270): sysext helpers and channel cards coverage

### DIFF
--- a/internal/tui/forms_test.go
+++ b/internal/tui/forms_test.go
@@ -1,0 +1,48 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+)
+
+func TestViewChannelCardsLongVersionNoPanic(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.Channel = "stable"
+	w.State.Channels = []bakery.ChannelInfo{
+		{
+			Channel: "stable",
+			Version: "99999.99.99-very-long-prerelease-tag-exceeding-width",
+			Kernel:  "6.99.0",
+		},
+	}
+	m := New(w)
+	m.cursor = 0
+
+	// This should not panic even with a very long version string
+	// Regression test for #248 (negative padding fix)
+	out := m.viewChannelCards()
+	if len(out) == 0 {
+		t.Error("viewChannelCards should render non-empty output")
+	}
+	if !strings.Contains(out, "stable") && !strings.Contains(out, "Stable") {
+		t.Errorf("viewChannelCards should contain channel name, got: %q", out)
+	}
+}
+
+func TestViewChannelCardsSelectsCurrent(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.Channel = "stable"
+	w.State.Channels = []bakery.ChannelInfo{
+		{Channel: "stable", Version: "1.0.0", Kernel: "6.1.0"},
+		{Channel: "edge", Version: "2.0.0", Kernel: "6.2.0"},
+	}
+	m := New(w)
+	m.cursor = 0
+
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "▸") {
+		t.Error("viewChannelCards should show cursor indicator for selected item")
+	}
+}

--- a/internal/tui/sysext_helpers_test.go
+++ b/internal/tui/sysext_helpers_test.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestRenderTierHeaderWithName(t *testing.T) {
+	out := renderTierHeader("Integrated")
+	if !strings.Contains(out, "Integrated") {
+		t.Errorf("renderTierHeader should contain tier name, got: %q", out)
+	}
+	if !strings.Contains(out, "──") {
+		t.Error("header should contain dashes for styling")
+	}
+}
+
+func TestRenderTierHeaderEmptyFallback(t *testing.T) {
+	out := renderTierHeader("")
+	if !strings.Contains(out, "Other") {
+		t.Errorf("renderTierHeader(\"\") should fallback to 'Other', got: %q", out)
+	}
+	if !strings.Contains(out, "──") {
+		t.Error("header should contain dashes for styling")
+	}
+}
+
+func TestSysextTitleNoSelection(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", Selected: false},
+		{Name: "wasmtime", Selected: false},
+	}
+	m := New(w)
+	title := m.sysextTitle()
+	if !strings.Contains(title, "0 selected") {
+		t.Errorf("sysextTitle with no selection should show '0 selected', got: %q", title)
+	}
+}
+
+func TestSysextTitleWithSelections(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", Selected: true},
+		{Name: "wasmtime", Selected: false},
+		{Name: "tailscale", Selected: true},
+	}
+	m := New(w)
+	title := m.sysextTitle()
+	if !strings.Contains(title, "2 selected") {
+		t.Errorf("sysextTitle should show '2 selected', got: %q", title)
+	}
+}
+
+func TestRefreshSysextListTitleNotReady(t *testing.T) {
+	w := newTestWizard()
+	m := New(w)
+	m.sysextListReady = false
+	m.refreshSysextListTitle() // must not panic
+}
+
+func TestRefreshSysextListTitleReady(t *testing.T) {
+	w := newTestWizard()
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "docker", SupportTier: bakery.TierIntegrated, Selected: true},
+		{Name: "wasmtime", SupportTier: bakery.TierExperimental, Selected: false},
+	}
+	m := New(w)
+	m.initSysextList()
+	if !m.sysextListReady {
+		t.Fatal("initSysextList should set sysextListReady=true")
+	}
+	if !strings.Contains(m.sysextList.Title, "1 selected") {
+		t.Errorf("initial title should show '1 selected', got: %q", m.sysextList.Title)
+	}
+	w.State.Sysexts[1].Selected = true
+	m.refreshSysextListTitle()
+	if !strings.Contains(m.sysextList.Title, "2 selected") {
+		t.Errorf("refreshSysextListTitle should update count to '2 selected', got: %q", m.sysextList.Title)
+	}
+}


### PR DESCRIPTION
## Summary

Add test coverage for sysext helper functions and regression test for channel cards padding.

## Tests Added

**sysext_helpers_test.go:**
- `TestRenderTierHeaderWithName` — verifies tier name rendering
- `TestRenderTierHeaderEmptyFallback` — verifies empty string defaults to "Other"
- `TestSysextTitleNoSelection` — verifies "0 selected" count
- `TestSysextTitleWithSelections` — verifies correct count formatting
- `TestRefreshSysextListTitleNotReady` — verifies no-op when list not initialized
- `TestRefreshSysextListTitleReady` — verifies title updates on selection change

**forms_test.go:**
- `TestViewChannelCardsLongVersionNoPanic` — regression test for #248 (long version padding)
- `TestViewChannelCardsSelectsCurrent` — verifies cursor indicator rendering

## Coverage

Brings functions to 100% coverage:
- `renderTierHeader` — 100%
- `sysextTitle` — 100%
- `refreshSysextListTitle` — 100%

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)