### PR TITLE
fix(ci): fail on flaky tests + retry just install on HTTP 502

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           done
           if [[ $flaky_detected -eq 1 ]]; then
             echo "::warning::Potential flaky tests detected — some runs failed. Check logs above."
-            exit 0  # Don't fail CI, just warn
+            exit 1  # Fail CI so flaky tests are not silently ignored
           fi
           echo "✓ All 5 runs passed — no flaky tests detected"
 
@@ -130,6 +130,11 @@ jobs:
           go-version: "1.26"
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        continue-on-error: true
+        id: setup-just-action
+      - name: install just (fallback if setup-just action fails)
+        if: steps.setup-just-action.outcome == 'failure'
+        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
       - name: per-package coverage thresholds
         run: just cover-check
@@ -164,6 +169,11 @@ jobs:
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        continue-on-error: true
+        id: setup-just-action-e2e
+      - name: install just (fallback if setup-just action fails)
+        if: steps.setup-just-action-e2e.outcome == 'failure'
+        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
       - name: headless dry-run
         run: just headless-test


### PR DESCRIPTION
## Fixes

**#354 — flaky test detection never fails CI**
The `flaky test detection` step ran tests 5× but always `exit 0` even when flakiness was found. PRs could merge with known-flaky tests. Changed to `exit 1`.

**#355 — extractions/setup-just returns HTTP 502, kills coverage-gate**
Added `continue-on-error: true` on the `extractions/setup-just` step with a curl fallback:
```bash
curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
```
Applied to both `coverage-gate` and `headless-e2e` jobs.

## Test plan

CI-only change. Behaviour is unchanged when both steps succeed. Fallback only fires on action failure.

Assisted-by: claude-sonnet-4-5 via pi