### PR TITLE
refactor(tui): remove dead nil-activeForm guards and stub renderSystemChecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ cover.html
 .iso-build/
 output/
 cover_tui.out
+
+# Local worktrees (never committed)
+.worktrees/
+coverage.txt

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -67,9 +67,6 @@ func (m *Model) onFormComplete() tea.Cmd {
 		if err := validate.Channel(cfg.Channel); err != nil {
 			m.err = err
 			m.initForm()
-			if m.activeForm != nil {
-				return m.activeForm.Init()
-			}
 			return nil
 		}
 		if cfg.IgnitionURL != "" {
@@ -78,9 +75,6 @@ func (m *Model) onFormComplete() tea.Cmd {
 			m.cursor = 0
 			m.initStepFields()
 			m.initForm()
-			if m.activeForm != nil {
-				return m.activeForm.Init()
-			}
 			return nil
 		}
 
@@ -123,10 +117,7 @@ func (m *Model) onFormComplete() tea.Cmd {
 		if err := m.Wizard.ValidateCurrentStep(); err != nil {
 			m.err = err
 			m.initForm()
-			if m.activeForm != nil {
-				return m.activeForm.Init()
-			}
-			return nil
+			return m.activeForm.Init()
 		}
 
 	case model.StepReview:
@@ -137,9 +128,6 @@ func (m *Model) onFormComplete() tea.Cmd {
 			m.cursor = 0
 			m.initStepFields()
 			m.initForm()
-			if m.activeForm != nil {
-				return m.activeForm.Init()
-			}
 			return nil
 		}
 		// Advance to install
@@ -162,10 +150,7 @@ func (m *Model) onFormComplete() tea.Cmd {
 	if err := m.Wizard.Next(); err != nil {
 		m.err = err
 		m.initForm()
-		if m.activeForm != nil {
-			return m.activeForm.Init()
-		}
-		return nil
+		return m.activeForm.Init()
 	}
 	m.err = nil
 	m.cursor = 0
@@ -184,15 +169,6 @@ func (m *Model) viewWithForm() string {
 	// Breadcrumb navigation (conversational style)
 	b.WriteString(m.buildBreadcrumb())
 	b.WriteString("\n")
-
-	// System checks — only on Welcome step, only if warn/fail
-	if m.Wizard.State.CurrentStep == model.StepWelcome {
-		checksStr := m.renderSystemChecks()
-		if checksStr != "" {
-			b.WriteString(checksStr)
-			b.WriteString("\n")
-		}
-	}
 
 	// Form
 	if m.activeForm != nil {

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -261,11 +261,6 @@ func (m *Model) buildBreadcrumb() string {
 	return m.renderZenChrome()
 }
 
-// renderSystemChecks absorbed into zen chrome — returns empty.
-func (m *Model) renderSystemChecks() string {
-	return ""
-}
-
 // renderZenChrome creates the ANSI-art inspired header.
 // Aesthetic: clean framed letterform, cool blue palette, scene-era vibes.
 // Info shown via color hierarchy — version numbers always visible.

--- a/internal/tui/quality_onformcomplete_test.go
+++ b/internal/tui/quality_onformcomplete_test.go
@@ -9,7 +9,6 @@ package tui
 //   - form_logic.go:66-68   onFormComplete StepWelcome invalid channel → nil form
 //   - form_logic.go:77-79   onFormComplete StepWelcome IgnitionURL skip → nil form
 //   - form_logic.go:162-168 onFormComplete fallthrough Next() error → re-inits form
-//   - form_logic.go:191-194 viewWithForm checksStr dead-code (renderSystemChecks = "")
 //   - form_logic.go:103-109 onFormComplete StepUser githubUserInput → async cmd
 //   - form_logic.go:136-138 onFormComplete StepReview unconfirmed go-back → nil form
 
@@ -246,23 +245,5 @@ func TestOnFormComplete_NetworkStep_StaticNextError_ReinitsForm(t *testing.T) {
 	// Wizard must not have advanced past StepNetwork.
 	if m.Wizard.State.CurrentStep != model.StepNetwork {
 		t.Errorf("expected wizard to remain at StepNetwork, got %v", m.Wizard.State.CurrentStep)
-	}
-}
-
-// ── form_logic.go:191-194  renderSystemChecks dead-code invariant ────────────
-
-// TestRenderSystemChecks_AlwaysEmpty documents that renderSystemChecks()
-// unconditionally returns "" (forms.go comment: "renderSystemChecks absorbed
-// into zen chrome — returns empty"). This makes the checksStr guard in
-// viewWithForm (form_logic.go:191-194) permanently unreachable.
-//
-// The test exists to catch a regression if someone adds logic to
-// renderSystemChecks() without updating or removing the guard in viewWithForm.
-func TestRenderSystemChecks_AlwaysEmpty(t *testing.T) {
-	w := newTestWizard()
-	m := New(w)
-
-	if got := m.renderSystemChecks(); got != "" {
-		t.Errorf("renderSystemChecks() must return empty string (absorbed into zen chrome), got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Remove dead code in `internal/tui` that was structurally unreachable.

### What was removed

**`renderSystemChecks` stub + callers** (forms.go, form_logic.go)
- `renderSystemChecks()` unconditionally returns `""` (comment: *"absorbed into zen chrome"*)
- The `checksStr != ""` guard in `viewWithForm` was therefore permanently unreachable
- Removed the stub, the call site, and the dead guard block entirely

**Five dead `if m.activeForm != nil` guards** in `onFormComplete` (form_logic.go)

| Location | Why dead |
|---|---|
| StepWelcome invalid channel | `initForm()` for StepWelcome always sets `nil` (card UI, no huh form) |
| StepWelcome IgnitionURL skip | `GoToStep(StepStorage)` + `initForm()` always sets `nil` (Storage has no huh form) |
| StepTailscale validation error | `initForm()` for StepTailscale always sets non-nil form — simplified to direct `activeForm.Init()` |
| StepReview go-back | `Previous()` lands on StepUpdate which has no huh form |
| Fallthrough Next() error | `onFormComplete` is only invoked from huh form steps (Network/User/Tailscale); these always rebuild a non-nil form |

**Removed test** `TestRenderSystemChecks_AlwaysEmpty` — it was testing the stub; now the stub is gone.

## Coverage impact

`internal/tui`: **98.1% → 98.7%** (dead statements removed, not untested ones added)

Closes #597 #599