### PR TITLE
test(install): cover Install() GenerateButane error path

### DIFF
--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -153,6 +153,32 @@ func TestInstallButaneCompilationFailure(t *testing.T) {
 	}
 }
 
+func TestInstall_GenerateButaneError(t *testing.T) {
+	// Covers install.go:56-58: GenerateButane returns error when a selected
+	// sysext has a non-HTTPS download URL.
+	spy := runner.NewSpyRunner()
+	installer := NewFlatcarInstaller(spy, testLogger())
+
+	cfg := &model.InstallConfig{
+		Hostname: "node01",
+		Channel:  "stable",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Disk:     model.DiskInfo{DevPath: "/dev/vda"},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+		Sysexts: []model.SysextEntry{
+			{Name: "docker", URL: "http://evil.example.com/docker.raw", Selected: true},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for non-HTTPS sysext URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "generating butane config") {
+		t.Errorf("error = %q, want 'generating butane config' prefix", err.Error())
+	}
+}
+
 func TestInstallFlatcarInstallFailure(t *testing.T) {
 	spy := runner.NewSpyRunner()
 	// Stub a generic error for any flatcar-install call


### PR DESCRIPTION
## Summary

- Add `TestInstall_GenerateButaneError` to cover `install.go:56-58` — the error branch when `Install()` calls `GenerateButane` and it fails
- Uses a non-HTTPS sysext URL to trigger the failure (already validated in `ignition_test.go`, but not exercised through the full `Install()` call path)
- `Install` function coverage: 91.9% → 94.6%; overall package: 88.8% → 90.0%

No production code changed.

Closes #329

## Test plan

- [ ] `go test ./internal/install/...` — all tests pass including `TestInstall_GenerateButaneError`
- [ ] `go test -cover ./internal/install/...` reports ≥ 90.0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)