### PR TITLE
ci(#296): add shellcheck gate for QA bash scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
           fi
           echo "✓ All 5 runs passed — no flaky tests detected"
 
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          severity: warning
+          scandir: scripts
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+# SC2086: intentional word-splitting for SSH option variables ($GOPTS, $SSH_OPTS)
+disable=SC2086
+# SC2029: intentional client-side expansion in _ghost() and ssh wrapper calls
+disable=SC2029
+# SC1091: dynamic source paths — handled per-file with # shellcheck source= directives
+disable=SC1091

--- a/Justfile
+++ b/Justfile
@@ -55,14 +55,18 @@ test:
 GOLANGCI_LINT_VERSION := "2.12.2"
 GOLANGCI_LINT := ".tools/golangci-lint"
 
+SHELLCHECK_VERSION := "0.10.0"
+SHELLCHECK := ".tools/shellcheck"
+
 # Install pinned tool binaries (idempotent — run once after clone, or after version bump)
 tools:
     just _install-golangci-lint
+    just _install-shellcheck
     go tool govulncheck -version
     @echo "tools ok"
 
 # Full CI (tidy + fmt-check + vet + lint + vuln + test-race + cover-check + headless-e2e + build)
-ci: _install-golangci-lint
+ci: _install-golangci-lint _install-shellcheck
     go mod tidy
     @git diff --exit-code go.mod go.sum || (echo "go.mod/go.sum dirty after tidy" && exit 1)
     just fmt-check
@@ -72,6 +76,7 @@ ci: _install-golangci-lint
     go test -race ./...
     just cover-check
     just headless-test
+    just shell-lint
     just build
 
 # Check formatting (CI gate — fails if any file would change)
@@ -1041,6 +1046,35 @@ _install-golangci-lint:
         "golangci-lint-{{GOLANGCI_LINT_VERSION}}-${OS}-${ARCH}/golangci-lint"
     chmod +x "{{GOLANGCI_LINT}}"
     echo "golangci-lint v{{GOLANGCI_LINT_VERSION}} installed to {{GOLANGCI_LINT}}"
+
+# Lint all bash scripts with shellcheck
+shell-lint: _install-shellcheck
+    {{SHELLCHECK}} --severity=warning \
+      scripts/qa-test-pr.sh \
+      scripts/build-iso.sh \
+      scripts/lib/vm-kubevirt.sh \
+      scripts/fix-ghost-otel-process-noise.sh \
+      scripts/nvidia_check.sh \
+      scripts/drive-demo.sh \
+      scripts/record-demo.sh
+
+_install-shellcheck:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -x "{{SHELLCHECK}}" ]]; then
+        ver=$("{{SHELLCHECK}}" --version 2>&1 | grep -oP 'version \K[0-9.]+' || true)
+        [[ "$ver" == "{{SHELLCHECK_VERSION}}" ]] && exit 0
+        echo "shellcheck version mismatch (got $ver, want {{SHELLCHECK_VERSION}}) — reinstalling"
+    fi
+    mkdir -p .tools
+    ARCH=$(uname -m)
+    URL="https://github.com/koalaman/shellcheck/releases/download/v{{SHELLCHECK_VERSION}}/shellcheck-v{{SHELLCHECK_VERSION}}.linux.${ARCH}.tar.xz"
+    echo "Downloading shellcheck v{{SHELLCHECK_VERSION}}..."
+    curl -sSfL "$URL" | tar -xJf - -C .tools \
+        --strip-components=1 \
+        "shellcheck-v{{SHELLCHECK_VERSION}}/shellcheck"
+    chmod +x "{{SHELLCHECK}}"
+    echo "shellcheck v{{SHELLCHECK_VERSION}} installed to {{SHELLCHECK}}"
 
 [private]
 _ensure-base:

--- a/scripts/lib/vm-kubevirt.sh
+++ b/scripts/lib/vm-kubevirt.sh
@@ -57,6 +57,7 @@ kv_apply_vm() {
   local name="$1"
   local root_path="/var/tmp/knuckle-test/${name}-raw.img"
   local tgt_path="/var/tmp/knuckle-test/${name}-target.img"
+  # shellcheck disable=SC2087 # intentional: ${name} vars expand locally before ssh receives heredoc
   ssh $GOPTS "$GHOST" kubectl apply -f - << YAML
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
@@ -258,6 +259,7 @@ kv_boot_installed() {
   done
 
   # Create a new minimal VM: only the installed target disk, no installer disk
+  # shellcheck disable=SC2087 # intentional: ${name} vars expand locally before ssh receives heredoc
   ssh $GOPTS "$GHOST" kubectl apply -f - << YAML
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -40,7 +40,7 @@ printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAu
   -display none -daemonize -pidfile .vm/qemu.pid -serial file:.vm/demo-serial.log
 
 echo "   Waiting for VM SSH..."
-for i in $(seq 1 30); do
+for _ in $(seq 1 30); do
   ssh $SSH_OPTS -o ConnectTimeout=3 -i .vm/e2e_key -p 2222 core@127.0.0.1 true 2>/dev/null && break
   sleep 3
 done


### PR DESCRIPTION
## Summary

- Adds `.shellcheckrc` suppressing project-wide intentional patterns
- Adds `shell-lint` recipe to `Justfile` + wires into `ci` and `tools`
- Adds `shellcheck` job to `.github/workflows/ci.yml` using pinned `ludeeus/action-shellcheck@2.0.0`
- Fixes 3 actual shellcheck warnings; no functional changes

## Findings (shellcheck v0.10.0, all 7 scripts)

**0 errors. 3 warnings fixed. 35 notes suppressed project-wide.**

| Fix | File | Code | Description |
|-----|------|------|-------------|
| `for i` → `for _` | `record-demo.sh:43` | SC2034 | Unused loop variable |
| inline `# shellcheck disable=SC2087` | `vm-kubevirt.sh:60,262` | SC2087 | Unquoted heredoc — intentional local expansion |

## Suppressed project-wide (`.shellcheckrc`)

| Code | Count | Reason |
|------|-------|--------|
| SC2086 | 22 | `$GOPTS`/`$SSH_OPTS` word-split is intentional in ssh calls |
| SC2029 | 13 | Client-side expansion in `_ghost()` SSH wrappers is intentional |
| SC1091 | 1 | Dynamic source paths handled per-file with `# shellcheck source=` |

Closes #289 #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)