### PR TITLE
chore(ci): add renovate.json5 configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Enable GitHub's native automerge; merging is handled by GitHub and remains subject to branch protection/bypass settings
+  "platformAutomerge": true,
+
+  // Only target main branch
+  "baseBranchPatterns": ["main"],
+
+  "extends": [
+    "config:best-practices",
+  ],
+
+  "git-submodules": {
+    "enabled": true
+  },
+
+  // Do not rebase when the default branch is updated
+  "rebaseWhen": "never",
+  "customManagers": [
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Justfile$/',
+      ],
+      matchStrings: [
+        '(?<justName>.+?)\\s:=\\s"(?<packageName>\\S+):(?<currentValue>\\S+)@(?<currentDigest>sha256:[a-f0-9]+?)"',
+      ],
+      datasourceTemplate: 'docker',
+    },
+    ],
+
+  "packageRules": [
+    {
+      // Auto-merge all digest/pin updates across all managers (dockerfile, github-actions, regex/Justfile)
+      "automerge": true,
+      "matchUpdateTypes": ["digest", "pin", "pinDigest"]
+    },
+    {
+      // Auto-merge minor/patch version bumps for GitHub Actions (e.g. cosign-installer v3.8 → v3.9)
+      "automerge": true,
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
+    }
+  ]
+}


### PR DESCRIPTION
Add renovate.json5 configuration file for automated dependency updates.

This configures Renovate to manage dependencies with automerge for digest and minor/patch updates.

The baseBranchPatterns is set to ['main'] for the knuckle repository.

Related to issue #410.