### PR TITLE
fix(headless): remove dead ToInstallConfig error branch

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -89,7 +89,7 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 // ToInstallConfig converts a headless Config to a model.InstallConfig.
-func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
+func (c *Config) ToInstallConfig() *model.InstallConfig {
 	cfg := &model.InstallConfig{
 		Arch:     c.Arch,
 		Channel:  c.Channel,
@@ -180,7 +180,7 @@ func (c *Config) ToInstallConfig() (*model.InstallConfig, error) {
 		cfg.UpdateStrategy.RebootStrategy = "reboot"
 	}
 
-	return cfg, nil
+	return cfg
 }
 
 // resolveSysexts fetches the bakery catalog for the given arch and matches each
@@ -444,10 +444,7 @@ func Run(ctx context.Context, cfg *Config, installer install.Installer, logger *
 	}
 
 	// Step 3: Convert to InstallConfig
-	installCfg, err := cfg.ToInstallConfig()
-	if err != nil {
-		return fmt.Errorf("converting config: %w", err)
-	}
+	installCfg := cfg.ToInstallConfig()
 	installCfg.Sysexts = resolvedSysexts
 
 	// Step 4: Full consistency check

--- a/internal/headless/headless_351_coverage_test.go
+++ b/internal/headless/headless_351_coverage_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/projectbluefin/knuckle/internal/model"
 )
 
-// TestToInstallConfig_NeverReturnsError documents that ToInstallConfig() currently
-// never returns an error (the error return exists for forward compatibility).
-// This means the error-handling path in Run() at line 448 is dead code.
-func TestToInstallConfig_NeverReturnsError(t *testing.T) {
-	// Exercise ToInstallConfig with various inputs to confirm no error is returned.
+// TestToInstallConfig_AlwaysBuildsInstallConfig verifies ToInstallConfig always
+// produces an InstallConfig for validated input shapes.
+func TestToInstallConfig_AlwaysBuildsInstallConfig(t *testing.T) {
 	cases := []struct {
 		name string
 		cfg  *Config
@@ -38,16 +36,16 @@ func TestToInstallConfig_NeverReturnsError(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.cfg.ToInstallConfig()
-			if err != nil {
-				t.Errorf("ToInstallConfig returned unexpected error: %v", err)
+			ic := tc.cfg.ToInstallConfig()
+			if ic == nil {
+				t.Fatal("ToInstallConfig returned nil config")
 			}
 		})
 	}
 }
 
 // TestRun_ToInstallConfigPathExercised verifies the full Run path passes through
-// ToInstallConfig without error, covering the L447-450 code path (the non-error branch).
+// config conversion and into install execution.
 func TestRun_ToInstallConfigPathExercised(t *testing.T) {
 	origFetch := fetchGitHubKeysFunc
 	defer func() { fetchGitHubKeysFunc = origFetch }()

--- a/internal/headless/headless_errorpaths_test.go
+++ b/internal/headless/headless_errorpaths_test.go
@@ -110,13 +110,9 @@ func TestRun_GitHubKeyInvalidFromRemote(t *testing.T) {
 	}
 }
 
-// TestRun_ToInstallConfigError tests the path (line 448) where ToInstallConfig
-// returns an error during Run. This requires a config that passes Validate()
-// but fails ToInstallConfig().
-func TestRun_ToInstallConfigError(t *testing.T) {
-	// ToInstallConfig can fail if update_strategy is unrecognized (Validate
-	// allows empty, but ToInstallConfig might reject it depending on logic).
-	// We test by passing a config with an arch that ToInstallConfig doesn't handle.
+// TestRun_InvalidUpdateStrategy_BlocksBeforeInstall verifies invalid
+// update_strategy is rejected at validation time and does not reach install.
+func TestRun_InvalidUpdateStrategy_BlocksBeforeInstall(t *testing.T) {
 	cfg := &Config{
 		Channel:        "stable",
 		Hostname:       "node01",
@@ -131,10 +127,14 @@ func TestRun_ToInstallConfigError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	err := Run(context.Background(), cfg, installer, logger)
-	// This test documents what happens with an invalid update_strategy.
-	// If Validate() catches it first, that's fine — we're testing the boundary.
 	if err == nil {
-		t.Log("NOTE: config passed both Validate and ToInstallConfig — adjust test input if coverage needed")
+		t.Fatal("expected validation error for invalid update_strategy")
+	}
+	if !strings.Contains(err.Error(), "validation failed: update_strategy") {
+		t.Errorf("expected validation failure for update_strategy, got: %v", err)
+	}
+	if installer.called {
+		t.Error("installer should not be called for invalid update_strategy")
 	}
 }
 

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -315,10 +315,7 @@ func TestToInstallConfig(t *testing.T) {
 		UpdateStrategy: "off",
 	}
 
-	installCfg, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	installCfg := cfg.ToInstallConfig()
 
 	if installCfg.Channel != "beta" {
 		t.Errorf("channel: got %q, want beta", installCfg.Channel)
@@ -349,10 +346,7 @@ func TestToInstallConfig_Defaults(t *testing.T) {
 		Disk:  "/dev/vdb",
 	}
 
-	installCfg, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	installCfg := cfg.ToInstallConfig()
 
 	if installCfg.Channel != "stable" {
 		t.Errorf("default channel: got %q, want stable", installCfg.Channel)
@@ -438,10 +432,7 @@ func TestToInstallConfig_StaticNetwork(t *testing.T) {
 		UpdateStrategy: "off",
 	}
 
-	installCfg, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	installCfg := cfg.ToInstallConfig()
 
 	if installCfg.Network.Mode != model.NetworkStatic {
 		t.Errorf("mode: got %v, want Static", installCfg.Network.Mode)
@@ -665,10 +656,7 @@ func TestToInstallConfig_DefaultArch(t *testing.T) {
 		Disk:           "/dev/vda",
 		UpdateStrategy: "reboot",
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.Arch != "amd64" {
 		t.Errorf("default arch: got %q, want \"amd64\"", ic.Arch)
 	}
@@ -734,10 +722,7 @@ func TestToInstallConfig_Arm64(t *testing.T) {
 		Disk:           "/dev/vda",
 		UpdateStrategy: "reboot",
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.Arch != "arm64" {
 		t.Errorf("got arch %q, want \"arm64\"", ic.Arch)
 	}
@@ -901,10 +886,7 @@ func TestToInstallConfig_NvidiaDriverVersionPropagation(t *testing.T) {
 		NvidiaDriverVersion: "570-open",
 	}
 
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.NvidiaDriverVersion != "570-open" {
 		t.Errorf("NvidiaDriverVersion not propagated: got %q, want \"570-open\"", ic.NvidiaDriverVersion)
 	}
@@ -920,10 +902,7 @@ func TestToInstallConfig_NvidiaDriverVersionEmpty(t *testing.T) {
 		Disk:     "/dev/vdb",
 	}
 
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.NvidiaDriverVersion != "" {
 		t.Errorf("NvidiaDriverVersion should be empty, got %q", ic.NvidiaDriverVersion)
 	}
@@ -1483,10 +1462,7 @@ func TestToInstallConfig_IgnitionURL_PropagatesCorrectly(t *testing.T) {
 		IgnitionURL: "https://myserver.example.com/nodes/prod-01.ign",
 	}
 
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.IgnitionURL != "https://myserver.example.com/nodes/prod-01.ign" {
 		t.Errorf("IgnitionURL = %q, want https://myserver.example.com/nodes/prod-01.ign", ic.IgnitionURL)
 	}
@@ -1510,10 +1486,7 @@ func TestToInstallConfig_PasswordOnlyUser_SetsPasswordHash(t *testing.T) {
 		Disk:     "/dev/sda",
 	}
 
-	installCfg, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig() error: %v", err)
-	}
+	installCfg := cfg.ToInstallConfig()
 
 	if len(installCfg.Users) == 0 {
 		t.Fatal("expected at least one user in install config")
@@ -1784,10 +1757,7 @@ func TestToInstallConfig_OmittedTailscaleSkipsIgnitionArtifacts(t *testing.T) {
 		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}}},
 	}
 
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 
 	gen := ignition.NewGenerator()
 	out, err := gen.GenerateButane(ic)
@@ -1813,10 +1783,7 @@ func TestToInstallConfig_TailscaleDefaultsMode(t *testing.T) {
 			Mode:    "", // should default to "connect"
 		},
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.Tailscale.Mode != "connect" {
 		t.Errorf("Tailscale.Mode = %q, want %q", ic.Tailscale.Mode, "connect")
 	}
@@ -1833,10 +1800,7 @@ func TestToInstallConfig_UserCustomGroups(t *testing.T) {
 			Groups:   []string{"wheel", "adm"},
 		}},
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if len(ic.Users) != 1 {
 		t.Fatalf("expected 1 user, got %d", len(ic.Users))
 	}
@@ -1853,10 +1817,7 @@ func TestToInstallConfig_DefaultTimezone(t *testing.T) {
 		Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}}},
 		Timezone: "", // should default to UTC
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.Timezone != "UTC" {
 		t.Errorf("Timezone = %q, want UTC", ic.Timezone)
 	}
@@ -1871,10 +1832,7 @@ func TestToInstallConfig_NonNilSwap(t *testing.T) {
 		Users:   []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz k"}}},
 		Swap:    &SwapConfig{Enabled: enabled, SizeMB: 512},
 	}
-	ic, err := cfg.ToInstallConfig()
-	if err != nil {
-		t.Fatalf("ToInstallConfig: %v", err)
-	}
+	ic := cfg.ToInstallConfig()
 	if ic.Swap.Enabled != false || ic.Swap.SizeMB != 512 {
 		t.Errorf("Swap = %+v, want {Enabled:false SizeMB:512}", ic.Swap)
 	}


### PR DESCRIPTION
## Summary
- simplify Config.ToInstallConfig to return *model.InstallConfig directly
- remove unreachable Run error handling around ToInstallConfig
- update headless tests to assert current behavior and replace obsolete dead-branch test with a strict validation-path test

## Testing
- go test ./internal/headless
- go test -cover ./internal/headless (99.1%)
- just ci (fails in cmd/knuckle on this non-interactive host with known /dev/tty Bubble Tea test limitation; same baseline failure)

Closes #562
