### PR TITLE
feat(ci): actionadon lifecycle bot + hive progress sync

### DIFF
--- a/.github/workflows/actionadon.yml
+++ b/.github/workflows/actionadon.yml
@@ -1,0 +1,313 @@
+# actionadon — lifecycle bot for Knuckle issues.
+#
+# Pipeline: filed → approved → queued → claimed → done
+#
+# Commands: /claim  /unclaim  /approve (/lgtm alias)
+#
+# The pipeline widget lives in the issue body, updated in place on every
+# transition. Zero comments for pipeline state — one edit per stage.
+
+name: Actionadon
+
+on:
+  issues:
+    types: [opened, labeled, closed]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 9 * * *'
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  DONATION_WORKFLOW_MARKER: "Workflow: Agent Donation"
+
+jobs:
+  ensure-labels:
+    if: >
+      github.event_name == 'issues' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request == null &&
+       (startsWith(github.event.comment.body, '/claim') ||
+        startsWith(github.event.comment.body, '/unclaim') ||
+        startsWith(github.event.comment.body, '/approve') ||
+        startsWith(github.event.comment.body, '/lgtm')))
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create lifecycle labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          label() {
+            gh label create "$1" --color "$2" --description "$3" --repo "$REPO" 2>/dev/null \
+              || gh label edit "$1" --color "$2" --description "$3" --repo "$REPO" 2>/dev/null \
+              || true
+          }
+          label "needs-triage"           "d4c5f9" "Needs human review — set kind, priority, and domain."
+          label "status/discussing"      "7c83fd" "Under discussion — not yet approved for the queue."
+          label "status/approved"        "2ea44f" "Approved — ready for contributors."
+          label "queue/agent-ready"      "a467dc" "Has a spec, ready to claim — comment /claim."
+          label "queue/claimed"          "e8b86d" "In active work — comment /unclaim to return."
+          label "lgtm"                   "0e8a16" "Maintainer approved — ready to merge."
+          label "agent/blocked"          "e74c3c" "Blocked — needs human input before work can continue."
+          label "needs-human/agent-oops" "f795fe" "Agent error — do not touch; humans only."
+          label "kind:agent-donation"    "1b7f83" "Donate agent time for a repo, issue, or PR review/report request."
+          label "flow/project-report"    "0e8a16" "Agent flow: produce a sourced project report."
+          label "flow/issue-review"      "5319e7" "Agent flow: review a linked issue and produce a sourced report."
+          label "flow/pr-review"         "fbca04" "Agent flow: review a linked pull request and produce a sourced report."
+          label "hold"                   "8b949e" "Do not touch; intentionally held by humans."
+          label "do-not-merge"           "b60205" "Do not merge or automate this item."
+
+  on-issue-opened:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    needs: ensure-labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Detect donation flow
+        id: donation
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          WORKFLOW="standard"
+          FLOW_LABEL=""
+          if printf '%s\n' "$ISSUE_BODY" | grep -Fq "$DONATION_WORKFLOW_MARKER"; then
+            WORKFLOW="agent_donation"
+            FLOW_LABEL="flow/project-report"
+            if printf '%s\n' "$ISSUE_BODY" | grep -Eq 'https://[^[:space:])>]+/pull/[0-9]+'  ; then
+              FLOW_LABEL="flow/pr-review"
+            elif printf '%s\n' "$ISSUE_BODY" | grep -Eq 'https://[^[:space:])>]+/issues/[0-9]+'; then
+              FLOW_LABEL="flow/issue-review"
+            fi
+          fi
+          echo "workflow=$WORKFLOW"   >> "$GITHUB_OUTPUT"
+          echo "flow_label=$FLOW_LABEL" >> "$GITHUB_OUTPUT"
+
+      - name: Inject stage-1 widget (standard)
+        if: steps.donation.outputs.workflow == 'standard'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit "$ISSUE_URL" --add-label "needs-triage"
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u25ba  filed      needs triage\n  \u00b7  approved   signed off by a maintainer\n  \u00b7  queued     waiting for a contributor to claim\n  \u00b7  claimed    \u2014\n  \u00b7  done       \u2014\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %-10s  \u00b7  next: /approve to queue\n```\n\n---\n\n' \
+            "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$FULL_BODY" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+      - name: Fast-track donated agent work
+        if: steps.donation.outputs.workflow == 'agent_donation'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          FLOW_LABEL: ${{ steps.donation.outputs.flow_label }}
+        run: |
+          gh issue edit "$ISSUE_URL" \
+            --add-label "status/approved" \
+            --add-label "queue/agent-ready" \
+            --add-label "kind:agent-donation" \
+            --add-label "$FLOW_LABEL"
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u2714  filed      needs triage\n  \u2714  approved   agent donation fast-tracked\n  \u25ba  queued     waiting for a contributor to claim\n  \u00b7  claimed    \u2014\n  \u00b7  done       \u2014\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %-10s  \u00b7  next: comment /claim to take this\n```\n\n---\n\n' \
+            "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$FULL_BODY" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+  on-labeled:
+    if: github.event_name == 'issues' && github.event.action == 'labeled'
+    needs: ensure-labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Approved — auto-queue and advance widget to stage 2
+        if: github.event.label.name == 'status/approved'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit "$ISSUE_URL" \
+            --add-label    "queue/agent-ready" \
+            --remove-label "needs-triage"      2>/dev/null || true
+          gh issue edit "$ISSUE_URL" \
+            --remove-label "status/discussing" 2>/dev/null || true
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          CLEAN=$(printf '%s\n' "$FULL_BODY" | awk 'BEGIN{s=0} /^<!-- actionadon-pipeline -->/{s=1} s && /^---$/{s=0; next} !s{print}')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u2714  filed      needs triage\n  \u2714  approved   signed off by a maintainer\n  \u25ba  queued     waiting for a contributor to claim\n  \u00b7  claimed    \u2014\n  \u00b7  done       \u2014\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %-10s  \u00b7  next: comment /claim to take this\n```\n\n---\n\n' \
+            "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$CLEAN" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+  on-comment:
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      (startsWith(github.event.comment.body, '/claim')   ||
+       startsWith(github.event.comment.body, '/unclaim') ||
+       startsWith(github.event.comment.body, '/approve') ||
+       startsWith(github.event.comment.body, '/lgtm'))
+    needs: ensure-labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check commenter write permission
+        id: permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          PERM=$(gh api "repos/$REPO/collaborators/$COMMENTER/permission" \
+                   --jq '.permission // "none"' 2>/dev/null || echo "none")
+          if [ "$PERM" = "write" ] || [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
+            echo "has_write=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "has_write=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Handle /claim
+        if: startsWith(github.event.comment.body, '/claim')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          gh issue edit "$ISSUE_URL" \
+            --add-label    "queue/claimed" \
+            --remove-label "queue/agent-ready" 2>/dev/null || true
+          gh issue edit "$ISSUE_URL" --add-assignee "$COMMENTER"
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          CLEAN=$(printf '%s\n' "$FULL_BODY" | awk 'BEGIN{s=0} /^<!-- actionadon-pipeline -->/{s=1} s && /^---$/{s=0; next} !s{print}')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u2714  filed      needs triage\n  \u2714  approved   signed off by a maintainer\n  \u2714  queued     waiting for a contributor to claim\n  \u25ba  claimed    %s is working on this\n  \u00b7  done       \u2014\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %-10s  \u00b7  next: comment /unclaim to return\n```\n\n---\n\n' \
+            "@$COMMENTER" "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$CLEAN" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+      - name: Handle /unclaim
+        if: startsWith(github.event.comment.body, '/unclaim')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          HAS_WRITE: ${{ steps.permission.outputs.has_write }}
+        run: |
+          ASSIGNEE=$(gh issue view "$ISSUE_URL" --json assignees --jq '.assignees[0].login // ""')
+          if [ "$COMMENTER" != "$ASSIGNEE" ] && [ "$HAS_WRITE" != "true" ]; then
+            gh issue comment "$ISSUE_URL" --body "Only @${ASSIGNEE} or a maintainer can unclaim this issue."
+            exit 0
+          fi
+          gh issue edit "$ISSUE_URL" \
+            --remove-label "queue/claimed" \
+            --add-label    "queue/agent-ready" 2>/dev/null || true
+          [ -n "$ASSIGNEE" ] && gh issue edit "$ISSUE_URL" --remove-assignee "$ASSIGNEE"
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          CLEAN=$(printf '%s\n' "$FULL_BODY" | awk 'BEGIN{s=0} /^<!-- actionadon-pipeline -->/{s=1} s && /^---$/{s=0; next} !s{print}')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u2714  filed      needs triage\n  \u2714  approved   signed off by a maintainer\n  \u25ba  queued     waiting for a contributor to claim\n  \u00b7  claimed    \u2014\n  \u00b7  done       \u2014\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %-10s  \u00b7  next: comment /claim to take this\n```\n\n---\n\n' \
+            "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$CLEAN" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+      - name: Handle /approve and /lgtm
+        if: >
+          startsWith(github.event.comment.body, '/approve') ||
+          startsWith(github.event.comment.body, '/lgtm')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          HAS_WRITE: ${{ steps.permission.outputs.has_write }}
+        run: |
+          if [ "$HAS_WRITE" != "true" ]; then
+            gh issue comment "$ISSUE_URL" --body "Only maintainers with write access can \`/approve\`."
+            exit 0
+          fi
+          gh issue edit "$ISSUE_URL" \
+            --add-label    "status/approved" \
+            --remove-label "needs-triage"      2>/dev/null || true
+          gh issue edit "$ISSUE_URL" \
+            --remove-label "status/discussing" 2>/dev/null || true
+
+  on-closed:
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    needs: ensure-labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Advance widget to stage 5 (done)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit "$ISSUE_URL" \
+            --remove-label "queue/agent-ready" \
+            --remove-label "queue/claimed"     \
+            --remove-label "agent/blocked"     \
+            --remove-label "needs-triage"      2>/dev/null || true
+          DATA=$(gh issue view "$ISSUE_URL" --json labels,body,stateReason)
+          FULL_BODY=$(printf '%s' "$DATA" | jq -r '.body // ""')
+          CLEAN=$(printf '%s\n' "$FULL_BODY" | awk 'BEGIN{s=0} /^<!-- actionadon-pipeline -->/{s=1} s && /^---$/{s=0; next} !s{print}')
+          REASON=$(printf '%s'   "$DATA" | jq -r '.stateReason // "completed"')
+          DOMAIN=$(printf '%s'   "$DATA" | jq -r '[.labels[].name | select(startswith("domain:"))  | ltrimstr("domain:")]  | first // "—"')
+          PRIORITY=$(printf '%s' "$DATA" | jq -r '[.labels[].name | select(startswith("priority:")) | ltrimstr("priority:")] | first // "—"')
+          SIZE=$(printf '%s'     "$DATA" | jq -r '[.labels[].name | select(startswith("size:"))     | ltrimstr("size:")]     | first // "—"')
+          # shellcheck disable=SC2016
+          WIDGET=$(printf \
+            '<!-- actionadon-pipeline -->\n```\nKNUCKLE \U0001f996  \u00b7  issue pipeline\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  \u2714  filed      \u2014\n  \u2714  approved   \u2014\n  \u2714  queued     \u2014\n  \u2714  claimed    \u2014\n  \u2714  done       %s\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n  domain:       %-10s  \u00b7  priority: %s\n  size:         %s\n```\n\n---\n\n' \
+            "$REASON" "$DOMAIN" "$PRIORITY" "$SIZE")
+          printf '%s%s' "$WIDGET" "$CLEAN" > /tmp/new-body.md
+          gh issue edit "$ISSUE_URL" --body-file /tmp/new-body.md
+
+  on-stale:
+    if: github.event_name == 'schedule'
+    needs: ensure-labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Mark stale issues (no activity 60 days)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          for LABEL in "needs-triage" "queue/agent-ready"; do
+            gh issue list --repo "$REPO" \
+              --label "$LABEL" \
+              --state open \
+              --json number,updatedAt \
+              --jq '.[] | select((now - (.updatedAt | fromdateiso8601)) > 60 * 86400) | .number' \
+            | while read -r num; do
+                # Skip issues with hold label
+                LABELS=$(gh issue view "$num" --repo "$REPO" --json labels --jq '[.labels[].name]')
+                if printf '%s' "$LABELS" | grep -q '"hold"'; then continue; fi
+                gh issue edit "$num" --repo "$REPO" \
+                  --add-label "lifecycle/stale" 2>/dev/null || true
+              done
+          done

--- a/.github/workflows/hive-progress-sync.yml
+++ b/.github/workflows/hive-progress-sync.yml
@@ -1,0 +1,130 @@
+# hive-progress-sync — posts Knuckle queue stats to the projectbluefin org
+# project board (todo.projectbluefin.io) hourly and on every push to main.
+#
+# Tracks: queue/agent-ready, queue/claimed, priority:p0 counts
+# CI status: ci.yml (knuckle's primary build+test workflow)
+#
+# Requires: PROJECT_TOKEN secret with project + read:project OAuth scopes
+# Project board: PVT_kwDOCCE0ds4BLZBC (todo.projectbluefin.io, #2)
+
+name: Hive Progress Sync
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 * * * *'  # offset from dakota's :00 sync to avoid races
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Post knuckle queue status to project board
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          python3 << 'PYEOF'
+          import json, subprocess, sys, os
+          from datetime import datetime, timezone
+
+          PROJECT_ID    = "PVT_kwDOCCE0ds4BLZBC"
+          REPO          = "projectbluefin/knuckle"
+          ISSUES_URL    = f"https://github.com/{REPO}/issues"
+          DASHBOARD_URL = "https://github.com/orgs/projectbluefin/projects/2"
+
+          def gh(*args):
+              result = subprocess.run(
+                  ["gh"] + list(args),
+                  capture_output=True, text=True
+              )
+              if result.returncode != 0:
+                  print(f"gh error: {result.stderr}", file=sys.stderr)
+                  sys.exit(1)
+              return result.stdout.strip()
+
+          # CI status: latest completed ci.yml run
+          ci_raw  = gh("run", "list", "--repo", REPO, "--workflow", "ci.yml",
+                       "--limit", "1", "--json", "conclusion")
+          ci_runs = json.loads(ci_raw)
+          if ci_runs and ci_runs[0].get("conclusion") == "success":
+              ci = "CI ✅"
+          elif ci_runs and ci_runs[0].get("conclusion") in ("failure", "startup_failure"):
+              ci = "CI ❌"
+          else:
+              ci = "CI ⏳"
+
+          # Queue counts
+          def count_label(label):
+              raw = gh("issue", "list", "--repo", REPO,
+                       "--label", label, "--state", "open", "--json", "number")
+              return len(json.loads(raw))
+
+          n_ready   = count_label("queue/agent-ready")
+          n_claimed = count_label("queue/claimed")
+          n_p0      = count_label("priority:p0")
+
+          now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+          # Body
+          p0_fragment = f" · ▲ {n_p0} P0" if n_p0 > 0 else ""
+          status_line = f"`{ci}` · {n_ready} ready · {n_claimed} claimed{p0_fragment}"
+
+          body = "\n".join([
+              f"### Knuckle 🦖",
+              "",
+              status_line,
+              "",
+              f"_Updated {now_utc} · [Issue queue]({ISSUES_URL})_",
+          ])
+
+          print(f"Status body:\n{body}")
+
+          # Determine project status
+          if n_p0 > 0:
+              status = "OFF_TRACK"
+          elif n_claimed > 0:
+              status = "ON_TRACK"
+          else:
+              status = "AT_RISK"
+
+          # Guard: skip if PROJECT_TOKEN is not set
+          if not os.environ.get("GH_TOKEN"):
+              print("WARNING: PROJECT_TOKEN secret not set — skipping", file=sys.stderr)
+              sys.exit(0)
+
+          mutation = """
+          mutation($projectId: ID!, $body: String!, $status: ProjectV2StatusUpdateStatus!) {
+            createProjectV2StatusUpdate(input: {
+              projectId: $projectId
+              body: $body
+              status: $status
+            }) {
+              statusUpdate { id createdAt }
+            }
+          }
+          """
+
+          result = subprocess.run(
+              ["gh", "api", "graphql",
+               "-f", f"query={mutation}",
+               "-f", f"projectId={PROJECT_ID}",
+               "-f", f"body={body}",
+               "-f", f"status={status}"],
+              capture_output=True, text=True
+          )
+
+          if result.returncode != 0 or '"errors"' in result.stdout:
+              print("ERROR posting status update:", file=sys.stderr)
+              print(result.stdout, file=sys.stderr)
+              print(result.stderr, file=sys.stderr)
+              sys.exit(1)
+
+          resp      = json.loads(result.stdout)
+          update_id = resp["data"]["createProjectV2StatusUpdate"]["statusUpdate"]["id"]
+          print(f"Posted: {update_id}")
+          PYEOF
+        shell: bash


### PR DESCRIPTION
## What

Ports the agent/human issue automation from `projectbluefin/dakota` to knuckle.

### `actionadon.yml` — lifecycle bot

Every new issue gets a pipeline widget injected into its body (no comments, one in-place edit per stage):

```
KNUCKLE 🦖  ·  issue pipeline
─────────────────────────────────────────────────
  ▶  filed      needs triage
  ·  approved   signed off by a maintainer
  ·  queued     waiting for a contributor to claim
  ·  claimed    —
  ·  done       —
─────────────────────────────────────────────────
  domain:       tui         ·  priority: p1
  size:         XS          ·  next: /approve to queue
```

**Commands (comment on any issue):**
- `/approve` or `/lgtm` — maintainers only; moves to `status/approved` → `queue/agent-ready`
- `/claim` — self-assigns and moves to `queue/claimed`
- `/unclaim` — releases; only the assignee or a maintainer can unclaim

**Agent donation fast-track:** issues containing `Workflow: Agent Donation` + a PR/issue link are auto-approved and queued with the appropriate `flow/*` label.

**Stale detection:** daily at 09:00 UTC, issues with no activity in 60 days get `lifecycle/stale`.

### `hive-progress-sync.yml` — project board progress meter

Posts knuckle queue stats to [todo.projectbluefin.io](https://github.com/orgs/projectbluefin/projects/2) hourly (`:30` — offset from dakota's `:00` to avoid races):

```
### Knuckle 🦖

`CI ✅` · 3 ready · 1 claimed

_Updated 2026-05-29 17:00 UTC · Issue queue_
```

**Requires:** `PROJECT_TOKEN` secret with `project` + `read:project` scopes (same secret dakota uses — ask @castrojo to confirm it's set in knuckle's secrets).

### Label cleanup

The `ensure-labels` step in `actionadon.yml` creates/updates all lifecycle labels on first run — including fixing `hold` (red → grey) and adding the `status/*`, `queue/*`, `agent/*`, `flow/*` labels that dakota uses.

## Adaptations from dakota

| dakota | knuckle |
|---|---|
| `DAKOTA 🦖` branding | `KNUCKLE 🦖` |
| `area/` label prefix | `domain:` prefix |
| `priority/p1` | `priority:p1` |
| `report:` + `confirms:` fields | removed (not applicable) |
| `build.yml` CI check | `ci.yml` |
| Project board title update | **omitted** (knuckle shares the org board — dakota owns the title) |

## Merge note

⚠️ This PR touches `.github/workflows/*.yml` — it cannot be auto-merged via the merge queue. **Requires manual merge via GitHub UI.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated issue lifecycle management workflow that handles issue states, labels, and transitions through approval and queue stages.
  * Added automated project progress tracking workflow that syncs queue metrics and updates project health status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->