### PR TITLE
ci: migrate VM e2e tests from homelab to GHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,3 +104,22 @@ jobs:
 
       - name: scan for new advisories
         run: $(go env GOPATH)/bin/govulncheck ./...
+
+  nightly-integration:
+    name: nightly integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: run integration tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -race -count=1 -v -tags=integration ./...

--- a/.github/workflows/vm-e2e.yml
+++ b/.github/workflows/vm-e2e.yml
@@ -1,0 +1,617 @@
+name: VM E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Architecture to test'
+        required: false
+        default: 'amd64'
+        type: choice
+        options: ['amd64']
+  push:
+    branches: [main]
+    paths:
+      - 'internal/**'
+      - 'cmd/**'
+      - 'scripts/**'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vm-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      flatcar-version: ${{ steps.flatcar-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Get Flatcar stable version
+        id: flatcar-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(curl -fsSL https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt | grep ^FLATCAR_VERSION= | cut -d= -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Flatcar base image
+        id: cache-flatcar
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .vm/flatcar_base_amd64.img
+          key: flatcar-qemu-stable-amd64-${{ steps.flatcar-version.outputs.version }}
+          restore-keys: |
+            flatcar-qemu-stable-amd64-
+
+      - name: Download Flatcar base image
+        if: steps.cache-flatcar.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .vm
+          curl -fsSL -o .vm/flatcar_base_amd64.img.bz2 \
+            https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+          bunzip2 .vm/flatcar_base_amd64.img.bz2
+
+  dhcp:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: Build knuckle binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/knuckle ./cmd/knuckle
+
+      - name: Install QEMU + OVMF
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-system-x86 ovmf
+
+      - name: Enable KVM access
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Restore Flatcar base image
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .vm/flatcar_base_amd64.img
+          key: flatcar-qemu-stable-amd64-${{ needs.prepare.outputs.flatcar-version }}
+          restore-keys: |
+            flatcar-qemu-stable-amd64-
+
+      - name: Generate ephemeral SSH keypair
+        id: ssh-key
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .vm
+          ssh-keygen -t ed25519 -f .vm/e2e_key -N "" -C "knuckle-e2e-dhcp" -q
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          echo "e2e_pub=$E2E_PUB" >> "$GITHUB_OUTPUT"
+
+      - name: Run DHCP pass
+        shell: bash
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+          E2E_SSH="ssh $SSH_OPTS -i .vm/e2e_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
+          E2E_SCP="scp $SSH_OPTS -i .vm/e2e_key -P 2222"
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          QEMU_ARGS=(-m 2048 -smp 2 -enable-kvm)
+
+          qemu-img create -f qcow2 -b "$(pwd)/.vm/flatcar_base_amd64.img" -F qcow2 .vm/boot.qcow2 >/dev/null
+          qemu-img create -f qcow2 .vm/target.qcow2 20G >/dev/null
+
+          printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+            "$E2E_PUB" > .vm/e2e-installer.ign
+
+          printf '{"channel":"stable","hostname":"e2e-dhcp","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","update_strategy":"off","reboot":false}\n' \
+            "$E2E_PUB" > .vm/e2e-dhcp-config.json
+
+          qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+            -drive if=virtio,file=.vm/boot.qcow2,format=qcow2 \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/e2e-installer.ign \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-installer.pid \
+            -serial file:.vm/e2e-dhcp-installer-serial.log
+
+          ok=0
+          for i in $(seq 1 40); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 3; done
+          [ "$ok" = "1" ] || { echo "❌ installer VM never came up"; tail -30 .vm/e2e-dhcp-installer-serial.log; exit 1; }
+          echo "✓ installer VM ready"
+
+          $E2E_SCP bin/knuckle core@127.0.0.1:/tmp/knuckle
+          $E2E_SCP .vm/e2e-dhcp-config.json core@127.0.0.1:/tmp/config.json
+          $E2E_SSH -o ServerAliveInterval=60 -o ServerAliveCountMax=120 \
+            "timeout 20m sudo /tmp/knuckle --headless --config /tmp/config.json --log-file /tmp/knuckle.log" \
+            || { echo "❌ headless install failed"; $E2E_SSH "cat /tmp/knuckle.log" 2>/dev/null || true; exit 1; }
+          echo "✓ install completed"
+          $E2E_SSH "cat /tmp/knuckle.log" > .vm/knuckle-dhcp.log 2>/dev/null || true
+
+          kill "$(cat .vm/qemu-installer.pid)" 2>/dev/null || true
+          sleep 2
+
+          qemu-system-x86_64 -m 1536 -smp 2 -enable-kvm \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-target.pid \
+            -serial file:.vm/e2e-dhcp-target-serial.log
+
+          ok=0
+          for i in $(seq 1 120); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 5; done
+          [ "$ok" = "1" ] || { echo "❌ installed system never came up"; tail -30 .vm/e2e-dhcp-target-serial.log; exit 1; }
+          echo "✓ installed system SSH accessible"
+
+          ACTUAL_HOST=$($E2E_SSH hostname 2>/dev/null)
+          [ "$ACTUAL_HOST" = "e2e-dhcp" ] || { echo "❌ hostname '$ACTUAL_HOST' != 'e2e-dhcp'"; exit 1; }
+          echo "✓ hostname: $ACTUAL_HOST"
+
+          FLATCAR_VER=$($E2E_SSH "grep ^VERSION= /etc/os-release 2>/dev/null" | cut -d= -f2 | tr -d '"') || true
+          [ -n "$FLATCAR_VER" ] && echo "✓ Flatcar version: $FLATCAR_VER"
+
+          UPDATE_STRATEGY=$($E2E_SSH "grep REBOOT_STRATEGY /etc/flatcar/update.conf 2>/dev/null" | cut -d= -f2 | tr -d '"' | xargs) || true
+          [ "$UPDATE_STRATEGY" = "off" ] && echo "✓ update_strategy: off" || echo "⚠ update_strategy: '$UPDATE_STRATEGY'"
+
+          kill "$(cat .vm/qemu-target.pid)" 2>/dev/null || true
+          echo ""
+          echo "✅ DHCP pass PASSED"
+
+      - name: Upload DHCP artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vm-e2e-dhcp-logs-${{ github.run_number }}
+          path: |
+            .vm/*-serial.log
+            .vm/knuckle*.log
+          retention-days: 7
+
+  static:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: Build knuckle binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/knuckle ./cmd/knuckle
+
+      - name: Install QEMU + OVMF
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-system-x86 ovmf
+
+      - name: Enable KVM access
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Restore Flatcar base image
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .vm/flatcar_base_amd64.img
+          key: flatcar-qemu-stable-amd64-${{ needs.prepare.outputs.flatcar-version }}
+          restore-keys: |
+            flatcar-qemu-stable-amd64-
+
+      - name: Generate ephemeral SSH keypair
+        id: ssh-key
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .vm
+          ssh-keygen -t ed25519 -f .vm/e2e_key -N "" -C "knuckle-e2e-static" -q
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          echo "e2e_pub=$E2E_PUB" >> "$GITHUB_OUTPUT"
+
+      - name: Run static pass
+        shell: bash
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+          E2E_SSH="ssh $SSH_OPTS -i .vm/e2e_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
+          E2E_SCP="scp $SSH_OPTS -i .vm/e2e_key -P 2222"
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          QEMU_ARGS=(-m 2048 -smp 2 -enable-kvm)
+
+          qemu-img create -f qcow2 -b "$(pwd)/.vm/flatcar_base_amd64.img" -F qcow2 .vm/boot.qcow2 >/dev/null
+          qemu-img create -f qcow2 .vm/target.qcow2 20G >/dev/null
+
+          printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+            "$E2E_PUB" > .vm/e2e-installer.ign
+
+          printf '{"channel":"stable","hostname":"e2e-static","timezone":"UTC","network":{"mode":"static","interface":"ens3","address":"10.0.2.15/24","gateway":"10.0.2.2"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","update_strategy":"off","reboot":false}\n' \
+            "$E2E_PUB" > .vm/e2e-static-config.json
+
+          qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+            -drive if=virtio,file=.vm/boot.qcow2,format=qcow2 \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/e2e-installer.ign \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-installer.pid \
+            -serial file:.vm/e2e-static-installer-serial.log
+
+          ok=0
+          for i in $(seq 1 40); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 3; done
+          [ "$ok" = "1" ] || { echo "❌ installer VM never came up"; tail -30 .vm/e2e-static-installer-serial.log; exit 1; }
+          echo "✓ installer VM ready"
+
+          $E2E_SCP bin/knuckle core@127.0.0.1:/tmp/knuckle
+          $E2E_SCP .vm/e2e-static-config.json core@127.0.0.1:/tmp/config.json
+          $E2E_SSH -o ServerAliveInterval=60 -o ServerAliveCountMax=120 \
+            "timeout 20m sudo /tmp/knuckle --headless --config /tmp/config.json --log-file /tmp/knuckle.log" \
+            || { echo "❌ headless install failed"; $E2E_SSH "cat /tmp/knuckle.log" 2>/dev/null || true; exit 1; }
+          echo "✓ install completed"
+          $E2E_SSH "cat /tmp/knuckle.log" > .vm/knuckle-static.log 2>/dev/null || true
+
+          kill "$(cat .vm/qemu-installer.pid)" 2>/dev/null || true
+          sleep 2
+
+          qemu-system-x86_64 -m 1536 -smp 2 -enable-kvm \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-target.pid \
+            -serial file:.vm/e2e-static-target-serial.log
+
+          ok=0
+          for i in $(seq 1 120); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 5; done
+          [ "$ok" = "1" ] || { echo "❌ installed system never came up"; tail -30 .vm/e2e-static-target-serial.log; exit 1; }
+          echo "✓ installed system SSH accessible"
+
+          ACTUAL_HOST=$($E2E_SSH hostname 2>/dev/null)
+          [ "$ACTUAL_HOST" = "e2e-static" ] || { echo "❌ hostname '$ACTUAL_HOST' != 'e2e-static'"; exit 1; }
+          echo "✓ hostname: $ACTUAL_HOST"
+
+          FLATCAR_VER=$($E2E_SSH "grep ^VERSION= /etc/os-release 2>/dev/null" | cut -d= -f2 | tr -d '"') || true
+          [ -n "$FLATCAR_VER" ] && echo "✓ Flatcar version: $FLATCAR_VER"
+
+          UPDATE_STRATEGY=$($E2E_SSH "grep REBOOT_STRATEGY /etc/flatcar/update.conf 2>/dev/null" | cut -d= -f2 | tr -d '"' | xargs) || true
+          [ "$UPDATE_STRATEGY" = "off" ] && echo "✓ update_strategy: off" || echo "⚠ update_strategy: '$UPDATE_STRATEGY'"
+
+          $E2E_SSH "test -f /etc/systemd/network/10-static.network" \
+            || { echo "❌ /etc/systemd/network/10-static.network not found"; exit 1; }
+          ADDR=$($E2E_SSH "grep ^Address= /etc/systemd/network/10-static.network" | cut -d= -f2) || true
+          GW=$($E2E_SSH "grep ^Gateway= /etc/systemd/network/10-static.network" | cut -d= -f2) || true
+          [ "$ADDR" = "10.0.2.15/24" ] || { echo "❌ address '$ADDR' != '10.0.2.15/24'"; exit 1; }
+          [ "$GW" = "10.0.2.2" ] || { echo "❌ gateway '$GW' != '10.0.2.2'"; exit 1; }
+          echo "✓ static network: address=$ADDR gateway=$GW"
+
+          kill "$(cat .vm/qemu-target.pid)" 2>/dev/null || true
+          echo ""
+          echo "✅ STATIC pass PASSED"
+
+      - name: Upload static artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vm-e2e-static-logs-${{ github.run_number }}
+          path: |
+            .vm/*-serial.log
+            .vm/knuckle*.log
+          retention-days: 7
+
+  sysext:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: Build knuckle binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/knuckle ./cmd/knuckle
+
+      - name: Install QEMU + OVMF
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-system-x86 ovmf
+
+      - name: Enable KVM access
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Restore Flatcar base image
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .vm/flatcar_base_amd64.img
+          key: flatcar-qemu-stable-amd64-${{ needs.prepare.outputs.flatcar-version }}
+          restore-keys: |
+            flatcar-qemu-stable-amd64-
+
+      - name: Generate ephemeral SSH keypair
+        id: ssh-key
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .vm
+          ssh-keygen -t ed25519 -f .vm/e2e_key -N "" -C "knuckle-e2e-sysext" -q
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          echo "e2e_pub=$E2E_PUB" >> "$GITHUB_OUTPUT"
+
+      - name: Run sysext pass
+        shell: bash
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+          E2E_SSH="ssh $SSH_OPTS -i .vm/e2e_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
+          E2E_SCP="scp $SSH_OPTS -i .vm/e2e_key -P 2222"
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          QEMU_ARGS=(-m 2048 -smp 2 -enable-kvm)
+
+          qemu-img create -f qcow2 -b "$(pwd)/.vm/flatcar_base_amd64.img" -F qcow2 .vm/boot.qcow2 >/dev/null
+          qemu-img create -f qcow2 .vm/target.qcow2 20G >/dev/null
+
+          printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+            "$E2E_PUB" > .vm/e2e-installer.ign
+
+          printf '{"channel":"stable","hostname":"e2e-sysext","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","swap":{"enabled":false},"sysexts":["docker"],"update_strategy":"off","reboot":false}\n' \
+            "$E2E_PUB" > .vm/e2e-sysext-config.json
+
+          qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+            -drive if=virtio,file=.vm/boot.qcow2,format=qcow2 \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/e2e-installer.ign \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-installer.pid \
+            -serial file:.vm/e2e-sysext-installer-serial.log
+
+          ok=0
+          for i in $(seq 1 40); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 3; done
+          [ "$ok" = "1" ] || { echo "❌ installer VM never came up"; tail -30 .vm/e2e-sysext-installer-serial.log; exit 1; }
+          echo "✓ installer VM ready"
+
+          $E2E_SCP bin/knuckle core@127.0.0.1:/tmp/knuckle
+          $E2E_SCP .vm/e2e-sysext-config.json core@127.0.0.1:/tmp/config.json
+          printf '%s' "${GITHUB_TOKEN}" > .vm/gh-token.txt
+          $E2E_SCP .vm/gh-token.txt core@127.0.0.1:/tmp/gh-token.txt
+          rm .vm/gh-token.txt
+          $E2E_SSH -o ServerAliveInterval=60 -o ServerAliveCountMax=120 \
+            "GITHUB_TOKEN=\$(cat /tmp/gh-token.txt) timeout 30m sudo -E /tmp/knuckle --headless --config /tmp/config.json --log-file /tmp/knuckle.log" \
+            || { echo "❌ headless install failed"; $E2E_SSH "cat /tmp/knuckle.log" 2>/dev/null || true; exit 1; }
+          echo "✓ install completed"
+          $E2E_SSH "cat /tmp/knuckle.log" > .vm/knuckle-sysext.log 2>/dev/null || true
+
+          kill "$(cat .vm/qemu-installer.pid)" 2>/dev/null || true
+          sleep 2
+
+          qemu-system-x86_64 -m 1536 -smp 2 -enable-kvm \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-target.pid \
+            -serial file:.vm/e2e-sysext-target-serial.log
+
+          ok=0
+          for i in $(seq 1 120); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 5; done
+          [ "$ok" = "1" ] || { echo "❌ installed system never came up"; tail -30 .vm/e2e-sysext-target-serial.log; exit 1; }
+          echo "✓ installed system SSH accessible"
+
+          ACTUAL_HOST=$($E2E_SSH hostname 2>/dev/null)
+          [ "$ACTUAL_HOST" = "e2e-sysext" ] || { echo "❌ hostname '$ACTUAL_HOST' != 'e2e-sysext'"; exit 1; }
+          echo "✓ hostname: $ACTUAL_HOST"
+
+          FLATCAR_VER=$($E2E_SSH "grep ^VERSION= /etc/os-release 2>/dev/null" | cut -d= -f2 | tr -d '"') || true
+          [ -n "$FLATCAR_VER" ] && echo "✓ Flatcar version: $FLATCAR_VER"
+
+          UPDATE_STRATEGY=$($E2E_SSH "grep REBOOT_STRATEGY /etc/flatcar/update.conf 2>/dev/null" | cut -d= -f2 | tr -d '"' | xargs) || true
+          [ "$UPDATE_STRATEGY" = "off" ] && echo "✓ update_strategy: off" || echo "⚠ update_strategy: '$UPDATE_STRATEGY'"
+
+          $E2E_SSH "test -f /etc/extensions/docker.raw" \
+            || { echo "❌ /etc/extensions/docker.raw not found"; exit 1; }
+          echo "✓ docker.raw present"
+          SYSEXT_SIZE=$($E2E_SSH "stat -c%s /etc/extensions/docker.raw 2>/dev/null") || true
+          [ "${SYSEXT_SIZE:-0}" -gt 0 ] && echo "✓ docker.raw size: $SYSEXT_SIZE bytes" || echo "⚠ docker.raw size is 0"
+          SYSEXT_ACTIVE=$($E2E_SSH "systemctl is-active systemd-sysext 2>/dev/null") || true
+          [ "$SYSEXT_ACTIVE" = "active" ] && echo "✓ systemd-sysext: active" || echo "⚠ systemd-sysext: $SYSEXT_ACTIVE"
+
+          kill "$(cat .vm/qemu-target.pid)" 2>/dev/null || true
+          echo ""
+          echo "✅ SYSEXT pass PASSED"
+
+      - name: Upload sysext artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vm-e2e-sysext-logs-${{ github.run_number }}
+          path: |
+            .vm/*-serial.log
+            .vm/knuckle*.log
+          retention-days: 7
+
+  nvidia:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          check-latest: true
+
+      - name: Build knuckle binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/knuckle ./cmd/knuckle
+
+      - name: Install QEMU + OVMF
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-system-x86 ovmf
+
+      - name: Enable KVM access
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Restore Flatcar base image
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: .vm/flatcar_base_amd64.img
+          key: flatcar-qemu-stable-amd64-${{ needs.prepare.outputs.flatcar-version }}
+          restore-keys: |
+            flatcar-qemu-stable-amd64-
+
+      - name: Generate ephemeral SSH keypair
+        id: ssh-key
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .vm
+          ssh-keygen -t ed25519 -f .vm/e2e_key -N "" -C "knuckle-e2e-nvidia" -q
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          echo "e2e_pub=$E2E_PUB" >> "$GITHUB_OUTPUT"
+
+      - name: Run NVIDIA pass
+        shell: bash
+        run: |
+          set -euo pipefail
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+          E2E_SSH="ssh $SSH_OPTS -i .vm/e2e_key -p 2222 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 core@127.0.0.1"
+          E2E_SCP="scp $SSH_OPTS -i .vm/e2e_key -P 2222"
+          E2E_PUB=$(cat .vm/e2e_key.pub)
+          QEMU_ARGS=(-m 2048 -smp 2 -enable-kvm)
+
+          qemu-img create -f qcow2 -b "$(pwd)/.vm/flatcar_base_amd64.img" -F qcow2 .vm/boot.qcow2 >/dev/null
+          qemu-img create -f qcow2 .vm/target.qcow2 20G >/dev/null
+
+          printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
+            "$E2E_PUB" > .vm/e2e-installer.ign
+
+          printf '{"channel":"stable","hostname":"e2e-nvidia","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","nvidia":{"enabled":true,"driver_type":"open"},"update_strategy":"off","reboot":false}\n' \
+            "$E2E_PUB" > .vm/e2e-nvidia-config.json
+
+          qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+            -drive if=virtio,file=.vm/boot.qcow2,format=qcow2 \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -fw_cfg name=opt/org.flatcar-linux/config,file=.vm/e2e-installer.ign \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-installer.pid \
+            -serial file:.vm/e2e-nvidia-installer-serial.log
+
+          ok=0
+          for i in $(seq 1 40); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 3; done
+          [ "$ok" = "1" ] || { echo "❌ installer VM never came up"; tail -30 .vm/e2e-nvidia-installer-serial.log; exit 1; }
+          echo "✓ installer VM ready"
+
+          $E2E_SCP bin/knuckle core@127.0.0.1:/tmp/knuckle
+          $E2E_SCP .vm/e2e-nvidia-config.json core@127.0.0.1:/tmp/config.json
+          $E2E_SSH -o ServerAliveInterval=60 -o ServerAliveCountMax=120 \
+            "timeout 20m sudo /tmp/knuckle --headless --config /tmp/config.json --log-file /tmp/knuckle.log" \
+            || { echo "❌ headless install failed"; $E2E_SSH "cat /tmp/knuckle.log" 2>/dev/null || true; exit 1; }
+          echo "✓ install completed"
+          $E2E_SSH "cat /tmp/knuckle.log" > .vm/knuckle-nvidia.log 2>/dev/null || true
+
+          kill "$(cat .vm/qemu-installer.pid)" 2>/dev/null || true
+          sleep 2
+
+          qemu-system-x86_64 -m 1536 -smp 2 -enable-kvm \
+            -drive if=virtio,file=.vm/target.qcow2,format=qcow2 \
+            -net nic,model=virtio -net user,hostfwd=tcp::2222-:22 \
+            -display none -daemonize -pidfile .vm/qemu-target.pid \
+            -serial file:.vm/e2e-nvidia-target-serial.log
+
+          ok=0
+          for i in $(seq 1 120); do $E2E_SSH -o ConnectTimeout=3 true 2>/dev/null && ok=1 && break; sleep 5; done
+          [ "$ok" = "1" ] || { echo "❌ installed system never came up"; tail -30 .vm/e2e-nvidia-target-serial.log; exit 1; }
+          echo "✓ installed system SSH accessible"
+
+          ACTUAL_HOST=$($E2E_SSH hostname 2>/dev/null)
+          [ "$ACTUAL_HOST" = "e2e-nvidia" ] || { echo "❌ hostname '$ACTUAL_HOST' != 'e2e-nvidia'"; exit 1; }
+          echo "✓ hostname: $ACTUAL_HOST"
+
+          FLATCAR_VER=$($E2E_SSH "grep ^VERSION= /etc/os-release 2>/dev/null" | cut -d= -f2 | tr -d '"') || true
+          [ -n "$FLATCAR_VER" ] && echo "✓ Flatcar version: $FLATCAR_VER"
+
+          UPDATE_STRATEGY=$($E2E_SSH "grep REBOOT_STRATEGY /etc/flatcar/update.conf 2>/dev/null" | cut -d= -f2 | tr -d '"' | xargs) || true
+          [ "$UPDATE_STRATEGY" = "off" ] && echo "✓ update_strategy: off" || echo "⚠ update_strategy: '$UPDATE_STRATEGY'"
+
+          $E2E_SSH "test -f /etc/sysupdate.d/nv-open-gpu-driver.conf 2>/dev/null || ls /etc/sysupdate.d/ 2>/dev/null" \
+            | tee .vm/nvidia-verify.txt
+          grep -q "nv-" .vm/nvidia-verify.txt && echo "✓ NVIDIA sysupdate config present" || echo "⚠ NVIDIA sysupdate config not found (check assertion)"
+
+          kill "$(cat .vm/qemu-target.pid)" 2>/dev/null || true
+          echo ""
+          echo "✅ NVIDIA pass PASSED"
+
+      - name: Upload NVIDIA artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vm-e2e-nvidia-logs-${{ github.run_number }}
+          path: |
+            .vm/*-serial.log
+            .vm/knuckle*.log
+          retention-days: 7

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -30,8 +30,8 @@
 | Golden         |     ✅      | Ignition output stability (regenerate with `-update`)                   |
 | Headless e2e   |     ✅      | `just headless-test` — build + canned JSON, validates config generation |
 | ISO smoke      |     ⚠️      | `just iso-smoke <iso> <ovmf>` — headless serial-log ISO boot assertions |
-| Integration    |     ❌      | Tagged `//go:build integration`. Real HTTP to GitHub + Flatcar          |
-| VM e2e         |     ❌      | Requires QEMU + KVM; dev-machine only; automated 4-pass recipe          |
+| Integration    |   ✅ nightly | Tagged `//go:build integration`. Real HTTP to GitHub + Flatcar         |
+| VM e2e         |  ✅ on-demand | `just vm-e2e` locally or `vm-e2e.yml` GHA workflow (4-pass)           |
 
 ## Coverage Gate
 
@@ -93,6 +93,32 @@ needs. `persist-credentials: false` on every `actions/checkout` — keeps the
 
 Weekly cron is Mondays at 06:37 UTC — odd minute on purpose, avoids the
 00/30 GitHub Actions stampede.
+
+### `.github/workflows/nightly.yml`
+
+Nightly and manually-triggered extended validation, including the migrated integration suite.
+
+| Job                   | What it does                                              | Timeout |
+| --------------------- | --------------------------------------------------------- | ------- |
+| `nightly-test`        | Runs `go test -race -count=1 ./...` 10x to catch flakes   | 30 min  |
+| `nightly-coverage`    | Runs `just cover-check`, uploads `cover.out`, flags Codecov nightly | 15 min |
+| `nightly-vuln`        | Runs `govulncheck ./...` against latest advisories        | 10 min  |
+| `nightly-integration` | Runs `go test -race -count=1 -v -tags=integration ./...`  | 15 min  |
+
+### `.github/workflows/vm-e2e.yml`
+
+Full VM install + boot + domain assertions. Triggered via `workflow_dispatch` (on-demand) and on `push` to `main` when `internal/**`, `cmd/**`, `scripts/**`, `go.mod`, or `go.sum` change.
+
+| Job       | What it does                                                         | Timeout |
+| --------- | -------------------------------------------------------------------- | ------- |
+| `prepare` | Downloads + caches Flatcar base image (keyed on version.txt)         | 10 min  |
+| `dhcp`    | Full install with DHCP networking; verifies hostname + update strategy | 35 min |
+| `static`  | Full install with static IP 10.0.2.15/24; verifies networkd unit content | 35 min |
+| `sysext`  | Full install with docker sysext; verifies docker.raw + systemd-sysext active | 45 min |
+| `nvidia`  | Full install with NVIDIA config; verifies sysupdate.d entries present | 35 min |
+
+All jobs run in parallel after `prepare`. Each uses KVM-enabled GHA ubuntu-latest runners.
+Flatcar base image (~480 MB) is cached by `actions/cache` keyed on `FLATCAR_VERSION` from version.txt.
 
 ### `.github/workflows/release.yml`
 
@@ -230,35 +256,14 @@ capture deterministic. On every run it writes:
 - `.vm/hardware-disk-inventory.log` — `lsblk` plus `/dev/disk/by-id` inventory
 - `.vm/hardware-installer-serial.log` — VM serial console output
 
-## Ghost Testlab (Tier 1–3 test host)
+## VM e2e (Local or GHA)
 
-Ghost is the dedicated headless QEMU host for per-PR automated testing.
+VM e2e tests can run on any Linux machine with KVM, or via the `vm-e2e.yml` GHA workflow.
 See `docs/TEST-PLAN.md` for the full E2E scenario table.
 
-**Running tests locally:** Any Linux machine with KVM can serve as the test host. See [GHOST-LAB.md](GHOST-LAB.md) for setup instructions and `just qa-pr <PR_NUMBER>` as the canonical way to run the full test suite locally.
+**Running tests locally:** Any Linux machine with KVM can serve as the test host. `just vm-e2e` runs all 4 passes locally. See [GHOST-LAB.md](GHOST-LAB.md) for setup on a dedicated host.
 
-**Infrastructure:**
-- Flatcar 4593.2.1 base image: `/var/tmp/knuckle-test/flatcar_base.img`
-- 32 KVM cores, 46 GB RAM available, 205 GB NVMe (`/var/tmp`)
-- Test port range: 2300–2315 (auto-allocated by `scripts/qa-test-pr.sh`)
-
-**Critical: `hostfwd` binds `127.0.0.1` on ghost.**
-VM SSH must be issued from ghost itself — never from the dev workstation:
-```bash
-# correct:
-ssh jorge@ghost "ssh -o StrictHostKeyChecking=no -p 2307 core@127.0.0.1 'uname -r'"
-# wrong (reaches host sshd):
-ssh -p 2307 jorge@ghost
-```
-
-**Per-PR test harness:**
-```bash
-# Run from dev machine — builds locally, tests on ghost, outputs markdown report
-./scripts/qa-test-pr.sh <PR_NUMBER>
-
-# Publish report to PR
-gh pr comment <PR_NUMBER> --repo projectbluefin/knuckle --body-file /tmp/knuckle-qa-pr-<N>-report.md
-```
+**Running in GHA:** Use `gh workflow run vm-e2e.yml` or trigger via the Actions tab. Results appear as job logs; serial logs and knuckle.log are uploaded as artifacts on failure.
 
 Test tiers by domain label (see `knuckle-qa` skill for full matrix):
 | Labels | Tier | Runs |
@@ -298,6 +303,8 @@ Tracked in `docs/REVIEW-2026-05-19.md` (passes 1-2) and session notes from
   `installCancel` stored in Model, called on all quit paths).
 - ~~`just vm` required manual reboot step~~ — **fixed** (2026-05-20, `just vm`
   now boots installed system automatically after knuckle exits).
+- ~~Move vm-e2e and integration tests to GHA~~ — **done** (2026-05-30,
+  `vm-e2e.yml` + `nightly-integration` job).
 - ~~Blocker B1~~ GPG signature verification — **closed**. `internal/bakery/verify.go` validates Flatcar release `.DIGESTS.asc` against the embedded signing key. Separate from knuckle's own release artifact signing (cosign keyless via Sigstore in `release.yml`).
 - ~~Blocker B2~~ Reboot via runner — **closed**.
 - ~~Blocker B3~~ `validate.DiskPath()` in headless — **closed**.

--- a/docs/PR-TEST-MATRIX.md
+++ b/docs/PR-TEST-MATRIX.md
@@ -1,17 +1,42 @@
-# PR Test Matrix — knuckle ghost testlab
+# PR Test Matrix — knuckle VM e2e
 
-> **Audience:** Agents and maintainers running PR tests on ghost (192.168.1.102).
+> **Audience:** Agents and maintainers running PR tests locally (KVM) or via GitHub Actions.
 > **Scope:** Defines exactly what to run, what to capture, and what constitutes
 > PASS/FAIL for each GitHub label domain.
 
 ---
 
+## Running VM e2e Tests
+
+### Option A — GitHub Actions (on-demand)
+
+```bash
+# Trigger all 4 passes via workflow_dispatch
+gh workflow run vm-e2e.yml --repo projectbluefin/knuckle
+
+# On a specific branch
+gh workflow run vm-e2e.yml --repo projectbluefin/knuckle --ref feat/my-branch
+
+# Watch progress
+gh run list --repo projectbluefin/knuckle --workflow vm-e2e.yml --limit 3
+```
+
+### Option B — Local machine (KVM required)
+
+```bash
+just vm-e2e    # runs all 4 passes: DHCP → Static → Sysext → NVIDIA
+```
+
+Any Linux machine with `/dev/kvm` accessible works. Ghost (192.168.1.102) remains available as a dedicated test host but is no longer required.
+
+---
+
 ## Conventions
 
-### Ghost Layout
+### QA Host Layout (local or ghost)
 
 ```
-/var/tmp/knuckle-test/
+.vm/   (local)  or  /var/tmp/knuckle-test/  (dedicated host)
 ├── flatcar_base_amd64.img          ← shared read-only base (CoW backing)
 ├── pr-NNN/                         ← one dir per PR under test
 │   ├── knuckle                     ← built binary for this PR


### PR DESCRIPTION
## Summary

Migrates the VM e2e test suite from the ghost homelab to GitHub Actions.

### Changes

**New: `.github/workflows/vm-e2e.yml`**
- `prepare` job: fetches Flatcar version, caches base image (~480 MB) via `actions/cache` keyed on `FLATCAR_VERSION` from `version.txt`
- 4 parallel passes after prepare:
  - `dhcp` — DHCP networking, verifies hostname + update strategy
  - `static` — Static IP 10.0.2.15/24, verifies networkd unit content
  - `sysext` — Docker sysext install, verifies docker.raw present + systemd-sysext active
  - `nvidia` — NVIDIA config, verifies sysupdate.d entries
- All passes: KVM-enabled ubuntu-latest (same pattern as `iso-boot-smoke`), 2 GB QEMU RAM, SHA-pinned actions, failure artifacts

**Updated: `nightly.yml`**
- New `nightly-integration` job: `go test -tags=integration ./...` with `GITHUB_TOKEN` for live API tests

**Updated: docs**
- `CI-AND-TESTING.md`: vm-e2e and integration now marked ✅ in test pyramid
- `PR-TEST-MATRIX.md`: GHA workflow_dispatch as primary path; ghost demoted to optional

### Test plan
- `just ci` passes locally
- Triggering `vm-e2e.yml` on this branch via workflow_dispatch to validate

Closes #TBD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added nightly integration testing automation
  * Introduced comprehensive VM-based end-to-end testing workflow covering DHCP, static IP, systemd-sysext, and NVIDIA configurations

* **Documentation**
  * Updated CI and testing documentation with new workflow details and local testing instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/knuckle/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->