### PR TITLE
refactor(tui): remove dead nil-activeForm guards in handleEnter

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -250,9 +250,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cursor = 0
 			m.initStepFields()
 			m.initForm()
-			if m.activeForm != nil {
-				return m, m.activeForm.Init()
-			}
 			return m, nil
 		}
 		return m, cmd
@@ -460,9 +457,6 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 			m.cursor = 0
 			m.initStepFields()
 			m.initForm()
-			if m.activeForm != nil {
-				return m, m.activeForm.Init()
-			}
 			return m, nil
 		}
 	case model.StepStorage:
@@ -480,10 +474,7 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 			m.cursor = 0
 			m.initStepFields()
 			m.initForm()
-			if m.activeForm != nil {
-				return m, m.activeForm.Init()
-			}
-			return m, nil
+			return m, m.activeForm.Init()
 		}
 	case model.StepNvidia:
 		// Confirm the cursor-selected driver series.
@@ -549,9 +540,6 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 	m.initStepFields()
 	m.initForm()
 
-	if m.Wizard.State.CurrentStep == model.StepDone {
-		return m, tea.Quit
-	}
 	if m.activeForm != nil {
 		return m, m.activeForm.Init()
 	}
@@ -980,10 +968,8 @@ func (m *Model) renderDetailPanel(ext model.SysextEntry) string {
 	}
 
 	// Content width: terminal width minus 8-space indent and 4 border chars (│ ... │).
+	// With effectiveWidth ≥ 60 (guaranteed above), panelWidth ≥ min(52,28) = 28.
 	panelWidth := min(52, effectiveWidth-32)
-	if panelWidth < 20 {
-		return ""
-	}
 
 	// Resolve long description and caveats from the curated catalog.
 	longDesc := ext.Description


### PR DESCRIPTION
## Summary

Remove five more dead nil-activeForm guards in `tui.go`, continuing the cleanup from #611 (`form_logic.go` and `forms.go`).

### Changes

| Location | What was dead | Why |
|---|---|---|
| `Update` StateAborted (line 253–255) | `if m.activeForm != nil { return m, .Init() }` | `Previous()` from any huh-form step lands on a non-form step (Welcome→Storage, User→Storage, Tailscale→Nvidia/Sysext, Review→Update); `initForm()` always sets nil |
| `handleEnter` StepWelcome IgnitionURL (line 463–465) | `if m.activeForm != nil { return m, .Init() }` | GoToStep(StepStorage); Storage has no form |
| `handleEnter` StepStorage IgnitionURL (line 483–485) | `return m, nil` after form guard | GoToStep(StepReview); Review always has a form — simplified to direct `.Init()` call |
| `handleEnter` StepDone check (line 546–548) | `if StepDone { return m, tea.Quit }` | Outer `Wizard.Next()` in handleEnter is never called from steps that transition to StepDone; Install exits early, Review uses onFormComplete |
| `renderDetailPanel` panelWidth guard (line 972–974) | `if panelWidth < 20 { return "" }` | `effectiveWidth >= 60` guard (line 966) guarantees `panelWidth = min(52, effectiveWidth-32) >= 28` |

## Coverage impact

`handleEnter`: **91.7% → 95.5%** on current main  
Overall `internal/tui`: **98.1% → 98.6%** on this branch (will rise further when #611 merges)