### PR TITLE
chore(ci): add skill-drift.yml workflow

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "cmd/**", "internal/**", "Justfile", "scripts/**"]'
+      skill-paths: '["docs/**/*.md", "AGENTS.md"]'


### PR DESCRIPTION
Add skill drift detection workflow for knuckle.

This workflow uses projectbluefin/actions to detect when code changes without corresponding updates to documentation or AGENTS.md.

Configuration:
- Code paths: .github/workflows, cmd, internal, Justfile, scripts
- Documentation paths: docs/*.md, AGENTS.md

Related to #413