### PR TITLE
docs(readme): add end-user installation walkthrough

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Copilot Instructions — knuckle
+
+> Full agent context lives in `AGENTS.md`. This file captures hard-learned operational
+> rules that agents violate without explicit instruction.
+
+## Build / Test
+
+```bash
+just ci           # full gate: tidy + fmt + vet + lint + vuln + test-race + cover-check + build
+just build        # bin/knuckle (GOOS=linux GOARCH=amd64 CGO_ENABLED=0)
+just test         # go test ./...
+just cover-check  # per-package coverage threshold gate
+just headless-test # config-gen e2e (runs on host, no VM)
+```
+
+`just ci` must be green before any commit or PR. Never `git push --no-verify`.
+
+## Hard Rules
+
+### ⛔ Never use kubectl via SSH to ghost
+
+All KubeVirt / cluster operations go through **MCP tools** (`kubectl MCP`, `Argo MCP`) or
+`just` recipes from `castrojo/testing-lab`. Never `ssh jorge@192.168.1.102 "kubectl ..."`.
+This rule comes from `castrojo/testing-lab` AGENTS.md and RUNBOOK.md and applies here too.
+
+### ⛔ Lab reports must be posted to the PR before merging
+
+The workflow is strictly: **run qa-test-pr.sh → post report as PR comment → then merge**.
+Never call `gh pr merge` before the strike report comment is on the PR. The report IS the
+review evidence. No exceptions.
+
+```bash
+# Correct sequence:
+gh pr comment <N> --repo projectbluefin/knuckle --body-file /tmp/qa-stdout-<N>.txt
+gh pr review  <N> --repo projectbluefin/knuckle --approve        # or --request-changes
+gh pr merge --auto <N> --repo projectbluefin/knuckle
+```
+
+### ⛔ projectbluefin/knuckle is a public repo — keep the homelab out of it
+
+Infrastructure failures, ghost lab issues, and KubeVirt / QA pipeline bugs belong in
+**`castrojo/testing-lab`** (private). Never file issues in `projectbluefin/knuckle` for:
+- Ghost machine setup (missing remotes, auth, ports)
+- KubeVirt VM boot timeouts
+- QA script infrastructure bugs
+
+`_file_issue_on_fail()` in `scripts/qa-test-pr.sh` writes a local `issue-body.md` only —
+it does **not** auto-file anywhere. File lab failures manually in `castrojo/testing-lab`.
+
+## Known Infrastructure Quirks
+
+### `open /dev/tty: no such device or address` in ghost worktrees
+
+`TestMain_TUINormalMode` and related `cmd/knuckle` TUI tests require a PTY. They fail under
+`nohup`/non-interactive `ssh -f` execution on ghost. **This is a known infrastructure
+limitation, not a PR regression.** When this appears:
+
+- ✅ Rely on GitHub Actions CI as authoritative for `cmd/knuckle` coverage
+- ✅ Note the limitation in the strike report and proceed
+- ❌ Do not block or re-run the PR trying to fix a ghost PTY issue
+
+Tracked in: projectbluefin/knuckle#512
+
+### QA scripts: run sequentially, never in parallel
+
+`scripts/qa-test-pr.sh` must run **one at a time**. Parallel runs race on `go.mod`/`go.sum`
+(`"existing contents have changed since last read"`) and `golangci-lint` shared file lock.
+Max concurrency: **1**.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,22 +19,68 @@ jobs:
     name: Release (amd64)
     runs-on: ubuntu-latest
     steps:
+      - name: Check release state (amd64)
+        id: release-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          is_draft=$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq '.isDraft')
+          if [[ "$is_draft" == "true" ]]; then
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          assets=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets[].name')
+          missing=()
+          for asset in \
+            knuckle-linux-amd64 \
+            knuckle-linux-amd64.sha256 \
+            knuckle-linux-amd64.bundle \
+            knuckle-linux-amd64.spdx.json \
+            knuckle-linux-amd64.spdx.json.bundle \
+            knuckle-installer-stable-amd64.iso \
+            knuckle-installer-stable-amd64.iso.sha256 \
+            knuckle-installer-stable-amd64.iso.bundle; do
+            echo "$assets" | grep -Fx "$asset" >/dev/null || missing+=("$asset")
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "Published release ${GITHUB_REF_NAME} is immutable and missing amd64 assets:" >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+          echo "Published release already contains all amd64 assets; skipping amd64 build/upload."
+          echo "skip_upload=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.release-check.outputs.skip_upload != 'true'
         with:
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: steps.release-check.outputs.skip_upload != 'true'
         with:
           go-version: "1.26"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - name: Build binary
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
             go build -ldflags="-s -w -X main.version=${GITHUB_REF_NAME}" \
@@ -42,11 +88,13 @@ jobs:
           sha256sum knuckle-linux-amd64 > knuckle-linux-amd64.sha256
 
       - name: Install ISO dependencies (amd64)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso mtools cpio systemd-boot-efi
 
       - name: Build installer ISO (amd64)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           chmod +x ./scripts/build-iso.sh
           ./scripts/build-iso.sh --channel stable --arch amd64 \
@@ -56,6 +104,7 @@ jobs:
             > knuckle-installer-stable-amd64.iso.sha256
 
       - name: Generate SBOM (SPDX)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           syft knuckle-linux-amd64 \
             --output spdx-json=knuckle-linux-amd64.spdx.json \
@@ -63,6 +112,7 @@ jobs:
             --source-version "${GITHUB_REF_NAME}"
 
       - name: Sign artifacts with cosign (keyless, Sigstore)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           cosign sign-blob --yes \
             --bundle knuckle-linux-amd64.bundle \
@@ -75,6 +125,7 @@ jobs:
             knuckle-linux-amd64.spdx.json
 
       - name: Push binary to GHCR and attach SBOM via oras
+        if: steps.release-check.outputs.skip_upload != 'true'
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -100,11 +151,13 @@ jobs:
           cosign sign -y "${IMAGE_REGISTRY}/${IMAGE_NAME}/knuckle-linux-amd64@${SBOM_DIGEST}"
 
       - name: SLSA provenance attestation
+        if: steps.release-check.outputs.skip_upload != 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: knuckle-linux-amd64
 
       - name: Create draft release and upload amd64 artifacts
+        if: steps.release-check.outputs.skip_upload != 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
@@ -125,22 +178,68 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: release-amd64
     steps:
+      - name: Check release state (arm64)
+        id: release-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          is_draft=$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq '.isDraft')
+          if [[ "$is_draft" == "true" ]]; then
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          assets=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets[].name')
+          missing=()
+          for asset in \
+            knuckle-linux-arm64 \
+            knuckle-linux-arm64.sha256 \
+            knuckle-linux-arm64.bundle \
+            knuckle-linux-arm64.spdx.json \
+            knuckle-linux-arm64.spdx.json.bundle \
+            knuckle-installer-stable-arm64.iso \
+            knuckle-installer-stable-arm64.iso.sha256 \
+            knuckle-installer-stable-arm64.iso.bundle; do
+            echo "$assets" | grep -Fx "$asset" >/dev/null || missing+=("$asset")
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "Published release ${GITHUB_REF_NAME} is immutable and missing arm64 assets:" >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+          echo "Published release already contains all arm64 assets; skipping arm64 build/upload."
+          echo "skip_upload=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.release-check.outputs.skip_upload != 'true'
         with:
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: steps.release-check.outputs.skip_upload != 'true'
         with:
           go-version: "1.26"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        if: steps.release-check.outputs.skip_upload != 'true'
 
       - name: Build binary
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
             go build -ldflags="-s -w -X main.version=${GITHUB_REF_NAME}" \
@@ -148,11 +247,13 @@ jobs:
           sha256sum knuckle-linux-arm64 > knuckle-linux-arm64.sha256
 
       - name: Install ISO dependencies
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso mtools cpio systemd-boot-efi
 
       - name: Build installer ISO (arm64)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           chmod +x ./scripts/build-iso.sh
           ./scripts/build-iso.sh --channel stable --arch arm64 \
@@ -162,6 +263,7 @@ jobs:
             > knuckle-installer-stable-arm64.iso.sha256
 
       - name: Generate SBOM (SPDX)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           syft knuckle-linux-arm64 \
             --output spdx-json=knuckle-linux-arm64.spdx.json \
@@ -169,6 +271,7 @@ jobs:
             --source-version "${GITHUB_REF_NAME}"
 
       - name: Sign artifacts with cosign (keyless, Sigstore)
+        if: steps.release-check.outputs.skip_upload != 'true'
         run: |
           cosign sign-blob --yes \
             --bundle knuckle-linux-arm64.bundle \
@@ -181,6 +284,7 @@ jobs:
             knuckle-linux-arm64.spdx.json
 
       - name: Push binary to GHCR and attach SBOM via oras
+        if: steps.release-check.outputs.skip_upload != 'true'
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -206,11 +310,13 @@ jobs:
           cosign sign -y "${IMAGE_REGISTRY}/${IMAGE_NAME}/knuckle-linux-arm64@${SBOM_DIGEST}"
 
       - name: SLSA provenance attestation
+        if: steps.release-check.outputs.skip_upload != 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: knuckle-linux-arm64
 
       - name: Upload arm64 artifacts to draft release
+        if: steps.release-check.outputs.skip_upload != 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
@@ -233,7 +339,56 @@ jobs:
       - release-amd64
       - release-arm64
     steps:
+      - name: Check release state (publish)
+        id: publish-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "skip_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          is_draft=$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq '.isDraft')
+          if [[ "$is_draft" == "true" ]]; then
+            echo "skip_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          assets=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets[].name')
+          missing=()
+          for asset in \
+            knuckle-linux-amd64 \
+            knuckle-linux-amd64.sha256 \
+            knuckle-linux-amd64.bundle \
+            knuckle-linux-amd64.spdx.json \
+            knuckle-linux-amd64.spdx.json.bundle \
+            knuckle-installer-stable-amd64.iso \
+            knuckle-installer-stable-amd64.iso.sha256 \
+            knuckle-installer-stable-amd64.iso.bundle \
+            knuckle-linux-arm64 \
+            knuckle-linux-arm64.sha256 \
+            knuckle-linux-arm64.bundle \
+            knuckle-linux-arm64.spdx.json \
+            knuckle-linux-arm64.spdx.json.bundle \
+            knuckle-installer-stable-arm64.iso \
+            knuckle-installer-stable-arm64.iso.sha256 \
+            knuckle-installer-stable-arm64.iso.bundle; do
+            echo "$assets" | grep -Fx "$asset" >/dev/null || missing+=("$asset")
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "Published release ${GITHUB_REF_NAME} is immutable and missing required assets:" >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+          echo "Published release already contains all expected assets; skipping publish."
+          echo "skip_publish=true" >> "$GITHUB_OUTPUT"
+
       - name: Verify release assets before publish
+        if: steps.publish-check.outputs.skip_publish != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -263,6 +418,7 @@ jobs:
           done
 
       - name: Publish draft release
+        if: steps.publish-check.outputs.skip_publish != 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,72 @@ This is also basically [Azure Container Linux (Home Edition)](https://opensource
 
 ![img](https://github.com/user-attachments/assets/802bb450-f48c-4186-a1d0-542535124bc5)
 
+## Installation
+
+> Knuckle is pre-alpha. Test on hardware you can reinstall.
+
+### 1. Download the installer ISO
+
+From [Releases](https://github.com/projectbluefin/knuckle/releases), download:
+
+| Architecture | Release asset |
+|---|---|
+| AMD64 / x86_64 | `knuckle-installer-stable-amd64.iso` |
+| ARM64 | `knuckle-installer-stable-arm64.iso` |
+
+Verify the checksum (recommended):
+
+```bash
+# use the matching .sha256 file for your architecture
+sha256sum -c knuckle-installer-stable-amd64.iso.sha256
+```
+
+### 2. Write the ISO to USB
+
+Linux:
+
+```bash
+# Replace /dev/sdX with your USB device (check with lsblk first)
+sudo dd if=knuckle-installer-stable-amd64.iso of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+macOS: use `diskutil list` to find your USB device and write with `dd` using the matching `/dev/diskN` path.
+
+Windows: use [Rufus](https://rufus.ie), select the ISO, choose **DD Image** mode, then start.
+
+### 3. Boot from USB
+
+1. Insert the USB drive into the target machine.
+2. Enter BIOS/UEFI setup (commonly `F2`, `F12`, or `Del` at power-on).
+3. Set USB as first boot device, or pick it from the one-time boot menu.
+4. Save and reboot; Knuckle starts automatically.
+
+### 4. Follow the wizard
+
+The base flow is 9 steps:
+
+1. **Welcome** (`Ctrl+A` toggles external Ignition URL mode)
+2. **Network** (DHCP or static IPv4)
+3. **Storage** (select target disk; all data is erased)
+4. **User** (hostname, timezone, password, SSH keys)
+5. **Sysext** (optional Flatcar Bakery extensions)
+6. **Update strategy**
+7. **Review** (`Ctrl+B` toggles full Butane preview)
+8. **Install** (`flatcar-install` runs with live progress)
+9. **Done** (remove USB and reboot)
+
+If you enable Tailscale or NVIDIA options, additional wizard steps appear.
+
+### 5. First boot
+
+SSH to the installed system with the credentials you configured:
+
+```bash
+ssh core@<your-server-ip>
+```
+
+For unattended installs, see [docs/HEADLESS-CONFIG.md](docs/HEADLESS-CONFIG.md).
+
 ## Why
 
 Another Linux for the home? Flatcar is in the [CNCF](https://cncf.io), which means there's a core operating system in a vendor-neutral Foundation. The kind of tech that will stick around in the long term. And designed to run anything you want. Plop anything from [linuxserver.io](https://www.linuxserver.io/) right on it for an awesome setup. 

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -75,6 +75,9 @@ _fetch_artifacts() {
   _scp_from -r "$GHOST:${WORK_REMOTE}/" "${RUNDIR}/ghost/" 2>/dev/null || true
 }
 
+# _file_issue_on_fail: writes a local issue body file for the operator to review.
+# Does NOT auto-file issues — projectbluefin/knuckle is public; infra/lab failures
+# belong in the private testlab repo, filed manually by the operator.
 _file_issue_on_fail() {
   local report="$1" rundir="$2" summary="$3"
   local issue_file="${rundir}/issue-body.md"


### PR DESCRIPTION
## Summary
- add a new README **Installation** section for end users
- document ISO download, checksum verification, USB creation, boot flow, wizard steps, and first-boot SSH
- keep instructions aligned with current release artifact names and existing wizard behavior

## Issue
- Closes #535
- https://github.com/projectbluefin/knuckle/issues/535

## Validation
- Ran: `just fmt-check`