### PR TITLE
test(catalog_check): cover newCatalogFetcher default factory closure

### DIFF
--- a/scripts/catalog_check/main_test.go
+++ b/scripts/catalog_check/main_test.go
@@ -186,3 +186,12 @@ func (f *archCaptureFetcher) FetchCatalogArch(_ context.Context, arch string) ([
 	*f.archPtr = arch
 	return nil, nil
 }
+
+func TestNewCatalogFetcher_ReturnsNonNil(t *testing.T) {
+	// newCatalogFetcher is the default injectable factory. Verify the default
+	// closure returns a non-nil CatalogFetcher (bakery.HTTPClient).
+	f := newCatalogFetcher()
+	if f == nil {
+		t.Fatal("newCatalogFetcher() returned nil")
+	}
+}


### PR DESCRIPTION
## Summary

Add a one-line test to cover the only uncovered statement in `scripts/catalog_check`: the body of the `newCatalogFetcher` default closure.

## Context

All tests call `mainWithArgs(...)` which accepts a custom `CatalogFetcher`, bypassing the default factory. The default closure body (`return bakery.NewHTTPClient()`) was never exercised.

The test calls `newCatalogFetcher()` directly and asserts non-nil. No network call is made — `bakery.NewHTTPClient()` just constructs a client struct.

## Coverage impact

`scripts/catalog_check`: **99.0% → 100.0%**

Closes #543