### PR TITLE
feat(model): add OS discriminator field to InstallConfig (#636)

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -91,6 +91,7 @@ func LoadConfig(path string) (*Config, error) {
 // ToInstallConfig converts a headless Config to a model.InstallConfig.
 func (c *Config) ToInstallConfig() *model.InstallConfig {
 	cfg := &model.InstallConfig{
+		OS:       model.OSFlatcar,
 		Arch:     c.Arch,
 		Channel:  c.Channel,
 		Version:  c.Version,

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -49,8 +49,15 @@ func (s WizardStep) String() string {
 	}
 }
 
+// OS target constants for the OS discriminator field.
+const (
+	OSFlatcar = "flatcar"
+	OSFCOS    = "fcos"
+)
+
 // InstallConfig is the complete installation configuration built by the wizard.
 type InstallConfig struct {
+	OS                  string // "flatcar" | "fcos"; defaults to "flatcar" for backward compatibility
 	Arch                string // amd64 or arm64 (determined at ISO build time; default "amd64")
 	Channel             string // stable, beta, alpha, edge
 	Version             string // optional: pin to specific Flatcar version (flatcar-install -V)
@@ -111,7 +118,8 @@ const (
 	TailscaleModeSubnetRouter = "subnet-router"
 )
 
-// UpdateStrategy holds OS update and reboot settings for Flatcar.
+// UpdateStrategy holds OS update and reboot settings.
+// Flatcar uses update-engine; FCOS uses zincati instead.
 type UpdateStrategy struct {
 	RebootStrategy string // "reboot", "off", "etcd-lock"
 	RebootWindow   string // optional: "Mon-Fri 04:00-05:00" format

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -71,6 +71,7 @@ func New(prober probe.Prober, bakeryClient bakery.Client, installer install.Inst
 		State: &State{
 			CurrentStep: model.StepWelcome,
 			Config: model.InstallConfig{
+				OS: model.OSFlatcar,
 				// Arch is set at compile time — the ISO is built for a specific architecture.
 				// runtime.GOARCH reflects the arch the binary was compiled for (amd64 or arm64).
 				Arch:           runtime.GOARCH,


### PR DESCRIPTION
## Summary

Adds OS discriminator field to InstallConfig as specified in #636.

### Changes
- **internal/model/model.go**: Added `OSFlatcar` / `OSFCOS` constants and `OS` field on `InstallConfig`. Default is `""` (treated as `"flatcar"` for backward compatibility). Updated `UpdateStrategy` comment to note FCOS uses zincati.
- **internal/wizard/wizard.go**: Default init sets `OS: model.OSFlatcar`
- **internal/headless/headless.go**: `ToInstallConfig()` sets `OS: model.OSFlatcar`

### Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — all 16 packages pass
- [x] All existing `InstallConfig{}` test literals still compile (zero-value `""` = `"flatcar"`)

Closes #636