### PR TITLE
docs: slim AGENTS.md to pointer doc; move workflow content to docs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,29 @@
 # knuckle — Agent Context
 
-> **Audience:** AI coding agents (Claude Code, pi, Copilot, Cursor). Humans want
-> `README.md`. This file is the authoritative description of how to work in this
-> repo without breaking it.
+> **Audience:** AI coding agents (Claude Code, pi, Copilot, Cursor). Humans want `README.md`.
 >
-> **Bar:** match CNCF-incubating rigor. Every change must keep `just ci` green,
-> respect the package boundaries, and preserve the safety invariants below.
+> **Bar:** CNCF-incubating rigor. Every change keeps `just ci` green, respects package
+> boundaries, and preserves the safety invariants below.
 
 ---
 
 ## What This Repo Is
 
-A modern TUI installer for [Flatcar Container Linux](https://www.flatcar.org/),
-targeting bare-metal deployments. Built in Go on the charm.sh stack (Bubble Tea
-v2, Lip Gloss v2, Huh v2). The wizard assembles an Ignition config and hands
-off to `flatcar-install` — knuckle never writes partitions itself.
+A TUI installer for [Flatcar Container Linux](https://www.flatcar.org/), targeting bare-metal.
+Built in Go on charm.sh (Bubble Tea v2, Lip Gloss v2, Huh v2). Assembles an Ignition config
+and hands off to `flatcar-install` — knuckle never writes partitions itself.
 
 - **Module:** `github.com/projectbluefin/knuckle` (Go 1.26+)
 - **License:** Apache-2.0
-- **Status:** v0.7.0 released; full install → reboot → SSH verified end-to-end in QEMU; dual-arch ISOs (amd64 + arm64); cosign keyless signing on releases.
-- **Distribution:** `knuckle` binary + installer ISO produced from
-  `.github/workflows/release.yml` on `v*` tags.
+- **Status:** v0.7.0; full install → reboot → SSH verified end-to-end in QEMU; dual-arch ISOs (amd64 + arm64); cosign keyless signing on releases.
 
 ## v1 Supported Scope
 
-- **Architecture:** x86_64 + ARM64 (dual-arch ISOs since v0.4.0)
-- **Storage:** single target disk (no RAID, LVM, LUKS)
-- **Networking:** DHCP + simple static IPv4 only
-- **UI Language:** English only
-- **Sysexts:** official Flatcar Bakery entries only (via GitHub Releases API)
-- **Config mode:** guided local generation OR external Ignition URL passthrough
-  (`Ctrl+A`) — mutually exclusive, no merging
+- Architecture: x86_64 + ARM64
+- Storage: single target disk (no RAID, LVM, LUKS)
+- Networking: DHCP + simple static IPv4 only
+- Sysexts: official Flatcar Bakery entries only (via GitHub Releases API)
+- Config: guided TUI OR external Ignition URL passthrough (`Ctrl+A`) — mutually exclusive
 
 Anything outside this list belongs in an issue, not a PR.
 
@@ -39,78 +32,61 @@ Anything outside this list belongs in an issue, not a PR.
 ## Build / Test / Lint
 
 ```bash
-just              # list recipes
+just              # list all recipes
 just ci           # tidy + gofmt + vet + lint + vuln + test-race + cover-check + build
 just build        # GOOS=linux GOARCH=amd64 CGO_ENABLED=0 → bin/knuckle
 just test         # go test ./...
-just fmt          # gofmt -w .
-just fmt-check    # CI gate: fails if any file is not gofmt-clean
-just vuln         # govulncheck ./...  (auto-installs into $GOBIN)
-just cover        # statement coverage profile → cover.out, prints total
 just cover-check  # per-package coverage threshold gate
-just headless-test       # build + run a canned JSON config (CI gate, runs on host)
-just vm                  # install in QEMU VM → auto-boots installed system after
+just headless-test       # config-gen e2e (CI gate, runs on host)
+just vm                  # install in QEMU → auto-boots installed system after
 just vm-e2e              # automated 4-pass: DHCP · static · sysext · NVIDIA
-just boot-iso            # build ISO → boot in QEMU GTK window (requires -cpu host; uses bin/knuckle)
+just boot-iso            # build ISO → boot in QEMU GTK window (requires -cpu host)
 just e2e                 # build ISO → boot in QEMU GTK window → interactive install
 ```
 
-`just ci` is the pre-push gate. CI re-runs every step in
-`.github/workflows/ci.yml` plus CodeQL / Scorecard / dependency-review in
-`.github/workflows/security.yml`. If CI fails, fix it — never `--no-verify`.
+`just ci` is the pre-push gate. Never `--no-verify`.
 
-## Safety Invariants (do not violate)
+---
 
-1. **Never run real `flatcar-install` on the host.** `just headless-test` runs
-   on the host and only validates config generation — it does not call
-   `flatcar-install`. Real installs run only inside QEMU (`just vm`, `just vm-e2e`).
-2. **All system commands route through `internal/runner`.** No
-   `exec.Command` outside `internal/runner`. Reboot is threaded via
-   `rebootFn func(context.Context) error` injected from `cmd/knuckle/main.go`.
-3. **Disk identity is `/dev/disk/by-id`.** Display model, serial, size,
-   transport, removable flag. Never trust `/dev/sdX` enumeration order.
-4. **Never log to stdout.** Bubble Tea owns it. Use `log/slog` with a file
-   handler (default `/tmp/knuckle.log`, override via `--log-file`).
-5. **Ignition contains secrets** (SSH keys, hashed passwords). Write it with
-   `os.CreateTemp` (O_EXCL), `chmod 0600`, defer `os.Remove`. Pattern in
-   `internal/install/install.go:WriteIgnitionFile`.
+## Safety Invariants ⛔
+
+1. **Never run `flatcar-install` on the host.** `just headless-test` only validates config generation. Real installs run only inside QEMU.
+2. **All system commands route through `internal/runner`.** No `exec.Command` outside that package. Reboot wired via `rebootFn func(context.Context) error` injected from `cmd/knuckle/main.go`.
+3. **Disk identity is `/dev/disk/by-id`.** Never trust `/dev/sdX` enumeration order.
+4. **Never log to stdout.** Bubble Tea owns it. Use `log/slog` with a file handler (`/tmp/knuckle.log` default).
+5. **Ignition contains secrets.** Write with `os.CreateTemp` (O_EXCL), `chmod 0600`, `defer os.Remove`. See `internal/install/install.go:WriteIgnitionFile`.
 
 ---
 
 ## Package Boundaries
 
-Coverage numbers are authoritative in [`docs/CI-AND-TESTING.md`](docs/CI-AND-TESTING.md#coverage-gate).
-Current values (as of 2026-05-28, `just cover-check`):
+Coverage gates are authoritative in [`docs/CI-AND-TESTING.md`](docs/CI-AND-TESTING.md#coverage-gate).
 
-| Package           | Responsibility                                                     | Coverage |
-| ----------------- | ------------------------------------------------------------------ | -------- |
-| `cmd/knuckle`     | CLI entrypoint, flag parsing, runner wiring                        | n/a      |
-| `internal/model`  | Pure data types — `InstallConfig`, `DiskInfo`, `NetworkInterface`  | 100%     |
-| `internal/runner` | `Runner` interface: `RealRunner`, `DryRunner`, `SpyRunner`         | 100%     |
-| `internal/probe`  | `lsblk` + `ip addr` JSON parsing, `/dev/disk/by-id` resolution     | 100%     |
-| `internal/validate` | Hostname, CIDR, gateway, SSH key, timezone, disk path validators | 100%     |
-| `internal/bakery` | sysext catalog + Flatcar release/SBOM fetchers, SHA512 check       | 100%     |
-| `internal/github` | SSH key fetch + GitHub Releases API client                         | 97%      |
-| `internal/ignition` | Butane assembly + in-process Butane→Ignition compilation         | 100%     |
-| `internal/install` | `flatcar-install` orchestration via runner                        | 100%     |
-| `internal/iso`    | Installer ISO builder helpers                                      | 100%     |
-| `internal/headless` | `--headless --config` JSON-driven install path                   | 99%      |
-| `internal/wizard` | Step state machine, navigation, validation gates                   | 99.5%    |
-| `internal/tui`    | Bubble Tea view models (one sub-model per step), forms             | 98.7%    |
+| Package             | Responsibility                                                    |
+| ------------------- | ----------------------------------------------------------------- |
+| `cmd/knuckle`       | CLI entrypoint, flag parsing, runner wiring                       |
+| `internal/model`    | Pure data types — `InstallConfig`, `DiskInfo`, `NetworkInterface` |
+| `internal/runner`   | `Runner` interface: `RealRunner`, `DryRunner`, `SpyRunner`        |
+| `internal/probe`    | `lsblk` + `ip addr` JSON parsing, `/dev/disk/by-id` resolution   |
+| `internal/validate` | Hostname, CIDR, gateway, SSH key, timezone, disk path validators  |
+| `internal/bakery`   | sysext catalog + Flatcar release/SBOM fetchers, SHA512 + GPG check|
+| `internal/github`   | SSH key fetch + GitHub Releases API client                        |
+| `internal/ignition` | Butane assembly + in-process Butane→Ignition compilation          |
+| `internal/install`  | `flatcar-install` orchestration via runner                        |
+| `internal/iso`      | Installer ISO builder helpers                                     |
+| `internal/headless` | `--headless --config` JSON-driven install path                    |
+| `internal/wizard`   | Step state machine, navigation, validation gates                  |
+| `internal/tui`      | Bubble Tea view models (one sub-model per step), forms            |
 
-Targets enforced by `just cover-check` are deliberately set ≤ current numbers
-so the gate guards against *regression*. Long-term aspirations live in
-`docs/CI-AND-TESTING.md` — raise the gate as coverage rises.
-
-### Dependency Graph (acyclic; enforced by import structure)
+### Dependency Graph (acyclic — `go vet` enforced)
 
 ```
-model    ← leaf, zero internal imports — everything depends on it
+model    ← leaf, zero internal imports
 runner   ← probe, install, headless (injected via interface)
-validate ← tui (field-level), ignition (final check), headless
-probe    ← wizard/tui (disk + network data)
-bakery   ← wizard/tui (sysext catalog + channel info)
-github   ← wizard (SSH key fetch)
+validate ← tui, ignition, headless
+probe    ← wizard/tui
+bakery   ← wizard/tui
+github   ← wizard
 ignition ← install, wizard
 install  ← wizard, headless
 headless ← cmd/knuckle
@@ -118,393 +94,68 @@ wizard   ← tui, cmd/knuckle
 tui      ← cmd/knuckle
 ```
 
-`go vet ./...` runs in CI; cycle violations break the build.
-
 ---
 
 ## Architecture Decisions
 
-1. **Runner abstraction.** Every external command goes through
-   `internal/runner.Runner`. Three implementations: `RealRunner` (prod),
-   `DryRunner` (no-op + structured logging), `SpyRunner` (test recorder).
-2. **Flatcar Butane variant.** `variant: flatcar` (not generic CoreOS),
-   compiled in-process via `github.com/coreos/butane` v0.27+ →
-   `ignition.CompileToIgnition()`. No `butane` CLI on the target system.
-   Rationale: `docs/BUTANE-DEPENDENCY.md`.
-3. **Mutually exclusive config modes.** Guided OR external Ignition URL
-   (`Ctrl+A`). No merge logic.
-4. **Disk identity via `/dev/disk/by-id`.** Falls back to raw device path only
-   when `/dev/disk/by-id/` is absent (CI containers). See
-   `internal/probe/probe.go:resolveByIDPath`.
-5. **TUI ↔ logic separation.** `internal/tui` renders; `internal/wizard`
-   transitions. No business logic in view models.
+1. **Runner abstraction.** Every external command through `internal/runner.Runner` — `RealRunner` (prod), `DryRunner` (no-op), `SpyRunner` (test recorder).
+2. **Flatcar Butane variant.** `variant: flatcar` compiled in-process via `ignition.CompileToIgnition()`. No `butane` CLI on target. See `docs/BUTANE-DEPENDENCY.md`.
+3. **Mutually exclusive config modes.** Guided TUI OR external Ignition URL. No merge logic.
+4. **Disk identity via `/dev/disk/by-id`.** Falls back to raw device path only when `/dev/disk/by-id/` absent (CI containers). See `internal/probe/probe.go:resolveByIDPath`.
+5. **TUI ↔ logic separation.** `internal/tui` renders; `internal/wizard` transitions. No business logic in view models.
 6. **Shared data model.** `internal/model` owns every cross-package type.
-   Wizard builds them, TUI reads/writes fields, ignition consumes, validate
-   checks.
-7. **huh.Form for form steps.** Welcome, Network, User, Review use
-   `charmbracelet/huh` with the Dracula theme. Storage, Sysext, Update,
-   Install, Done are raw Bubble Tea. Validation via `.Validate()` callbacks.
-8. **Supply-chain signals.** SBOM JSON (SPDX) is the primary version source.
-   SHA512 against `.DIGESTS` is verified. GPG signature on the digest file is
-   fully verified via `github.com/ProtonMail/go-crypto` against the embedded
-   Flatcar signing key (`internal/bakery/keys/flatcar-signing.asc`).
-9. **Headless mode mirrors the TUI.** `--headless --config <file.json>` drives
-   `internal/headless` through the same `internal/install` path. New TUI
-   fields must round-trip through the headless config schema.
+7. **huh.Form for form steps.** Welcome, Network, User, Review use `charmbracelet/huh` + Dracula theme. Storage, Sysext, Update, Install, Done are raw Bubble Tea.
+8. **Supply-chain.** SBOM JSON (SPDX) is the primary version source. SHA512 + GPG against `.DIGESTS.asc` (PGP clearsigned — verify with `gpg --decrypt`, not `gpg --verify`).
+9. **Headless mirrors the TUI.** `--headless --config <file.json>` drives the same `internal/install` path. New TUI fields must round-trip through the headless config schema.
 
 ---
 
-## Test Pyramid
-
-| Layer        | Where                                  | What                                                | Ghost? |
-| ------------ | -------------------------------------- | --------------------------------------------------- | ------ |
-| Unit         | `internal/**/_test.go`                 | Pure logic, fixture-driven                          | dev only |
-| Golden       | `internal/ignition/testdata/`          | Butane → Ignition output diffs (`-update` rewrites) | dev only |
-| Integration  | `//go:build integration` (not in CI)   | Real network: GitHub API, Flatcar release server    | dev only |
-| Headless e2e | `just headless-test`                   | Build + canned JSON config, runs on host (CI gate)  | ✅ ghost |
-| VM           | `just vm`                              | Install in QEMU, auto-boots installed system after  | local only (interactive TUI) |
-| VM automated | `just vm-e2e`                          | 4-pass: DHCP, static network, sysext (docker), NVIDIA — fully automated | ✅ ghost |
-| Ghost PR test | `scripts/qa-test-pr.sh <PR>`          | Per-PR: build + unit + VM dry-run + headless install, report to PR | ✅ ghost only |
-| ISO e2e      | `just e2e`                             | Build ISO → boot in QEMU GTK window → interactive install | local only (requires display) |
-
-CI runs unit + race + lint + vuln + coverage gate. `just vm-e2e` and `scripts/qa-test-pr.sh` run on **ghost** (192.168.1.102). `just e2e`/`just vm` require a local display.
-
-### Per-PR Verification Policy
-
-| PR labels | Minimum required before merge | Evidence standard |
-|---|---|---|
-| `domain:ci`, `kind/test`, docs only | `just ci` green | Unit test output |
-| `domain:validate`, `domain:model`, `domain:runner` | `just ci` green | Unit test output |
-| `domain:probe`, `domain:tui` | ghost Tier 1 (tool check + dry-run) | Tool versions + dry-run log |
-| `domain:security` | ghost Tier 1 + bad-input rejection tests | Every invalid input must be **rejected** with quoted output |
-| `domain:ignition`, `domain:headless` | **ghost Tier 3 (install + boot + assertions)** | Ignition files, hostname, authorized_keys from **booted installed system** |
-| `domain:install` | **ghost Tier 3** | GPT table, lsblk, disk-by-id from **booted installed system** |
-| swap feature | **ghost Tier 3** | `swapon --show`, `ls -lah /var/swapfile`, `free -h` from **booted system** |
-| tailscale feature | **ghost Tier 3** | `stat -c "%a %n" /etc/tailscale/tailscale.env` (must be 600) from **booted system** |
-| `domain:iso` | ghost Tier 3 + `hardware-repro` | GPT layout, ISO boot log |
-| `size:XL` or >4 domains | Human `just vm-e2e` sign-off | All 4 passes green |
-
-**The bar:** Tier 3 means the installed system booted and responded to SSH. Evidence is quoted command output from inside that system — not build logs, not unit test output, not exit codes alone.
-
-> ⛔ Never queue a PR without a passing ghost test report. Code review approval alone is not sufficient.
-
-> ⛔ Never merge or queue a PR with failed CI. If required checks or merge-queue (`merge_group`)
-> CI fail, rerun/fix first, then requeue only after checks are green.
-
----
-
-## Working in this repo as an agent
-
-
-### ISO build internals
-
-The installer ISO modifies Flatcar's `usr.squashfs` directly — the only reliable
-injection method for Flatcar PXE live boot.
-
-- **Flatcar PXE initrd** = cpio with only `etc/` (empty) + `usr.squashfs`. No `/init`
-  in the external cpio; dracut init is embedded in `vmlinuz`. Appended cpio overlays
-  are abandoned at pivot_root — there is no `apply-live-updates.sh` hook.
-- **`squashfs-root/` = `/usr/` in the live system.** So `squashfs-root/bin/knuckle` →
-  `/usr/bin/knuckle`. Place units in `squashfs-root/lib/systemd/system/`.
-- **Binary selection:** `scripts/build-iso.sh` uses `bin/knuckle` (built by `just build`
-  with `CGO_ENABLED=0`). Never use the repo-root binary — it may contain AVX instructions
-  that crash with `trap invalid opcode` in QEMU.
-- **QEMU:** always pass `-cpu host`. Without it, AVX binaries silently crash. `just boot-iso`
-  and `just e2e` both set this. Use `-display gtk` (not `-nographic`) to see the TUI on tty1.
-- **Ignition in QEMU:** pass config via `-fw_cfg name=opt/org.flatcar-linux/config,file=config.ign`.
-  The `ignition.config.data=` kernel cmdline parameter is silently ignored on the QEMU platform.
-- **Build cache:** squashfs is content-addressed on `sha256sum bin/knuckle` — skips repack when
-  binary unchanged.
-- **`systemd.gpt_auto=0` is REQUIRED on every BLS entry.** Without it, bare-metal machines
-  with real GPT disks trigger `systemd-gpt-auto-generator`, which creates synthetic device units.
-  Dracut's `xd2root` root-mount hook then can't satisfy its dependencies and is silently skipped
-  → the installer fails to appear on bare metal. Both `knuckle.conf` and `knuckle-serial.conf`
-  must include this parameter. Root cause of the v0.6.2 regression (fixed in v0.7.0).
-- **Pure systemd-boot, no GRUB.** The ESP contains only `EFI/BOOT/BOOTX64.EFI` (systemd-boot
-  binary sourced from the system `systemd-boot-efi` package), `loader/loader.conf`, and two BLS
-  entries. The `.iso-build/` build-cache directory is gitignored; any GRUB artifacts there are
-  stale local artifacts and never included in the ISO.
-- **`just vm-e2e` does NOT test ISO boot.** It deploys knuckle via SSH to a running Flatcar VM.
-  Use `just iso-smoke <iso> <ovmf>` for a headless serial-log ISO boot check (systemd-boot menu,
-  initrd targets, no `xd2root`/`x2dauto` errors). `just boot-iso`/`just e2e` remain the full
-  display-driven ISO paths. CI currently dry-runs the recipe definition; run the real smoke test on
-  ghost when validating release candidates.
-- **Flatcar `.DIGESTS.asc` format** = PGP clearsigned (contains `-----BEGIN PGP SIGNED MESSAGE-----`
-  header + content + signature). Verify with `gpg --decrypt asc > verified_content`, not
-  `gpg --verify asc data` (detached-signature form — always fails on clearsigned input).
-
-### All agents
+## Agent Rules
 
 1. **Read this file, then the issue.** Don't infer scope from a commit subject.
 2. **Declare SCOPE / GOAL / OUT OF SCOPE** before editing.
-3. **One PR per issue.** Branch `feat/<slug>` or `fix/<slug>`. Conventional
-   commits (`feat:`, `fix:`, `test:`, `refactor:`, `docs:`, `ci:`, `chore:`).
+3. **One PR per issue.** Branch `feat/<slug>` or `fix/<slug>`. Conventional commits (`feat:`, `fix:`, `test:`, `refactor:`, `docs:`, `ci:`, `chore:`).
 4. **`just ci` is the gate.** If it fails, fix it; don't push.
-5. **Push to `origin` (projectbluefin/knuckle) only.** No upstream pushes from
-   automation.
-6. **Touch `.github/workflows/*.yml`?** Coordinate via PR description — these
-   are security-sensitive. CodeQL + Scorecard run on every push.
-7. **Adding a new external command?** Wire it through `runner.Runner`. Period.
-8. **Adding a new disk-touching code path?** Test it in QEMU via `just vm` or
-   `just vm-e2e`. Unit tests use `SpyRunner` to assert commands without execution.
-
-
-**Tier selection by label:**
-
-| Labels present | Tier | What runs | Evidence in report | Time |
-|---|---|---|---|---|
-| `domain:ci`, `kind/test`, `domain:validate`, docs | 0 | `just ci` only | Unit test output | ~2m |
-| `domain:probe`, `domain:tui` | 1 | Tier 0 + VM tool check + `--dry-run` | Tool versions, dry-run log | ~5m |
-| `domain:security` | 1+sec | Tier 1 + bad-input rejection tests | Each invalid input must be **rejected** (quoted output) | ~7m |
-| `domain:install`, `domain:headless`, `domain:ignition`, swap, tailscale | **3** | Tier 1 + **full install + BOOT installed system** + domain assertions | GPT table, swapfile, env file modes, Ignition-provisioned files — **all quoted from installed system** | ~20m |
-| `domain:iso` | 3 | Tier 3 + `hardware-repro` | ISO boot + GPT + install log | ~30m |
-
-**Full QA science standard — Tier 3 reports must include:**
-- Quoted `sfdisk -l` output (GPT intact)
-- Quoted `swapon --show` (if swap PR)
-- Quoted `stat -c "%a %n" /etc/tailscale/tailscale.env` (if tailscale PR)
-- Quoted `ls ~/.ssh/authorized_keys` (Ignition applied)
-- Quoted `hostname` (config applied correctly)
-- Any `FAIL:` line causes the report to fail
-
-Tier 3 is triggered automatically by the script based on labels. Never accept a
-Tier 1/2 report for a PR that touches the installed system.
-
-**If the script exits non-zero:** read the report. Common failures:
-- `VM BOOT TIMEOUT` — check ghost port occupancy: `ssh jorge@ghost "ss -tlnp | grep 23"`
-- `BUILD FAILED` — the PR has a compilation error; request changes
-- `ASSERTIONS_FAILED` — the installed system did not match the expected state
-- `BAD_PW_ACCEPTED_FAIL` — plaintext password was accepted (security regression)
-- `INSTALL_FAILED` — `flatcar-install` exited non-zero; check install log in report
+5. **Push to `origin` (projectbluefin/knuckle) only.** No upstream pushes from automation.
+6. **Workflow files (`.github/workflows/*.yml`):** security-sensitive, cannot be auto-merged. Coordinate via PR description.
+7. **New external command?** Wire through `runner.Runner`. Period.
+8. **New disk-touching code?** Test in QEMU via `just vm` or `just vm-e2e`. Unit tests use `SpyRunner`.
 
 ---
 
-### Step 4 — Aggressive QA agent review
+## Docs — Load on Demand
 
-Dispatch the QA subagent with this exact brief:
+These docs live in `docs/` and improve continuously. Load the relevant one for your task — don't load all of them.
 
-```
-You are an adversarial QA reviewer. Your job is to find what's wrong.
-Be blunt — no softening. The PR is: <TITLE>
-
-CODE DIFF:
-<paste output of: gh pr diff $PR --repo projectbluefin/knuckle>
-
-GHOST TEST REPORT:
-<paste contents of /tmp/knuckle-qa-pr-${PR}-report.md>
-
-Find:
-1. Edge cases not covered by the test suite
-2. Security issues (disk writes, credentials, path traversal)
-3. Behavioral gaps between TUI and headless paths
-4. Missing error paths in the new code
-5. Test assertions that verify presence but not behavior
-
-For each finding: BLOCKER / SHOULD-FIX / NIT, file:line, and exact fix.
-If you find nothing significant: say so explicitly with your reasoning.
-```
-
-Capture output: `tee /tmp/knuckle-qa-pr-${PR}-qa-findings.md`
-
----
-
-### Step 5 — Publish report and decide
-
-**ONE COMMENT RULE: The strike report is the only comment posted on the PR. No other text.**
-
-```bash
-# 1. Post the full strike report as the single PR comment
-gh pr comment $PR --repo projectbluefin/knuckle \
-  --body-file /tmp/qa-stdout-${PR}.txt
-
-# 2. Approve or request changes with NO body text (-b flag is forbidden here)
-gh pr review $PR --repo projectbluefin/knuckle --approve          # if passing
-gh pr review $PR --repo projectbluefin/knuckle --request-changes  # if failing
-```
-
-> ⛔ Never add a `-b` body to `gh pr review`. Never post a second comment. The report IS the review.
-
-**Decision matrix:**
-
-| Code review | Ghost tests | Action |
-|---|---|---|
-| APPROVE | PASS | Post report → `gh pr review --approve` (no body) → queue |
-| APPROVE | FAIL | Post report → `gh pr review --request-changes` (no body) |
-| REQUEST_CHANGES | any | Post report → `gh pr review --request-changes` (no body) |
-| Complex (skipped) | skipped | Post Tier 0 CI result only → leave review |
-
-**Queueing:**
-```bash
-# Before queuing: check the PR is not DIRTY
-STATE=$(gh pr view $PR --repo projectbluefin/knuckle --json mergeStateStatus --jq .mergeStateStatus)
-[[ "$STATE" == "DIRTY" ]] && {
-  # Try GitHub rebase first
-  gh pr update-branch $PR --repo projectbluefin/knuckle || {
-    echo "Manual rebase required — see Step 6"
-    exit 1
-  }
-}
-
-# Never queue while required checks are failing
-gh pr checks $PR --repo projectbluefin/knuckle
-
-gh pr merge $PR --repo projectbluefin/knuckle
-
-# If merge_group failed, inspect and rerun then requeue
-gh run view <RUN_ID> --repo projectbluefin/knuckle --log-failed
-gh run rerun <RUN_ID> --repo projectbluefin/knuckle --failed
-gh pr merge --auto $PR --repo projectbluefin/knuckle
-```
-
----
-
-### Step 6 — Conflict resolution (if PR is DIRTY)
-
-Never open a new PR for a rebase. Push to the existing branch.
-Check for file overlap before resolving — if the same file appears in multiple
-open PRs, review them sequentially (queue one, wait for merge, then review next).
-
-```bash
-# 0. Check if GitHub can do it automatically
-gh pr update-branch $PR --repo projectbluefin/knuckle && exit 0
-```
-
-Then proceed with local rebase only if the above fails.
-
-```bash
-# 1. Fetch the PR head
-git fetch upstream pull/${PR}/head:pr${PR}-head
-
-# 2. Create a rebase branch from current main
-git checkout -b fix/pr${PR}-rebased upstream/main
-git cherry-pick pr${PR}-head   # or git merge --no-commit pr${PR}-head
-
-# 3. Resolve conflicts (keep both sides for additive changes)
-git add <resolved files> && git cherry-pick --continue
-
-# 4. Verify
-go build ./...   # MUST exit 0 before git add
-just ci          # must be green
-
-# 5. Push to the EXISTING PR branch (maintainerCanModify: true required)
-git remote add pr-author git@github.com:<AUTHOR>/knuckle.git 2>/dev/null || true
-git fetch upstream main && git rebase upstream/main
-git push pr-author fix/pr${PR}-rebased:<ORIGINAL_BRANCH> --force-with-lease
-
-# 6. Queue (CI will re-run on the new head)
-gh pr merge $PR --repo projectbluefin/knuckle
-```
-
-**If maintainerCanModify is false:** request author to rebase, comment with
-the exact conflict resolution (paste the diff).
-
----
-
-### Quick reference card
-
-```
-1. ghost reachable?    ssh jorge@192.168.1.102 hostname
-2. PR complexity?      gh pr view $PR --repo projectbluefin/knuckle --json labels
-3. Code review         gh pr diff $PR --repo projectbluefin/knuckle
-4. Ghost test          ./scripts/qa-test-pr.sh $PR
-5. QA agent            dispatch qa subagent with diff + report
-6. Publish + queue     gh pr comment ... && gh pr merge $PR ...
-```
-
-**Ghost test port cleanup** (if ports are stuck):
-```bash
-ssh jorge@192.168.1.102 "
-  echo '=== QEMU VMs ==='
-  pgrep -a qemu-system | grep -v 'qemu.pid' || echo none
-  echo '=== Ports 2300-2315 ==='
-  ss -tlnp | grep ':23[0-1][0-9]' || echo none
-  echo '=== /var/tmp knuckle dirs ==='
-  ls -d /var/tmp/knuckle-qa-pr-* 2>/dev/null || echo none
-"
-# Kill a stuck VM:
-ssh jorge@192.168.1.102 "kill \$(cat /var/tmp/knuckle-qa-pr-${PR}/qemu.pid 2>/dev/null) 2>/dev/null || true"
-```
-
----
-
-
-## Release Checklist
-
-Run this before tagging any release. Anything red blocks the tag.
-
-```bash
-# One command to run them all — must be green on a clean checkout
-just tools && just ci
-```
-
-Individual gates (all exercised by `just ci`):
-
-- [ ] `go mod tidy && git diff --exit-code go.mod go.sum` — module graph clean
-- [ ] `gofmt -l .` empty
-- [ ] `go vet ./...` clean
-- [ ] `.tools/golangci-lint run ./...` clean
-- [ ] `go tool govulncheck ./...` — `No vulnerabilities found.`
-- [ ] `go test -race ./...` — all 12 packages green
-- [ ] `just cover-check` — all packages above gate thresholds
-- [ ] `just headless-test` — config generation e2e passes (runs on host)
-- [ ] `just vm-e2e` — all 4 passes green (DHCP, static, sysext, NVIDIA)
-- [ ] `just build` — binary compiles
-- [ ] `git status` clean — no untracked files in repo
-- [ ] `grep -rn 'exec\.Command' --include='*.go' --exclude-dir=internal/runner .`
-      → zero results (all reboot paths use `rebootFn` injected via runner)
-- [ ] All claims in `README.md` still true
-- [ ] `docs/REVIEW-*.md` reconciled — every blocker fixed or deferred with issue
-
-**Blockers status:** B1 (GPG) ✓, B2 (reboot runner) ✓, B3 (headless disk path) ✓,
-B4 (SSH keys not reaching Ignition) ✓. No open blockers for 1.0.
-
-**VM verification (required before release tag):**
-```bash
-just vm      # go through the full TUI, confirm install completes and SSH works
-just vm-e2e  # automated 4-pass — must exit 0 (DHCP · static · sysext · NVIDIA)
-```
-
-The most recent review record is `docs/REVIEW-2026-05-20.md`.
+| Task | Document |
+| ---- | -------- |
+| Coverage gates, test pyramid, CI pipeline, ISO build internals | [`docs/CI-AND-TESTING.md`](docs/CI-AND-TESTING.md) |
+| PR test matrix, tier classification, domain assertions, ghost QA evidence | [`docs/PR-TEST-MATRIX.md`](docs/PR-TEST-MATRIX.md) |
+| Ghost lab setup, port inventory, KubeVirt, QA workflow, conflict resolution | [`docs/GHOST-LAB.md`](docs/GHOST-LAB.md) |
+| Release tag checklist, VM verification, blocker history | [`docs/RELEASE.md`](docs/RELEASE.md) |
+| Headless config schema, field reference, validation rules | [`docs/HEADLESS-CONFIG.md`](docs/HEADLESS-CONFIG.md) |
+| Security posture, threat model, disclosure path | [`docs/SECURITY.md`](docs/SECURITY.md) |
+| Sysext catalog, Bakery support tiers, extension behavior | [`docs/SYSEXTS.md`](docs/SYSEXTS.md) |
+| Troubleshooting runbook, first-boot diagnostics | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
+| Butane-as-library rationale | [`docs/BUTANE-DEPENDENCY.md`](docs/BUTANE-DEPENDENCY.md) |
 
 ---
 
 ## Routine Maintenance
 
-**Dependency bumps** — bump, run `just ci`, verify `just vm` still works:
 ```bash
-go get -u ./...
-go mod tidy
-just ci
-just vm
+# Dependency bumps
+go get -u ./... && go mod tidy && just ci && just vm
+
+# Tool version bumps — update GOLANGCI_LINT_VERSION in Justfile AND .github/workflows/ci.yml together
+just tools && just ci
+
+# Flatcar release tracking — fetched live by bakery; to force a check:
+go test ./internal/bakery/... -run TestFetch
 ```
-
-**Tool version bumps** — update `GOLANGCI_LINT_VERSION` in Justfile AND
-`.github/workflows/ci.yml` together, then `just tools && just ci`.
-
-**Flatcar release tracking** — bakery fetches current versions live; no manual
-update needed. To force a check: `go test ./internal/bakery/... -run TestFetch`.
-
-**Flatcar manual update on a running node:**
-```bash
-sudo update_engine_client -update   # trigger download
-sudo update_engine_client -status   # watch progress
-sudo systemctl reboot               # apply (if REBOOT_STRATEGY=off)
-```
-
-**Release tag checklist:**
-1. `just tools && just ci` — must be green
-2. `just vm` — manual install walkthrough, confirm SSH works on installed system
-3. `just vm-e2e` — all 4 passes must exit 0 (DHCP · static · sysext · NVIDIA)
-4. `git tag v0.X.Y && git push origin v0.X.Y` — triggers release.yml
 
 ---
 
 ## Reference
 
-- [Flatcar Container Linux](https://www.flatcar.org/)
-- [Flatcar Bakery (sysexts)](https://www.flatcar.org/docs/latest/provisioning/sysext/)
-- [Butane / Ignition](https://coreos.github.io/butane/config-flatcar-v1_1/)
-- [charm.sh](https://charm.sh) — Bubble Tea, Lip Gloss, Huh, Bubbles
-- [flatcar-install](https://www.flatcar.org/docs/latest/installing/bare-metal/installing-to-disk/)
-- [OSSF Scorecard](https://github.com/ossf/scorecard) — runs weekly in `security.yml`
-- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) — runs every PR
+[Flatcar](https://www.flatcar.org/) · [Bakery](https://www.flatcar.org/docs/latest/provisioning/sysext/) · [Butane](https://coreos.github.io/butane/config-flatcar-v1_1/) · [charm.sh](https://charm.sh) · [flatcar-install](https://www.flatcar.org/docs/latest/installing/bare-metal/installing-to-disk/) · [OSSF Scorecard](https://github.com/ossf/scorecard) · [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -268,6 +268,21 @@ Test tiers by domain label (see `knuckle-qa` skill for full matrix):
 | `domain:install`, `domain:headless`, `domain:ignition` | 2 | Tier 1 + real headless install on ghost |
 | `domain:iso` | 3 | Tier 2 + `hardware-repro` on ghost |
 
+## ISO Build Internals
+
+The installer ISO injects knuckle into Flatcar's `usr.squashfs` — the only
+reliable method for Flatcar PXE live boot.
+
+- **`squashfs-root/` = `/usr/` in the live system.** `squashfs-root/bin/knuckle` → `/usr/bin/knuckle`. Units in `squashfs-root/lib/systemd/system/`.
+- **Binary:** `scripts/build-iso.sh` uses `bin/knuckle` (`just build`, `CGO_ENABLED=0`). Never the repo-root binary — may contain AVX instructions that crash with `trap invalid opcode` in QEMU.
+- **QEMU:** always `-cpu host`. Without it AVX binaries crash silently. Use `-display gtk` to see the TUI on tty1.
+- **Ignition in QEMU:** pass via `-fw_cfg name=opt/org.flatcar-linux/config,file=config.ign`. The `ignition.config.data=` kernel cmdline is silently ignored on the QEMU platform.
+- **`systemd.gpt_auto=0` is REQUIRED on every BLS entry.** Without it, bare-metal GPT disks trigger `systemd-gpt-auto-generator` → dracut `xd2root` hook is skipped → installer fails to appear. Both `knuckle.conf` and `knuckle-serial.conf` must include this. Root cause of the v0.6.2 regression (fixed v0.7.0).
+- **Pure systemd-boot, no GRUB.** ESP contains only `EFI/BOOT/BOOTX64.EFI` (from `systemd-boot-efi`), `loader/loader.conf`, and two BLS entries.
+- **Flatcar `.DIGESTS.asc`** = PGP clearsigned. Verify with `gpg --decrypt asc > content`, not `gpg --verify` (detached form — always fails on clearsigned input).
+- **Build cache:** squashfs is content-addressed on `sha256sum bin/knuckle` — skips repack when binary unchanged.
+- **`just vm-e2e` does NOT test ISO boot.** Use `just iso-smoke <iso> <ovmf>` for headless serial-log ISO boot validation on ghost.
+
 ## Roadmap
 
 Tracked in `docs/REVIEW-2026-05-19.md` (passes 1-2) and session notes from

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ This directory contains supplementary documentation for knuckle. Start with the 
 | [HEADLESS-CONFIG.md](HEADLESS-CONFIG.md) | Canonical reference for the `--headless --config` JSON schema, including fields, defaults, and validation rules. |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Practical runbook for common install failures, first-boot issues, and quick diagnostics. |
 | [SECURITY.md](SECURITY.md) | Security posture, threat model, known gaps, and the disclosure path for vulnerabilities. |
-| [CI-AND-TESTING.md](CI-AND-TESTING.md) | CI pipeline overview, test pyramid, and coverage gates used for contributor changes. |
+| [CI-AND-TESTING.md](CI-AND-TESTING.md) | CI pipeline overview, test pyramid, coverage gates, and ISO build internals. |
 | [SYSEXTS.md](SYSEXTS.md) | Reference guide to the Flatcar Bakery sysext catalog, support tiers, and extension behavior. |
 | [BUTANE-DEPENDENCY.md](BUTANE-DEPENDENCY.md) | Explains why knuckle embeds Butane as a Go library instead of relying on the `butane` CLI. |
 | [HIVE-DEPLOYMENT.md](HIVE-DEPLOYMENT.md) | Host-side deployment notes for running knuckle's Hive container on Flatcar. |
@@ -23,6 +23,7 @@ These files are mainly useful for maintainers, reviewers, and agent-assisted dev
 |------|-------------|
 | [GHOST-LAB.md](GHOST-LAB.md) | Hardware lab notes for real-device and ghost test environment setup. |
 | [PR-TEST-MATRIX.md](PR-TEST-MATRIX.md) | Maintainer-oriented matrix for mapping change types to the expected PR test coverage. |
+| [RELEASE.md](RELEASE.md) | Release tag checklist — gates, VM verification, and tag procedure. |
 | [SUBIQUITY-TUI-ANALYSIS.md](SUBIQUITY-TUI-ANALYSIS.md) | Design research comparing knuckle's installer UX to Ubuntu Subiquity. |
 | [TUI-WIZARD-PATTERNS.md](TUI-WIZARD-PATTERNS.md) | Background research on wizard and TUI interaction patterns used to shape the current flow. |
 | [internal/REVIEW-2026-05-19.md](internal/REVIEW-2026-05-19.md) | Agent-authored principal-engineer review notes from 2026-05-19. |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,49 @@
+# Release Checklist — knuckle
+
+Run this before tagging any release. Every item must be green.
+
+```bash
+# One command to verify everything
+just tools && just ci
+```
+
+## Gates
+
+- [ ] `go mod tidy && git diff --exit-code go.mod go.sum` — module graph clean
+- [ ] `gofmt -l .` empty
+- [ ] `go vet ./...` clean
+- [ ] `.tools/golangci-lint run ./...` clean
+- [ ] `go tool govulncheck ./...` — `No vulnerabilities found.`
+- [ ] `go test -race ./...` — all packages green
+- [ ] `just cover-check` — all packages above gate thresholds
+- [ ] `just headless-test` — config generation e2e passes
+- [ ] `just vm-e2e` — all 4 passes green (DHCP · static · sysext · NVIDIA)
+- [ ] `just build` — binary compiles
+- [ ] `git status` clean — no untracked files
+- [ ] `grep -rn 'exec\.Command' --include='*.go' --exclude-dir=internal/runner .` → zero results
+- [ ] All claims in `README.md` still true
+- [ ] `docs/internal/REVIEW-*.md` reconciled — every blocker fixed or deferred with issue
+
+## VM Verification (required)
+
+```bash
+just vm       # manual TUI walkthrough — confirm install + SSH on installed system
+just vm-e2e   # automated 4-pass — must exit 0
+```
+
+## Tag and Push
+
+```bash
+git tag v0.X.Y
+git push origin v0.X.Y   # triggers release.yml: build → sign → publish
+```
+
+The release workflow (`release.yml`) builds amd64 + arm64 binaries, installer ISOs,
+cosign keyless signatures, and publishes a GitHub Release. See `docs/GHOST-LAB.md`
+for validating ARM64 artifacts before tagging.
+
+## Blockers History
+
+B1 (GPG) ✓ · B2 (reboot runner) ✓ · B3 (headless disk path) ✓ · B4 (SSH keys → Ignition) ✓
+
+No open blockers for v1.0.


### PR DESCRIPTION
## What

AGENTS.md was 510 lines, duplicating content that already lives (and continuously
improves) in `docs/`. Reduces to **161 lines** with a pointer table.

## Why

- Agents load 510 lines of context on every invocation — most irrelevant to the task
- Workflow docs (QA tiers, ghost steps, release checklist) were frozen in AGENTS.md while the live `docs/` versions evolved separately
- Skills and docs should be the single source of truth; AGENTS.md should point, not duplicate

## Content moved

| Content | Now in |
|---|---|
| Test pyramid, coverage gates | `docs/CI-AND-TESTING.md` (already there) |
| ISO build internals (squashfs, BLS, gpt_auto=0, QEMU flags) | `docs/CI-AND-TESTING.md` (new section) |
| Per-PR verification policy, tier classification | `docs/PR-TEST-MATRIX.md` (already there) |
| QA workflow (Steps 4–6), ghost port cleanup, conflict resolution | `docs/GHOST-LAB.md` (already there) |
| Release tag checklist, VM verification | `docs/RELEASE.md` (new file) |

## Result

AGENTS.md is a **context document** — 161 lines of identity, build commands, safety
invariants, package boundaries, architecture decisions, agent rules, and a pointer table.
Agents load the relevant `docs/*.md` for task-specific detail only when needed.