### PR TITLE
fix(#297): catalog_check uses runtime.GOARCH instead of hardcoded amd64

### DIFF
--- a/scripts/catalog_check/main.go
+++ b/scripts/catalog_check/main.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ import (
 
 func main() {
 	strict := flag.Bool("strict", false, "exit 1 if any extensions are missing curated descriptions")
+	arch := flag.String("arch", runtime.GOARCH, "architecture to query (default: host arch)")
 	flag.Parse()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
@@ -36,8 +38,8 @@ func main() {
 
 	client := bakery.NewHTTPClient()
 
-	fmt.Print("Fetching live bakery catalog (amd64)... ")
-	entries, err := client.FetchCatalogArch(ctx, "amd64")
+	fmt.Printf("Fetching live bakery catalog (%s)... ", *arch)
+	entries, err := client.FetchCatalogArch(ctx, *arch)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR fetching catalog: %v\n", err)
 		os.Exit(2)


### PR DESCRIPTION
## Summary

- Adds `--arch` flag to `catalog_check` (default: `runtime.GOARCH`)
- Replaces the hardcoded `"amd64"` string passed to `FetchCatalogArch`
- Output now prints the actual architecture being queried

## Before / After

```diff
-fmt.Print("Fetching live bakery catalog (amd64)... ")
-entries, err := client.FetchCatalogArch(ctx, "amd64")
+fmt.Printf("Fetching live bakery catalog (%s)... ", *arch)
+entries, err := client.FetchCatalogArch(ctx, *arch)
```

## Impact

- arm64-only extensions no longer appear as missing on arm64 build pipelines
- amd64-only extensions are correctly flagged on arm64 hosts
- Overridable via `--arch amd64` for cross-arch checks

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)