### PR TITLE
fix(#298): scope nvidia_check.sh MODEL_IDS grep to NvidiaDriverOptions block

### DIFF
--- a/scripts/nvidia_check.sh
+++ b/scripts/nvidia_check.sh
@@ -49,7 +49,8 @@ fi
 # ── Extract model.go entries ──────────────────────────────────────────────────
 echo ""
 echo "Driver series in model.go NvidiaDriverOptions:"
-MODEL_IDS=$(grep -oE 'ID:\s+"[^"]+"' "$MODEL_GO" | grep -A1 -B0 '.' | \
+MODEL_IDS=$(awk '/NvidiaDriverOptions/,/^\}/' "$MODEL_GO" | \
+  grep -oE 'ID:\s+"[^"]+"' | \
   sed 's/.*ID:\s*"\([^"]*\)".*/\1/' | sort -u)
 
 while IFS= read -r id; do


### PR DESCRIPTION
## Summary

Replaces the broad `grep -oE 'ID:\s+"[^"]+"'` over all of `model.go` with an `awk` block extractor that captures only the `NvidiaDriverOptions` slice before grepping.

## Before / After

```diff
-MODEL_IDS=$(grep -oE 'ID:\s+"[^"]+"' "$MODEL_GO" | grep -A1 -B0 '.' | \
-  sed 's/.*ID:\s*"\([^"]*\)".*/\1/' | sort -u)
+MODEL_IDS=$(awk '/NvidiaDriverOptions/,/^\}/' "$MODEL_GO" | \
+  grep -oE 'ID:\s+"[^"]+"' | \
+  sed 's/.*ID:\s*"\([^"]*\)".*/\1/' | sort -u)
```

## Why

The old grep matched **all** `ID:` fields in `model.go`. Any new struct that gets an `ID:` field (channels, sysexts, config types) would silently contaminate the NVIDIA driver comparison set, producing false positives or incorrect "missing in model" warnings.

The `awk` range pattern `/NvidiaDriverOptions/,/^\}/` captures only the top-level slice block (closing `}` at column 0), then pipes to the same grep/sed chain.

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)