### PR TITLE
fix(governance): add CODEOWNERS to knuckle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default: knuckle maintainers review all changes
+* @castrojo @jreilly1821 @ahmedadan
+
+# Sensitive governance and CI paths — require explicit maintainer review
+.github/                @castrojo @jreilly1821 @ahmedadan
+Justfile                @castrojo @jreilly1821 @ahmedadan
+.pre-commit-config.yaml @castrojo @jreilly1821 @ahmedadan
+renovate.json           @castrojo @jreilly1821 @ahmedadan
+codecov.yml             @castrojo @jreilly1821 @ahmedadan
+
+# Core installation and system interaction
+internal/install/       @castrojo @jreilly1821
+internal/runner/        @castrojo @jreilly1821
+internal/ignition/      @castrojo @jreilly1821
+
+# Release and build artifacts
+cmd/                    @castrojo @jreilly1821


### PR DESCRIPTION
## Summary
Added CODEOWNERS file to establish clear code ownership and review requirements for knuckle.

## Changes
- **Default rule**: All changes reviewed by knuckle maintainers (@castrojo, @jreilly1821, @ahmedadan)
- **Sensitive paths**: .github/*, Justfile, build configuration, CI, and release automation require explicit maintainer review
- **Core systems**: installation, runner, and ignition changes reviewed by primary maintainers
- **Build artifacts**: cmd/ reviewed by primary maintainers

This establishes governance boundaries consistent with other projectbluefin repositories while respecting knuckle's unique role as the Flatcar installer.

🤖 Generated with Claude Code