### PR TITLE
fix(ci): enforce Codecov patch coverage gate (#520)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,8 +12,8 @@ coverage:
         informational: false
     patch:
       default:
-        target: 80%
-        informational: true
+        target: 70%
+        informational: false
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## Summary

Change Codecov patch status from informational-only to a blocking 70% gate.

Currently `codecov.yml` sets:
- **Project**: `informational: false` at 91% ✓ (already blocking)
- **Patch**: `informational: true` at 80% — regressions on small/partial PRs pass silently

This PR changes patch to `informational: false` at 70%, ensuring new/modified lines must maintain at least 70% coverage or CI fails. The lower threshold (70% vs 80%) avoids blocking small drive-by fixes while still catching deletions of existing tests.

The per-package `cover-check` recipe in the Justfile already provides hard gates for internal packages (94-100%), so this complements CI with an aggregate safety net.

Closes #520