### PR TITLE
ci(release): run amd64 + arm64 jobs in parallel via create-release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,24 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  create-release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Create or verify draft release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        with:
+          draft: true
+          make_latest: "false"
+          generate_release_notes: true
+
   release-amd64:
     name: Release (amd64)
     runs-on: ubuntu-latest
+    needs: create-release
     steps:
       - name: Check release state (amd64)
         id: release-check
@@ -156,13 +171,13 @@ jobs:
         with:
           subject-path: knuckle-linux-amd64
 
-      - name: Create draft release and upload amd64 artifacts
+      - name: Upload amd64 artifacts to draft release
         if: steps.release-check.outputs.skip_upload != 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
           make_latest: "false"
-          generate_release_notes: true
+          generate_release_notes: false
           files: |
             knuckle-linux-amd64
             knuckle-linux-amd64.sha256
@@ -176,7 +191,7 @@ jobs:
   release-arm64:
     name: Release (arm64)
     runs-on: ubuntu-24.04-arm
-    needs: release-amd64
+    needs: create-release
     steps:
       - name: Check release state (arm64)
         id: release-check


### PR DESCRIPTION
## Problem

`release-arm64` had `needs: release-amd64`, running them sequentially. On tag retry or workflow re-run, the `publish` job could mark the release immutable before arm64 could upload — root cause of v0.7.0 missing all arm64 artifacts (#508).

## Solution

Add a `create-release` job that creates the empty draft release first. Both arch jobs depend on `create-release` and run **in parallel**. `publish` still gates on both.

```
Before: create-release → release-amd64 → release-arm64 → publish
After:  create-release → release-amd64 ─┬→ publish
                       → release-arm64 ─┘
```

## Changes

- `.github/workflows/release.yml`: new `create-release` job; `release-amd64` and `release-arm64` both `needs: create-release`; `generate_release_notes` moved to `create-release` (set to `false` on arch upload steps)

## Testing

Tier 0 — CI only. The next release tag will produce 16 assets: 8 × amd64 + 8 × arm64.

Closes part of #508.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release workflow to consolidate release note generation and improve the artifact upload process across build architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->