### PR TITLE
docs: add demo mode quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ just build-arm64
 # Run the installer (on a Flatcar live environment)
 ./bin/knuckle
 
+# Explore the full TUI with mocked hardware and catalog data
+./bin/knuckle --demo
+
 # Dry-run mode (no disk writes)
 ./bin/knuckle --dry-run
 
@@ -163,6 +166,8 @@ just cover        # coverage profile + summary
 just cover-check  # per-package coverage threshold gate
 just headless-test  # build + canned JSON config (CI gate, runs on host)
 ```
+
+Tip: use `./bin/knuckle --demo` to run the full wizard with mocked hardware and catalog data. No QEMU, network, or real disks required.
 
 ### VM Testing
 


### PR DESCRIPTION
## What
Adds a `./bin/knuckle --demo` example to the source-build Quick Start and a Development tip for running the wizard with mocked hardware and catalog data.

## Why
Closes #441. The flag table documented `--demo`, but the contributor entry points did not show the no-hardware/no-network TUI path.

## How tested
- [ ] `just ci` is green locally
- [ ] `just vm-e2e` passes (end-to-end install + boot)
- [ ] `just headless-test` passes (for headless-mode changes)
- [ ] Tested on real hardware — describe below
- [x] Doc / template / CI change only — no install path touched

Validation run:
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --exit-code 1`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact --exit-code 1`

Local limitations:
- `just ci` was not run because `just` is not installed locally.
- `go test ./...` was attempted, then stopped after a local Go linker process stayed active for several minutes. This PR only changes README text and does not touch the install path.

## Scope check
This is documentation-only and stays inside the existing v1 scope. No install, headless, TUI, or VM behavior changes.

## Notes for reviewers
The commit is DCO signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated build instructions with information about a demo mode that allows exploring the complete interface with mocked hardware and catalog data, eliminating the need for real hardware or network connectivity during development and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->