### PR TITLE
test(validate): cover BlockDevice success path via discoverable block device

### DIFF
--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -240,6 +241,29 @@ func TestBlockDevice_PermissionDenied(t *testing.T) {
 	// Must NOT say "not found" — that would mean IsNotExist hit instead.
 	if strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected generic stat error, got not-found message: %v", err)
+	}
+}
+
+func TestBlockDevice_Success(t *testing.T) {
+	// Find any block device that stat(2) can read (no read permission needed).
+	candidates := []string{"/dev/sda", "/dev/vda", "/dev/nvme0n1", "/dev/loop0", "/dev/zram0"}
+	var blkdev string
+	for _, dev := range candidates {
+		info, err := os.Stat(dev)
+		if err != nil {
+			continue
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if ok && st.Mode&syscall.S_IFMT == syscall.S_IFBLK {
+			blkdev = dev
+			break
+		}
+	}
+	if blkdev == "" {
+		t.Skip("no accessible block device found for test (CI may have none)")
+	}
+	if err := BlockDevice(blkdev); err != nil {
+		t.Errorf("BlockDevice(%q) = %v, want nil", blkdev, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `TestBlockDevice_Success` to cover the happy-path `return nil` in `validate.BlockDevice`.

`BlockDevice()` was at 88.9% coverage — the only uncovered statement was `return nil` (the success path when the path points to an actual block device). All error branches were already tested.

## Approach

`stat(2)` does **not** require read permission — it only reads inode metadata. So we can stat `/dev/sda`, `/dev/loop0`, etc. without being root or in the `disk` group. The test scans a list of common block device paths, picks the first one that `stat` confirms as `S_IFBLK`, and calls `BlockDevice()` expecting `nil`.

If no block device is found (some CI containers), the test calls `t.Skip` — it never blocks CI on restricted environments.

## Coverage impact

`internal/validate`: **99.4% → 100.0%**

Closes #591