### PR TITLE
fix(release): add checkout to publish job so gh release view --json works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,9 @@ jobs:
       - release-amd64
       - release-arm64
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check release state (publish)
         id: publish-check
         env:


### PR DESCRIPTION
## Problem

The `publish` job in `release.yml` was missing `actions/checkout`. Without a git repo context, `gh release view --json assets` fails with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This caused the v0.8.0 release to stall at the `Verify release assets before publish` step, even though all 16 assets had uploaded successfully. The draft had to be published manually.

## Fix

Add `actions/checkout` as the first step in the `publish` job.

## Evidence

- v0.8.0 run: https://github.com/projectbluefin/knuckle/actions/runs/26590529238
- All 16 assets were present; only the publish step failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->