### PR TITLE
chore: raise coverage gates to match current actual coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,23 +80,23 @@ just e2e                 # build ISO → boot in QEMU GTK window → interactive
 ## Package Boundaries
 
 Coverage numbers are authoritative in [`docs/CI-AND-TESTING.md`](docs/CI-AND-TESTING.md#coverage-gate).
-Current values (as of 2026-05-25, `just cover-check`):
+Current values (as of 2026-05-28, `just cover-check`):
 
 | Package           | Responsibility                                                     | Coverage |
 | ----------------- | ------------------------------------------------------------------ | -------- |
 | `cmd/knuckle`     | CLI entrypoint, flag parsing, runner wiring                        | n/a      |
 | `internal/model`  | Pure data types — `InstallConfig`, `DiskInfo`, `NetworkInterface`  | 100%     |
-| `internal/runner` | `Runner` interface: `RealRunner`, `DryRunner`, `SpyRunner`         | 81%      |
-| `internal/probe`  | `lsblk` + `ip addr` JSON parsing, `/dev/disk/by-id` resolution     | 81%      |
-| `internal/validate` | Hostname, CIDR, gateway, SSH key, timezone, disk path validators | 97%      |
-| `internal/bakery` | sysext catalog + Flatcar release/SBOM fetchers, SHA512 check       | 97.8%    |
-| `internal/github` | SSH key fetch + GitHub Releases API client                         | 90%      |
-| `internal/ignition` | Butane assembly + in-process Butane→Ignition compilation         | 93%      |
-| `internal/install` | `flatcar-install` orchestration via runner                        | 98.8%    |
+| `internal/runner` | `Runner` interface: `RealRunner`, `DryRunner`, `SpyRunner`         | 100%     |
+| `internal/probe`  | `lsblk` + `ip addr` JSON parsing, `/dev/disk/by-id` resolution     | 100%     |
+| `internal/validate` | Hostname, CIDR, gateway, SSH key, timezone, disk path validators | 100%     |
+| `internal/bakery` | sysext catalog + Flatcar release/SBOM fetchers, SHA512 check       | 100%     |
+| `internal/github` | SSH key fetch + GitHub Releases API client                         | 97%      |
+| `internal/ignition` | Butane assembly + in-process Butane→Ignition compilation         | 100%     |
+| `internal/install` | `flatcar-install` orchestration via runner                        | 100%     |
 | `internal/iso`    | Installer ISO builder helpers                                      | 100%     |
-| `internal/headless` | `--headless --config` JSON-driven install path                   | 98.5%    |
+| `internal/headless` | `--headless --config` JSON-driven install path                   | 99%      |
 | `internal/wizard` | Step state machine, navigation, validation gates                   | 99.5%    |
-| `internal/tui`    | Bubble Tea view models (one sub-model per step), forms             | 94.1%    |
+| `internal/tui`    | Bubble Tea view models (one sub-model per step), forms             | 98.7%    |
 
 Targets enforced by `just cover-check` are deliberately set ≤ current numbers
 so the gate guards against *regression*. Long-term aspirations live in

--- a/Justfile
+++ b/Justfile
@@ -113,9 +113,9 @@ cover-check:
     #!/usr/bin/env bash
     set -euo pipefail
     declare -A targets=(
-        [model]=99  [validate]=98  [ignition]=97  [github]=93
-        [bakery]=96 [probe]=97     [runner]=99    [install]=97
-        [headless]=97 [wizard]=98  [iso]=99       [tui]=94
+        [model]=100 [validate]=100 [ignition]=100 [github]=96
+        [bakery]=100 [probe]=100   [runner]=100   [install]=100
+        [headless]=99 [wizard]=99  [iso]=100      [tui]=98
         [demo]=100
     )
     fail=0
@@ -136,7 +136,7 @@ cover-check:
         fi
     done
     script_pkg=scripts/catalog_check
-    script_target=95
+    script_target=100
     script_pct=$(go test -count=1 -cover ./${script_pkg} 2>/dev/null \
         | awk '/coverage:/ {gsub("%",""); print $(NF-2); exit}')
     script_pct=${script_pct%.*}

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -36,24 +36,24 @@
 ## Coverage Gate
 
 `just cover-check` enforces per-package thresholds. Current numbers as of
-2026-05-26:
+2026-05-28:
 
 | Package                      | Now    | Gate | Aspiration (TEST-PLAN.md) |
 | ---------------------------- | ------ | ---- | ------------------------- |
-| `internal/model`             |  100%  |  99% | ≥ 90%                     |
-| `internal/iso`               |  100%  |  99% | (n/a)                     |
-| `internal/runner`            |  100%  |  99% | ≥ 80%                     |
+| `internal/model`             |  100%  | 100% | ≥ 90%                     |
+| `internal/iso`               |  100%  | 100% | (n/a)                     |
+| `internal/runner`            |  100%  | 100% | ≥ 80%                     |
 | `internal/demo`              |  100%  | 100% | (n/a)                     |
-| `internal/validate`          |  99.4% |  98% | ≥ 95%                     |
-| `internal/wizard`            |  99.5% |  98% | ≥ 85%                     |
-| `internal/probe`             |  98.9% |  97% | ≥ 85%                     |
-| `internal/install`           |  98.8% |  97% | ≥ 80%                     |
-| `internal/ignition`          |  98.1% |  97% | ≥ 90%                     |
-| `internal/headless`          |  98.6% |  97% | (n/a)                     |
-| `internal/bakery`            |  97.8% |  96% | ≥ 85%                     |
-| `internal/tui`               |  95.6% |  94% | ≥ 85%                     |
-| `internal/github`            |  94.4% |  93% | (n/a)                     |
-| `scripts/catalog_check`      |  99.0% |  95% | (n/a)                     |
+| `internal/validate`          |  100%  | 100% | ≥ 95%                     |
+| `internal/probe`             |  100%  | 100% | ≥ 85%                     |
+| `internal/install`           |  100%  | 100% | ≥ 80%                     |
+| `internal/ignition`          |  100%  | 100% | ≥ 90%                     |
+| `internal/bakery`            |  100%  | 100% | ≥ 85%                     |
+| `scripts/catalog_check`      |  100%  | 100% | (n/a)                     |
+| `internal/wizard`            |  99.5% |  99% | ≥ 85%                     |
+| `internal/headless`          |  99%   |  99% | (n/a)                     |
+| `internal/tui`               |  98.7% |  98% | ≥ 85%                     |
+| `internal/github`            |  97%   |  96% | (n/a)                     |
 
 Gates are set conservatively below current numbers so CI fails on
 **regression**, not on aspirational drift. When a package's actual coverage


### PR DESCRIPTION
## Summary

Raises all `just cover-check` gate thresholds in `Justfile` to match the coverage that has been achieved by the quality improvement PRs (#610–#613). Also updates `AGENTS.md` and `docs/CI-AND-TESTING.md` to reflect current actual coverage.

## New gates

| Package | Old gate | New gate | Actual |
|---|---|---|---|
| model, iso, runner, probe, validate, bakery, ignition, install | 97–99% | **100%** | 100% |
| scripts/catalog_check | 95% | **100%** | 100% |
| wizard | 98% | **99%** | 99.5% |
| headless | 97% | **99%** | 99% |
| tui | 94% | **98%** | 98.7% |
| github | 93% | **96%** | 97% |

## Why

Gates are set conservatively below current actuals (per `CI-AND-TESTING.md` design) to catch regressions without requiring perfection. The old gates were stale — set before the quality sprint that pushed most packages to 100%.

## Affected files

- `Justfile` — `cover-check` targets
- `AGENTS.md` — package coverage table (was last updated 2026-05-25)
- `docs/CI-AND-TESTING.md` — coverage table (was last updated 2026-05-26)