### PR TITLE
refactor: convert nvidia_check.sh to Go nvidia-check tool (#626)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ cover_tui.out
 # Local worktrees (never committed)
 .worktrees/
 coverage.txt
+bin/
+nvidia-check

--- a/Justfile
+++ b/Justfile
@@ -1044,7 +1044,10 @@ catalog-check-strict:
 # Verify model.go NvidiaDriverOptions against the Flatcar NVIDIA docs.
 # Reports driver series mentioned in upstream docs vs what is in model.go.
 nvidia-check:
-    ./scripts/nvidia_check.sh
+    #!/usr/bin/env bash
+    GOOS=linux GOARCH={{KNUCKLE_ARCH}} CGO_ENABLED=0 go build \
+        -o bin/nvidia-check ./cmd/nvidia-check
+    ./bin/nvidia-check
 
 # Full pre-release preflight: catalog coverage + nvidia versions + CI gate.
 # Run this before tagging any release.

--- a/cmd/nvidia-check/main.go
+++ b/cmd/nvidia-check/main.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+const (
+	docsURL = "https://api.github.com/repos/flatcar/flatcar-website/contents/content/docs/latest/setup/customization/using-nvidia.md"
+	modelGo = "internal/model/model.go"
+)
+
+// ghContentResponse is the minimal GitHub API response for file contents.
+type ghContentResponse struct {
+	Content  string `json:"content"`
+	Encoding string `json:"encoding"`
+}
+
+func main() {
+	fmt.Println("nvidia_check — verifying model.go NvidiaDriverOptions against Flatcar docs")
+	fmt.Println("──────────────────────────────────────────────────────────────────────────")
+	fmt.Println()
+
+	// ── Fetch Flatcar docs ────────────────────────────────────────────────
+	fmt.Println("Fetching Flatcar NVIDIA docs...")
+	docContent, err := fetchNvidiaDocs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Could not fetch Flatcar NVIDIA docs from GitHub.\n")
+		fmt.Fprintf(os.Stderr, "  Check network or try: curl -sf '%s'\n", docsURL)
+		os.Exit(2)
+	}
+
+	// Extract all nvidia-drivers-* patterns from the docs.
+	docSeries := extractDriverSeries(docContent)
+	sort.Strings(docSeries)
+
+	fmt.Println()
+	fmt.Println("Driver series mentioned in Flatcar NVIDIA docs:")
+	if len(docSeries) == 0 {
+		fmt.Println("  (none found — docs may have changed structure)")
+	} else {
+		for _, series := range docSeries {
+			id := strings.TrimPrefix(series, "nvidia-drivers-")
+			fmt.Printf("  %s  (%s)\n", id, series)
+		}
+	}
+
+	// ── Extract model.go entries ──────────────────────────────────────────
+	fmt.Println()
+	fmt.Println("Driver series in model.go NvidiaDriverOptions:")
+	modelIDs := model.DriverSeriesMap()
+	var modelIDKeys []string
+	for k := range modelIDs {
+		modelIDKeys = append(modelIDKeys, k)
+	}
+	sort.Strings(modelIDKeys)
+
+	modelIDSet := make(map[string]bool)
+	for _, id := range modelIDKeys {
+		modelIDSet[id] = true
+		fmt.Printf("  %s  (nvidia-drivers-%s)\n", id, id)
+	}
+
+	// ── Compare ───────────────────────────────────────────────────────────
+	fmt.Println()
+	fmt.Println("──────────────────────────────────────────────────────────────────────────")
+
+	docSet := make(map[string]bool)
+	needsAdd := false
+	for _, series := range docSeries {
+		docSet[series] = true
+		id := strings.TrimPrefix(series, "nvidia-drivers-")
+		if !modelIDSet[id] {
+			fmt.Printf("⚠ MISSING IN MODEL: %s — mentioned in Flatcar docs but not in model.go\n", id)
+			needsAdd = true
+		}
+	}
+
+	for _, id := range modelIDKeys {
+		if !docSet["nvidia-drivers-"+id] {
+			fmt.Printf("  NOTE: %s is in model.go but not mentioned in current Flatcar docs\n", id)
+			fmt.Println("        (This is normal — docs typically only show the recommended series)")
+		}
+	}
+
+	fmt.Println()
+	if needsAdd {
+		fmt.Println("ACTION REQUIRED: Update internal/model/model.go NvidiaDriverOptions")
+		fmt.Println()
+		fmt.Println("  1. Add the missing series to NvidiaDriverOptions in internal/model/model.go")
+		fmt.Println("  2. Set Recommended: true on the newest open-source series")
+		fmt.Println("  3. Update DefaultNvidiaDriverSeries to the newest recommended series")
+		fmt.Println("  4. Update Description field with GPU compatibility information")
+		fmt.Println("  5. Update the NVIDIA section in docs/SYSEXTS.md")
+		fmt.Println("  6. Run: just ci")
+		os.Exit(1)
+	} else {
+		fmt.Println("✓ model.go NvidiaDriverOptions appears consistent with Flatcar docs.")
+		fmt.Println()
+		fmt.Println("Note: The Flatcar docs may only show a single example series.")
+		fmt.Println("For authoritative driver series availability, check:")
+		fmt.Println("  https://www.flatcar.org/docs/latest/setup/customization/using-nvidia/")
+		fmt.Println("  https://github.com/flatcar/flatcar-website")
+	}
+}
+
+func fetchNvidiaDocs() (string, error) {
+	resp, err := http.Get(docsURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var ghResp ghContentResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ghResp); err != nil {
+		return "", err
+	}
+
+	if ghResp.Encoding != "base64" {
+		return "", fmt.Errorf("unexpected encoding: %s", ghResp.Encoding)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(ghResp.Content, "\n", ""))
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+var driverSeriesRE = regexp.MustCompile(`nvidia-drivers-[a-z0-9-]+`)
+
+func extractDriverSeries(doc string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, match := range driverSeriesRE.FindAllString(doc, -1) {
+		if !seen[match] {
+			seen[match] = true
+			result = append(result, match)
+		}
+	}
+	return result
+}

--- a/cmd/nvidia-check/main.go
+++ b/cmd/nvidia-check/main.go
@@ -117,7 +117,7 @@ func fetchNvidiaDocs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP %d", resp.StatusCode)

--- a/cmd/nvidia-check/main_test.go
+++ b/cmd/nvidia-check/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestExtractDriverSeries_Empty(t *testing.T) {
+	result := extractDriverSeries("")
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestExtractDriverSeries_Single(t *testing.T) {
+	doc := "Install with nvidia-drivers-latest and reboot."
+	result := extractDriverSeries(doc)
+	if len(result) != 1 || result[0] != "nvidia-drivers-latest" {
+		t.Errorf("expected [nvidia-drivers-latest], got %v", result)
+	}
+}
+
+func TestExtractDriverSeries_Multiple(t *testing.T) {
+	doc := `Available driver series:
+- SYSEXTNAME=nvidia-drivers-550
+- SYSEXTNAME=nvidia-drivers-535
+- SYSEXTNAME=nvidia-drivers-470`
+	result := extractDriverSeries(doc)
+	if len(result) != 3 {
+		t.Errorf("expected 3 results, got %d: %v", len(result), result)
+	}
+	expected := []string{"nvidia-drivers-550", "nvidia-drivers-535", "nvidia-drivers-470"}
+	for i, exp := range expected {
+		if result[i] != exp {
+			t.Errorf("result[%d] = %q, want %q", i, result[i], exp)
+		}
+	}
+}
+
+func TestExtractDriverSeries_Dedup(t *testing.T) {
+	doc := "nvidia-drivers-latest and nvidia-drivers-latest again"
+	result := extractDriverSeries(doc)
+	if len(result) != 1 || result[0] != "nvidia-drivers-latest" {
+		t.Errorf("expected deduped [nvidia-drivers-latest], got %v", result)
+	}
+}
+
+func TestExtractDriverSeries_Production(t *testing.T) {
+	// Production-like examples (open-source and proprietary variants)
+	doc := `Example: SYSEXTNAME=nvidia-drivers-latest SYSEXTOPTS="--strip"
+For older GPUs: SYSEXTNAME=nvidia-drivers-550
+Also available: nvidia-drivers-production nvidia-drivers-470`
+	result := extractDriverSeries(doc)
+	if len(result) != 4 {
+		t.Errorf("expected 4 results, got %d: %v", len(result), result)
+	}
+	seen := make(map[string]bool)
+	for _, r := range result {
+		seen[r] = true
+	}
+	for _, want := range []string{"nvidia-drivers-latest", "nvidia-drivers-550", "nvidia-drivers-production", "nvidia-drivers-470"} {
+		if !seen[want] {
+			t.Errorf("missing expected driver series: %s", want)
+		}
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -225,6 +225,15 @@ var NvidiaDriverOptions = []NvidiaDriverSeries{
 	},
 }
 
+// DriverSeriesMap returns a map of NvidiaDriverSeries ID to Label for verification tools.
+func DriverSeriesMap() map[string]string {
+	m := make(map[string]string, len(NvidiaDriverOptions))
+	for _, s := range NvidiaDriverOptions {
+		m[s.ID] = s.Label
+	}
+	return m
+}
+
 // DefaultNvidiaDriverSeries is the driver series selected when auto-detecting an NVIDIA GPU.
 const DefaultNvidiaDriverSeries = "570-open"
 

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -159,3 +159,20 @@ func TestDefaultNvidiaDriverSeries_IsRecommended(t *testing.T) {
 	}
 	t.Fatalf("DefaultNvidiaDriverSeries %q not found", DefaultNvidiaDriverSeries)
 }
+
+func TestDriverSeriesMap(t *testing.T) {
+	m := DriverSeriesMap()
+	if len(m) != len(NvidiaDriverOptions) {
+		t.Errorf("expected map length %d, got %d", len(NvidiaDriverOptions), len(m))
+	}
+	for _, opt := range NvidiaDriverOptions {
+		label, exists := m[opt.ID]
+		if !exists {
+			t.Errorf("expected key %q to exist in map", opt.ID)
+		}
+		if label != opt.Label {
+			t.Errorf("expected key %q to have label %q, got %q", opt.ID, opt.Label, label)
+		}
+	}
+}
+

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -175,4 +175,3 @@ func TestDriverSeriesMap(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

Converts `scripts/nvidia_check.sh` (109-line shell script) to a Go binary at `cmd/nvidia-check/main.go`.

Closes #626

## Changes

- **cmd/nvidia-check/main.go** — Go reimplementation with stdlib only (net/http, encoding/json, encoding/base64, regexp)
- **internal/model/model.go** — Adds `DriverSeriesMap()` helper to expose NvidiaDriverOptions for tooling
- **Justfile** — Updates `nvidia-check` recipe to build and run the Go binary

## Why

Part of #626 (Get rid of shell scripts). The nvidia_check shell script is the smallest CI-facing script — converting it first establishes the pattern for converting the remaining scripts. The Go version is faster, type-safe, and testable.