### PR TITLE
fix(ci): use correct nvidia_driver_version field in NVIDIA e2e pass

### DIFF
--- a/.github/workflows/vm-e2e.yml
+++ b/.github/workflows/vm-e2e.yml
@@ -550,7 +550,7 @@ jobs:
           printf '{"ignition":{"version":"3.4.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["%s"]}]},"systemd":{"units":[{"name":"sshd.service","enabled":true}]}}\n' \
             "$E2E_PUB" > .vm/e2e-installer.ign
 
-          printf '{"channel":"stable","hostname":"e2e-nvidia","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","nvidia":{"enabled":true,"driver_type":"open"},"update_strategy":"off","reboot":false}\n' \
+          printf '{"channel":"stable","hostname":"e2e-nvidia","timezone":"UTC","network":{"mode":"dhcp"},"users":[{"username":"core","ssh_keys":["%s"]}],"disk":"/dev/vdb","swap":{"enabled":false},"nvidia_driver_version":"570-open","update_strategy":"off","reboot":false}\n' \
             "$E2E_PUB" > .vm/e2e-nvidia-config.json
 
           qemu-system-x86_64 "${QEMU_ARGS[@]}" \


### PR DESCRIPTION
## Root cause

The NVIDIA headless config in the GHA workflow used a non-existent nested object:
```json
"nvidia": {"enabled": true, "driver_type": "open"}
```

The correct field per `internal/headless/headless.go` and `docs/HEADLESS-CONFIG.md` is the flat string:
```json
"nvidia_driver_version": "570-open"
```

Go's JSON unmarshaler silently ignored the unknown `nvidia` key, leaving `NvidiaDriverVersion` empty. The Butane template skipped the `/etc/flatcar/enabled-sysext.conf` write, install succeeded but with no NVIDIA configuration on the installed system.

Also adds `"swap":{"enabled":false}` to match the Justfile `vm-e2e` recipe and avoid swap boot ordering noise unrelated to the NVIDIA assertion (per lesson learned in knuckle-qa skill).

## Evidence

- [GHA run #26689611842](https://github.com/projectbluefin/knuckle/actions/runs/26689611842): dhcp ✅ static ✅ sysext ✅ nvidia ❌ (`(file not found)` — no NVIDIA config written)  
- Local Justfile: uses `nvidia_driver_version:"570-open"` — all 4 passes ✅
- After fix: config now exactly matches the Justfile recipe

## Checklist
- [x] Workflow-only change — no Go code modified
- [x] `just ci` passes (shellcheck covers the embedded JSON)