### PR TITLE
test(catalog_check): assert writer errors take precedence in strict mode

### DIFF
--- a/scripts/catalog_check/main_write_error_test.go
+++ b/scripts/catalog_check/main_write_error_test.go
@@ -90,6 +90,9 @@ func TestRun_WriteErrorPropagation_AllOutputWrites(t *testing.T) {
 				if err == nil {
 					t.Fatalf("failAt=%d: expected write error, got nil", failAt)
 				}
+				if errors.Is(err, errStrictViolation) {
+					t.Fatalf("failAt=%d: expected write error precedence over strict violation", failAt)
+				}
 				if !errors.Is(err, errInjectedWrite) {
 					t.Fatalf("failAt=%d: expected injected write error, got %v", failAt, err)
 				}
@@ -115,6 +118,9 @@ func TestRun_WriteErrorPropagation_StrictErrWriter(t *testing.T) {
 	err := run(context.Background(), stdout, stderr, fetcher, "amd64", true)
 	if err == nil {
 		t.Fatal("expected error when strict-mode stderr write fails")
+	}
+	if errors.Is(err, errStrictViolation) {
+		t.Fatal("expected write error precedence over strict violation")
 	}
 	if !errors.Is(err, errInjectedWrite) {
 		t.Fatalf("expected injected write error, got %v", err)


### PR DESCRIPTION
## Summary
- strengthens scripts/catalog_check/main_write_error_test.go for strict-mode writer-failure paths
- asserts injected io.Writer failures are returned as wrapped write errors, not errStrictViolation
- keeps behavior-focused coverage for issue #543 writer-error branches

## Why
Issue #543 tracks missing/fragile writer error coverage in scripts/catalog_check. These assertions lock in the intended precedence when strict mode and writer failures overlap.

## Testing
- TMPDIR=/var/home/jorge/src/knuckle/.worktrees/issue-543/.tmp GOCACHE=/var/home/jorge/src/knuckle/.worktrees/issue-543/.gocache go test -count=1 ./scripts/catalog_check
- TMPDIR=/var/home/jorge/src/knuckle/.worktrees/issue-543/.tmp GOCACHE=/var/home/jorge/src/knuckle/.worktrees/issue-543/.gocache go test -count=1 -cover ./scripts/catalog_check
- TMPDIR=/var/home/jorge/src/knuckle/.worktrees/issue-543/.tmp GOCACHE=/var/home/jorge/src/knuckle/.worktrees/issue-543/.gocache go vet ./scripts/catalog_check

Issue: https://github.com/projectbluefin/knuckle/issues/543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling verification tests to ensure correct error prioritization in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->