### PR TITLE
fix(ci): correct NVIDIA e2e assertion path (enabled-sysext.conf)

### DIFF
--- a/.github/workflows/vm-e2e.yml
+++ b/.github/workflows/vm-e2e.yml
@@ -598,9 +598,9 @@ jobs:
           UPDATE_STRATEGY=$($E2E_SSH "grep REBOOT_STRATEGY /etc/flatcar/update.conf 2>/dev/null" | cut -d= -f2 | tr -d '"' | xargs) || true
           [ "$UPDATE_STRATEGY" = "off" ] && echo "✓ update_strategy: off" || echo "⚠ update_strategy: '$UPDATE_STRATEGY'"
 
-          $E2E_SSH "test -f /etc/sysupdate.d/nv-open-gpu-driver.conf 2>/dev/null || ls /etc/sysupdate.d/ 2>/dev/null" \
-            | tee .vm/nvidia-verify.txt
-          grep -q "nv-" .vm/nvidia-verify.txt && echo "✓ NVIDIA sysupdate config present" || echo "⚠ NVIDIA sysupdate config not found (check assertion)"
+          NVIDIA_LINE=$($E2E_SSH "grep -i nvidia /etc/flatcar/enabled-sysext.conf 2>/dev/null || true")
+          [ -n "$NVIDIA_LINE" ] && echo "✓ NVIDIA sysext enabled: $NVIDIA_LINE" \
+            || { echo "❌ NVIDIA entry missing from /etc/flatcar/enabled-sysext.conf"; $E2E_SSH "cat /etc/flatcar/enabled-sysext.conf 2>/dev/null || echo '(file not found)'"; exit 1; }
 
           kill "$(cat .vm/qemu-target.pid)" 2>/dev/null || true
           echo ""


### PR DESCRIPTION
## Summary

The NVIDIA pass in `vm-e2e.yml` was failing with exit code 2 on the assertion step. Root cause: the assertion checked `/etc/sysupdate.d/nv-open-gpu-driver.conf` but knuckle actually writes to `/etc/flatcar/enabled-sysext.conf` (as seen in the Butane template in `internal/ignition/ignition.go`).

When that directory didn't exist, `ls /etc/sysupdate.d/` exited 2 and `pipefail` propagated the error.

## Fix

Check `/etc/flatcar/enabled-sysext.conf` for a nvidia entry (matching the actual Butane output). Failure is now hard (exit 1 with helpful debug output) instead of silently passing with a warning.

## Evidence

- [GHA run #26689068412](https://github.com/projectbluefin/knuckle/actions/runs/26689068412): dhcp ✅ static ✅ sysext ✅ nvidia ❌ (wrong path)
- Local vm-e2e (2026-05-30): all 4 passes ✅ — `enabled-sysext.conf` confirmed correct path
- Ignition template: `internal/ignition/ignition.go` writes `/etc/flatcar/enabled-sysext.conf` with `nvidia-drivers-{{.NvidiaDriverVersion}}`

## Checklist
- [x] `just ci` passes (workflow-only change, no Go code modified)
- [x] Assertion now hard-fails with debug output on miss
