### PR TITLE
🔍 test(bakery): add injectable seam and cover verifyFlatcarSignature keyring-read error

### DIFF
--- a/internal/bakery/verify.go
+++ b/internal/bakery/verify.go
@@ -3,6 +3,7 @@ package bakery
 import (
 	"bytes"
 	_ "embed"
+	"io"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -13,11 +14,17 @@ import (
 //go:embed keys/flatcar-signing.asc
 var flatcarSigningKeyASC string
 
+// readArmoredKeyRingFn is the function used to parse a PGP armored key ring.
+// Tests can replace it to simulate keyring-parse failures.
+var readArmoredKeyRingFn = func(r io.Reader) (openpgp.EntityList, error) {
+	return openpgp.ReadArmoredKeyRing(r)
+}
+
 // verifyFlatcarSignature verifies a cleartext-signed PGP message (the .DIGESTS.asc
 // format used by Flatcar releases) against the embedded Flatcar release key.
 // Returns true only when the signature is cryptographically valid.
 func verifyFlatcarSignature(signedMessage string) bool {
-	keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(flatcarSigningKeyASC))
+	keyring, err := readArmoredKeyRingFn(strings.NewReader(flatcarSigningKeyASC))
 	if err != nil {
 		return false
 	}

--- a/internal/bakery/verify_test.go
+++ b/internal/bakery/verify_test.go
@@ -1,9 +1,13 @@
 package bakery
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 func TestVerifyFlatcarSignature_ValidSignature(t *testing.T) {
@@ -37,5 +41,20 @@ func TestVerifyFlatcarSignature_NotPGP(t *testing.T) {
 func TestVerifyFlatcarSignature_Empty(t *testing.T) {
 	if verifyFlatcarSignature("") {
 		t.Error("empty input should not verify")
+	}
+}
+
+// TestVerifyFlatcarSignature_KeyringReadError covers the return-false branch
+// when readArmoredKeyRingFn returns an error (structurally unreachable in
+// production because flatcarSigningKeyASC is a compile-time //go:embed constant).
+func TestVerifyFlatcarSignature_KeyringReadError(t *testing.T) {
+	old := readArmoredKeyRingFn
+	readArmoredKeyRingFn = func(_ io.Reader) (openpgp.EntityList, error) {
+		return nil, fmt.Errorf("injected keyring error")
+	}
+	t.Cleanup(func() { readArmoredKeyRingFn = old })
+
+	if verifyFlatcarSignature("anything") {
+		t.Error("keyring read error should return false")
 	}
 }


### PR DESCRIPTION
## Summary

The `return false` branch on `openpgp.ReadArmoredKeyRing` failure in `verifyFlatcarSignature()` was structurally unreachable because `flatcarSigningKeyASC` is a `//go:embed` compile-time constant — it can never produce a parse error.

Applies the same injectable-var pattern already used by `translateButane` (ignition/compile.go) and `fetchGitHubKeysFn` (tui/form_logic.go):

- Add `readArmoredKeyRingFn` package-level var wrapping `openpgp.ReadArmoredKeyRing`
- `verifyFlatcarSignature` calls through the var instead of directly
- Add `TestVerifyFlatcarSignature_KeyringReadError` to stub the fn and cover the `return false` path

Fixes #540