### PR TITLE
fix(test): correct tailscale validation tests that passed for wrong reason

### DIFF
--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -1525,30 +1525,54 @@ func TestValidate_SwapNegativeSize(t *testing.T) {
 }
 
 func TestValidate_TailscaleInvalidKey(t *testing.T) {
+	// Uses SSH key (not password) so user validation passes and reaches tailscale validation.
+	// Previously used Password:"hunter2" which failed PasswordHash before reaching tailscale.
 	cfg := &Config{
 		Channel:   "stable",
 		Disk:      "/dev/vda",
-		Users:     []UserConfig{{Username: "core", Password: "hunter2"}},
+		Users:     []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}}},
 		Tailscale: TailscaleConfig{AuthKey: "not-a-real-key"},
 	}
-	if err := cfg.Validate(); err == nil {
+	err := cfg.Validate()
+	if err == nil {
 		t.Fatal("expected error for invalid Tailscale auth key, got nil")
+	}
+	if !strings.Contains(err.Error(), "tailscale auth_key") {
+		t.Errorf("error should mention 'tailscale auth_key', got: %v", err)
 	}
 }
 
 func TestValidate_TailscaleSubnetRouterNoRoutes(t *testing.T) {
+	// Uses SSH key (not password) so user validation passes and reaches tailscale validation.
+	// Previously used Password:"hunter2" which failed PasswordHash before reaching tailscale.
 	cfg := &Config{
 		Channel: "stable",
 		Disk:    "/dev/vda",
-		Users:   []UserConfig{{Username: "core", Password: "hunter2"}},
+		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}}},
 		Tailscale: TailscaleConfig{
 			AuthKey: "tskey-auth-kExampleKeyID1-ExampleSecretThatIsLongEnough123",
 			Mode:    "subnet-router",
 			Routes:  "",
 		},
 	}
-	if err := cfg.Validate(); err == nil {
+	err := cfg.Validate()
+	if err == nil {
 		t.Fatal("expected error for subnet router with no routes, got nil")
+	}
+	if !strings.Contains(err.Error(), "tailscale routes") {
+		t.Errorf("error should mention 'tailscale routes', got: %v", err)
+	}
+}
+
+func TestResolveSysexts_EmptyNames(t *testing.T) {
+	// Covers the len(names)==0 early return guard in resolveSysexts (line 190).
+	// Run() never calls resolveSysexts with empty names, so this path needs a direct test.
+	got, err := resolveSysexts(context.Background(), []string{}, nil, "amd64")
+	if err != nil {
+		t.Fatalf("expected nil error for empty names, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil result for empty names, got: %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two existing tests in `internal/headless/headless_test.go` were passing for the wrong reason, leaving two tailscale validation branches at 0% coverage despite "green" tests.

**Root cause**: both tests supplied `Password: "hunter2"` (plaintext, not a crypt hash). `Validate()` runs user validation before tailscale validation, so `validate.PasswordHash("hunter2")` returned an error first — the function never reached the tailscale checks.

**Affected tests** (before):
| Test | Expected error source | Actual error source |
|------|----------------------|---------------------|
| `TestValidate_TailscaleInvalidKey` | `tailscale auth_key:` | `users[0] (core): password_hash must be a valid crypt hash` |
| `TestValidate_TailscaleSubnetRouterNoRoutes` | `tailscale routes:` | same password error |

**Fixes**:
- Switch both tests from `Password: "hunter2"` → `SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}` so user validation passes and reaches the tailscale block
- Add `strings.Contains(err.Error(), "tailscale ...")` assertions to pin each test to the correct error source
- Add `TestResolveSysexts_EmptyNames` to cover the `len(names)==0` early-return guard in `resolveSysexts` (line 190), which `Run()` never calls with an empty list

**Coverage impact**: `headless` package 93.2% → 95.6%; `Validate` 94.1% → 96.5%

Closes #327

## Test plan

- [ ] `go test ./internal/headless/...` — all tests pass including the three affected ones
- [ ] `go test -cover ./internal/headless/...` reports ≥ 95.5%
- [ ] The two fixed tests now fail if the tailscale validation is removed (verify the assertions pin the right code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)