### PR TITLE
fix(test): add return after t.Fatal to resolve SA5011 nil-deref lint

### DIFF
--- a/internal/bakery/bakery_test.go
+++ b/internal/bakery/bakery_test.go
@@ -566,6 +566,7 @@ func TestNewHTTPClient(t *testing.T) {
 	c := bakery.NewHTTPClient()
 	if c == nil {
 		t.Fatal("NewHTTPClient() returned nil")
+		return
 	}
 	if c.CatalogURL != bakery.DefaultCatalogURL {
 		t.Errorf("CatalogURL = %q, want %q", c.CatalogURL, bakery.DefaultCatalogURL)

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -63,6 +63,7 @@ func TestInstallWithGeneratedConfig(t *testing.T) {
 	}
 	if installCall == nil {
 		t.Fatal("flatcar-install was not called")
+		return
 	}
 	// Check basic structure: -d /dev/sda -C stable -i <some-temp-path>
 	if len(installCall.Args) < 6 {
@@ -115,6 +116,7 @@ func TestInstallWithExternalURL(t *testing.T) {
 	}
 	if installCall == nil {
 		t.Fatal("flatcar-install was not called")
+		return
 	}
 	wantArgs := []string{"-d", "/dev/vda", "-C", "beta", "-I", "https://example.com/config.ign"}
 	if len(installCall.Args) != len(wantArgs) {
@@ -548,6 +550,7 @@ func TestInstallWithSysexts(t *testing.T) {
 	}
 	if installCall == nil {
 		t.Fatal("flatcar-install was not called")
+		return
 	}
 	// The ignition file passed to -i must have been generated (sysext URLs included)
 	if len(installCall.Args) < 5 || installCall.Args[4] != "-i" {

--- a/internal/install/security_test.go
+++ b/internal/install/security_test.go
@@ -59,6 +59,7 @@ func TestCommandInjectionViaDiskPath(t *testing.T) {
 			}
 			if installCall == nil {
 				t.Fatal("flatcar-install was not called")
+				return
 			}
 
 			// The disk path must appear as a SINGLE argument after -d

--- a/internal/runner/runner_context_test.go
+++ b/internal/runner/runner_context_test.go
@@ -33,6 +33,7 @@ func TestRealRunner_ContextTimeout(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected result on timeout, got nil")
+		return
 	}
 	if result.ExitCode == 0 {
 		t.Errorf("expected non-zero exit code on timeout, got 0")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -134,6 +134,7 @@ func TestSpyRunnerAllErrorAppliesToRunWithInput(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("RunWithInput() result = nil, want non-nil result")
+		return
 	}
 	if result.ExitCode != 1 {
 		t.Errorf("RunWithInput() exit code = %d, want 1", result.ExitCode)


### PR DESCRIPTION
## Summary

Add missing `return` statements after `t.Fatal` calls in test files where the pointer/value is used after the nil guard. Staticcheck SA5011 flags these because `t.Fatal` does not halt execution from the linter's perspective without an explicit `return`.

This is blocking CI for all open PRs in the merge queue.

## Files changed

- `internal/bakery/bakery_test.go` — `NewHTTPClient()` nil check
- `internal/install/install_test.go` — `installCall` nil check (3 locations)
- `internal/install/security_test.go` — `installCall` nil check
- `internal/runner/runner_context_test.go` — `result` nil check
- `internal/runner/runner_test.go` — `result` nil check

## Test

`go test ./...` passes on all packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test reliability by adding explicit early exits after fatal test failures, ensuring proper test termination and preventing spurious assertion failures in multiple test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->