### PR TITLE
test(ci): fix coverage gates and add missing BATS tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -115,7 +115,7 @@ cover-check:
     declare -A targets=(
         [model]=100 [validate]=100 [ignition]=100 [github]=96
         [bakery]=100 [probe]=100   [runner]=100   [install]=100
-        [headless]=99 [wizard]=99  [iso]=100      [tui]=98
+        [headless]=99 [wizard]=99  [iso]=100      [tui]=99
         [demo]=100
     )
     fail=0
@@ -150,7 +150,7 @@ cover-check:
         echo "ok    ${script_pkg}  ${script_pct}%  (target ${script_target}%)"
     fi
     cmd_pkg=cmd/knuckle
-    cmd_target=50
+    cmd_target=85
     cmd_pct=$(go test -count=1 -cover ./${cmd_pkg}/... 2>/dev/null \
         | awk '/coverage:/ {gsub("%",""); print $(NF-2); exit}')
     cmd_pct=${cmd_pct%.*}
@@ -162,6 +162,20 @@ cover-check:
         fail=1
     else
         echo "ok    ${cmd_pkg}  ${cmd_pct}%  (target ${cmd_target}%)"
+    fi
+    cbf_pkg=cmd/compile-butane-fresh
+    cbf_target=100
+    cbf_pct=$(go test -count=1 -cover ./${cbf_pkg}/... 2>/dev/null \
+        | awk '/coverage:/ {gsub("%",""); print $(NF-2); exit}')
+    cbf_pct=${cbf_pct%.*}
+    if [[ -z "$cbf_pct" ]]; then
+        echo "FAIL  ${cbf_pkg}   no coverage reported"
+        fail=1
+    elif (( cbf_pct < cbf_target )); then
+        echo "FAIL  ${cbf_pkg}  ${cbf_pct}%  (target ${cbf_target}%)"
+        fail=1
+    else
+        echo "ok    ${cbf_pkg}  ${cbf_pct}%  (target ${cbf_target}%)"
     fi
     exit $fail
 

--- a/scripts/tests/build-iso.bats
+++ b/scripts/tests/build-iso.bats
@@ -61,3 +61,44 @@ run_expect_fail() {
   # beta should be accepted; riscv64 should fail
   [[ "$output" == *"must be amd64 or arm64"* ]]
 }
+
+# ── --binary argument forms (issue #671) ─────────────────────────────────────
+
+@test "--binary value (space-separated) does not trigger unknown-argument error" {
+  run bash "$SCRIPT" --binary /tmp/fake-knuckle 2>&1 || true
+  [[ "$output" != *"Unknown argument"* ]]
+}
+
+@test "--binary=value (equals form) does not trigger unknown-argument error" {
+  run bash "$SCRIPT" --binary=/tmp/fake-knuckle 2>&1 || true
+  [[ "$output" != *"Unknown argument"* ]]
+}
+
+@test "--binary combined with valid flags does not trigger arg-parse error" {
+  run bash "$SCRIPT" --binary /tmp/fake-knuckle --channel stable --arch amd64 2>&1 || true
+  [[ "$output" != *"Unknown argument"* ]]
+  [[ "$output" != *"must be amd64 or arm64"* ]]
+  [[ "$output" != *"must be stable, beta, alpha, lts, or edge"* ]]
+}
+
+# ── arm64 valid channel combinations (issue #671) ────────────────────────────
+
+@test "arm64 + stable is a valid combination" {
+  run bash "$SCRIPT" --arch arm64 --channel stable 2>&1 || true
+  [[ "$output" != *"LTS channel is not available for arm64"* ]]
+}
+
+@test "arm64 + beta is a valid combination" {
+  run bash "$SCRIPT" --arch arm64 --channel beta 2>&1 || true
+  [[ "$output" != *"LTS channel is not available for arm64"* ]]
+}
+
+@test "arm64 + alpha is a valid combination" {
+  run bash "$SCRIPT" --arch arm64 --channel alpha 2>&1 || true
+  [[ "$output" != *"LTS channel is not available for arm64"* ]]
+}
+
+@test "arm64 + edge is a valid combination" {
+  run bash "$SCRIPT" --arch arm64 --channel edge 2>&1 || true
+  [[ "$output" != *"LTS channel is not available for arm64"* ]]
+}

--- a/scripts/tests/qa-test-pr.bats
+++ b/scripts/tests/qa-test-pr.bats
@@ -461,3 +461,31 @@ GITEOF
   # Cleanup (in case test logic changes)
   rm -rf "$WORKTREE_PATH" 2>/dev/null || true
 }
+
+# ── domain:iso tier routing (issue #672) ─────────────────────────────────────
+
+@test "domain:iso routes to Tier 3 with needs_boot" {
+  export MOCK_GH_PR_JSON='{"title":"iso","headRefName":"feat/iso","labels":[{"name":"domain:iso"},{"name":"size:S"}],"body":"","author":{"login":"dev"}}'
+  export MOCK_PR_TITLE="iso"
+  export MOCK_PR_BRANCH="feat/iso"
+  export MOCK_PR_LABELS="domain:iso, size:S"
+  export MOCK_PR_SIZE="size:S"
+  export MOCK_GH_DIFF_FILES=""
+  run bash "$SCRIPT" 999 2>&1
+  [[ "$output" == *"tier=3"* ]]
+  [[ "$output" == *"needs_boot=1"* ]]
+}
+
+@test "non-routing domain labels (bakery, wizard, validate, ci) stay at Tier 0" {
+  for label in domain:bakery domain:wizard domain:validate domain:ci; do
+    export MOCK_GH_PR_JSON="{\"title\":\"x\",\"headRefName\":\"feat/x\",\"labels\":[{\"name\":\"${label}\"},{\"name\":\"size:S\"}],\"body\":\"\",\"author\":{\"login\":\"dev\"}}"
+    export MOCK_PR_TITLE="x"
+    export MOCK_PR_BRANCH="feat/x"
+    export MOCK_PR_LABELS="${label}, size:S"
+    export MOCK_PR_SIZE="size:S"
+    export MOCK_GH_DIFF_FILES=""
+    run bash "$SCRIPT" 999 2>&1
+    [[ "$output" != *"tier=3"* ]] || { echo "FAIL: ${label} should not route to tier=3"; exit 1; }
+    [[ "$output" != *"tier=1"* ]] || { echo "FAIL: ${label} should not route to tier=1"; exit 1; }
+  done
+}


### PR DESCRIPTION
## Summary

Closes #669, #670, #671, #672, #673
Partially closes #661, #663

## Changes

### Justfile — coverage gate fixes (#669 / #673 / #670 / #663 / #661)
- **`cmd/compile-butane-fresh`** added to `cover-check` at 100% — was entirely absent despite having tests at 100% coverage
- **`cmd/knuckle`** gate raised 50% → 85% — actual coverage is 86.1%; the 50% floor was stale
- **`internal/tui`** gate raised 98% → 99% — actual coverage is 99.7%; remaining 0.3% is the `tea.Run()` PTY path and `os.UserHomeDir()` failure path, both infeasible without dependency injection

### `scripts/tests/qa-test-pr.bats` (#672)
- `domain:iso routes to Tier 3 with needs_boot` — the production routing branch was completely untested; a typo would silently skip full ISO boot tests for ISO PRs
- `non-routing domain labels (bakery, wizard, validate, ci) stay at Tier 0` — negative guard against accidental future elevation

### `scripts/tests/build-iso.bats` (#671)
- `--binary` space form, equals form, and combined-flags tests — CI hot path was entirely untested
- `arm64 + stable/beta/alpha/edge` valid combination tests — only the blocked `arm64 + lts` case was previously tested

## Blocked (separate PRs needed)
- **#654** (nvidia-check unit tests) — blocked on PR #652 landing
- **#655** (headless/wizard FCOS OS-branching) — blocked on PR #653 landing