### PR TITLE
feat(ignition): FCOS Butane variant, zincati update config, FCOS strategy constants

### DIFF
--- a/internal/ignition/builder.go
+++ b/internal/ignition/builder.go
@@ -63,10 +63,11 @@ func (b *Builder) SetPasswdUsers(fragment string) {
 	b.passwdUsersYAML = fragment
 }
 
-// Build assembles the final Butane YAML document.
-func (b *Builder) Build() string {
+// BuildWithVariant assembles the final Butane YAML document using the given
+// variant header (e.g. "variant: fcos\nversion: 1.5.0\n").
+func (b *Builder) BuildWithVariant(header string) string {
 	var doc strings.Builder
-	doc.WriteString("variant: flatcar\nversion: 1.1.0\n")
+	doc.WriteString(header)
 
 	if len(b.storageFiles) > 0 || len(b.storageLinks) > 0 {
 		doc.WriteString("storage:\n")
@@ -97,6 +98,16 @@ func (b *Builder) Build() string {
 	}
 
 	return doc.String()
+}
+
+// Build assembles the final Butane YAML document with the Flatcar variant header.
+func (b *Builder) Build() string {
+	return b.BuildWithVariant("variant: flatcar\nversion: 1.1.0\n")
+}
+
+// BuildFCOS assembles the final Butane YAML document with the FCOS variant header.
+func (b *Builder) BuildFCOS() string {
+	return b.BuildWithVariant("variant: fcos\nversion: 1.5.0\n")
 }
 
 // indentFragment ensures every line of fragment is at least baseIndent spaces

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -163,6 +163,289 @@ func tailscaleExtraArgs(ts model.TailscaleConfig) string {
 	}
 }
 
+// GenerateFCOSButane produces a Butane YAML config string for Fedora CoreOS.
+// The output uses variant: fcos, spec 1.5.0, with zincati for updates instead
+// of update-engine. Flatcar-specific paths (/etc/flatcar/*) are excluded.
+func (g *Generator) GenerateFCOSButane(cfg *model.InstallConfig) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("config cannot be nil")
+	}
+
+	for _, s := range filterSelected(cfg.Sysexts) {
+		if !strings.HasPrefix(s.URL, "https://") {
+			return "", fmt.Errorf("sysext %q has non-HTTPS download URL %q", s.Name, s.URL)
+		}
+	}
+
+	b := NewBuilder(cfg)
+
+	if err := addSharedFragments(b, cfg); err != nil {
+		return "", err
+	}
+
+	fcosStrategy := cfg.UpdateStrategy.FCOSUpdateStrategy
+	if fcosStrategy == "" {
+		fcosStrategy = model.FCOSStrategyImmediate
+	}
+
+	zincatiTOML, err := renderTemplate("zincati", zincatiTemplate, struct{ FCOSUpdateStrategy string }{
+		FCOSUpdateStrategy: fcosStrategy,
+	})
+	if err != nil {
+		return "", fmt.Errorf("rendering zincati config: %w", err)
+	}
+	b.AddStorageFile(zincatiTOML)
+
+	if len(filterSelected(cfg.Sysexts)) > 0 {
+		b.AddSystemdUnit("- name: systemd-sysext.service\n  enabled: true")
+	}
+	b.AddSystemdUnit("- name: zincati.service\n  enabled: true")
+
+	addSwapUnits(b, cfg)
+	addTailscaleUnits(b, cfg)
+
+	return b.BuildFCOS(), nil
+}
+
+const zincatiTemplate = `- path: /etc/zincati/config.d/55-updates.toml
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: |
+      [updates]
+      strategy = "{{.FCOSUpdateStrategy | yamlEscape}}"`
+
+// addSharedFragments adds storage files, links, and passwd entries that are
+// common to both Flatcar and FCOS variants.
+func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
+	hostnameFrag, err := renderTemplate("hostname", `- path: /etc/hostname
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: "{{.Hostname | yamlEscape}}"`, struct{ Hostname string }{Hostname: cfg.Hostname})
+	if err != nil {
+		return fmt.Errorf("rendering hostname: %w", err)
+	}
+	b.AddStorageFile(hostnameFrag)
+
+	hasPassword := false
+	for _, u := range cfg.Users {
+		if u.PasswordHash != "" {
+			hasPassword = true
+			break
+		}
+	}
+	sshFrag, err := renderTemplate("ssh-hardening", `- path: /etc/ssh/sshd_config.d/99-knuckle-hardening.conf
+  mode: 0600
+  overwrite: true
+  contents:
+    inline: |
+      PasswordAuthentication {{if .HasPassword}}yes{{else}}no{{end}}
+      PermitRootLogin no
+      PubkeyAuthentication yes`, struct{ HasPassword bool }{HasPassword: hasPassword})
+	if err != nil {
+		return fmt.Errorf("rendering ssh hardening: %w", err)
+	}
+	b.AddStorageFile(sshFrag)
+
+	if cfg.Network.Mode == model.NetworkStatic {
+		netFrag, err := renderTemplate("static-net", `- path: /etc/systemd/network/10-static.network
+  mode: 0644
+  contents:
+    inline: |
+      [Match]
+      Name={{.Interface}}
+
+      [Network]
+      Address={{.Address}}
+      Gateway={{.Gateway}}
+{{- range .DNS}}
+      DNS={{.}}
+{{- end}}`, cfg.Network)
+		if err != nil {
+			return fmt.Errorf("rendering static network: %w", err)
+		}
+		b.AddStorageFile(netFrag)
+	}
+
+	for _, s := range filterSelected(cfg.Sysexts) {
+		sysextFrag, err := renderTemplate("sysext-"+s.Name, sysextTemplate, s)
+		if err != nil {
+			return fmt.Errorf("rendering sysext %q: %w", s.Name, err)
+		}
+		b.AddStorageFile(sysextFrag)
+	}
+
+	if cfg.Swap.Enabled {
+		b.AddStorageFile(`- path: /var/swapfile
+  mode: 0600
+  contents:
+    source: "data:,"`)
+	}
+
+	tailscaleEnabled := hasTailscaleConfig(cfg.Tailscale)
+	if tailscaleEnabled {
+		tsFrag, err := renderTemplate("tailscale-env", tailscaleEnvTemplate, struct {
+			Tailscale          model.TailscaleConfig
+			TailscaleExtraArgs string
+		}{
+			Tailscale:          cfg.Tailscale,
+			TailscaleExtraArgs: tailscaleExtraArgs(cfg.Tailscale),
+		})
+		if err != nil {
+			return fmt.Errorf("rendering tailscale env: %w", err)
+		}
+		b.AddStorageFile(tsFrag)
+
+		if cfg.Tailscale.Mode == model.TailscaleModeExitNode || cfg.Tailscale.Mode == model.TailscaleModeSubnetRouter {
+			b.AddStorageFile(`- path: /etc/sysctl.d/99-tailscale.conf
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: |
+      net.ipv4.ip_forward = 1
+      net.ipv6.conf.all.forwarding = 1`)
+		}
+	}
+
+	if cfg.Timezone != "" {
+		tzFrag, err := renderTemplate("timezone", `- path: /etc/localtime
+  target: "/usr/share/zoneinfo/{{.Timezone | yamlEscape}}"
+  overwrite: true`, struct{ Timezone string }{Timezone: cfg.Timezone})
+		if err != nil {
+			return fmt.Errorf("rendering timezone: %w", err)
+		}
+		b.AddStorageLink(tzFrag)
+	}
+
+	passwdFrag, err := renderTemplate("passwd", passwdTemplate, struct {
+		Users   []model.UserConfig
+		SSHKeys []string
+	}{Users: cfg.Users, SSHKeys: cfg.SSHKeys})
+	if err != nil {
+		return fmt.Errorf("rendering passwd: %w", err)
+	}
+	b.SetPasswdUsers(passwdFrag)
+
+	return nil
+}
+
+const sysextTemplate = `- path: /etc/extensions/{{.Name}}.raw
+  contents:
+    source: "{{.URL | yamlEscape}}"
+{{- if .Sha256}}
+    verification:
+      hash: "sha256-{{.Sha256}}"
+{{- end}}`
+
+const tailscaleEnvTemplate = `- path: /etc/tailscale/tailscale.env
+  mode: 0600
+  overwrite: true
+  contents:
+    inline: |
+      TS_AUTHKEY={{.Tailscale.AuthKey | yamlEscape}}
+      TS_AUTH_ONCE=true
+{{- if .TailscaleExtraArgs}}
+      TS_EXTRA_ARGS={{.TailscaleExtraArgs | yamlEscape}}
+{{- end}}`
+
+const passwdTemplate = `{{- if .Users}}{{- range .Users}}- name: "{{.Username | yamlEscape}}"
+{{- if .Groups}}
+  groups:
+{{- range .Groups}}
+    - "{{. | yamlEscape}}"
+{{- end}}
+{{- end}}
+{{- if .SSHKeys}}
+  ssh_authorized_keys:
+{{- range .SSHKeys}}
+    - "{{. | yamlEscape}}"
+{{- end}}
+{{- end}}
+{{- if .PasswordHash}}
+  password_hash: "{{.PasswordHash | yamlEscape}}"
+{{- end}}
+{{end}}{{- else}}- name: "core"
+{{- if .SSHKeys}}
+  ssh_authorized_keys:
+{{- range .SSHKeys}}
+    - "{{. | yamlEscape}}"
+{{- end}}
+{{- end}}
+{{end}}`
+
+// addSwapUnits adds swap-related systemd units if swap is enabled.
+func addSwapUnits(b *Builder, cfg *model.InstallConfig) {
+	if !cfg.Swap.Enabled {
+		return
+	}
+	swapSize := cfg.Swap.SizeMB
+	if swapSize <= 0 {
+		swapSize = model.DefaultSwapSizeMB
+	}
+	createFrag, _ := renderTemplate("swap-create", `- name: knuckle-create-swapfile.service
+  enabled: true
+  contents: |
+    [Unit]
+    Description=Create the /var/swapfile (knuckle, {{.SwapSizeMB}} MiB)
+    Before=var-swapfile.swap
+    ConditionPathExists=!/var/lib/knuckle/.swap-created
+
+    [Service]
+    Type=oneshot
+    ExecStart=/usr/bin/fallocate -l {{.SwapSizeMB}}M /var/swapfile
+    ExecStart=/usr/bin/chmod 0600 /var/swapfile
+    ExecStart=/usr/sbin/mkswap /var/swapfile
+    ExecStartPost=/bin/sh -c 'install -m 0644 -D /dev/null /var/lib/knuckle/.swap-created'
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target`, struct{ SwapSizeMB int }{SwapSizeMB: swapSize})
+	b.AddSystemdUnit(createFrag)
+
+	b.AddSystemdUnit(`- name: var-swapfile.swap
+  enabled: true
+  contents: |
+    [Unit]
+    Description=Activate /var/swapfile
+    Requires=knuckle-create-swapfile.service
+    After=knuckle-create-swapfile.service
+
+    [Swap]
+    What=/var/swapfile
+
+    [Install]
+    WantedBy=multi-user.target`)
+}
+
+// addTailscaleUnits adds Tailscale systemd units if Tailscale is configured.
+func addTailscaleUnits(b *Builder, cfg *model.InstallConfig) {
+	if !hasTailscaleConfig(cfg.Tailscale) {
+		return
+	}
+	b.AddSystemdUnit("- name: tailscaled.service\n  enabled: true")
+	tsFrag, _ := renderTemplate("tailscale-up", `- name: knuckle-tailscale-up.service
+  enabled: true
+  contents: |
+    [Unit]
+    Description=Bring up Tailscale with the auth key provisioned by knuckle
+    Requires=tailscaled.service network-online.target
+    After=tailscaled.service network-online.target
+    ConditionPathExists=/etc/tailscale/tailscale.env
+    ConditionPathExists=!/var/lib/tailscale/.knuckle-up-done
+
+    [Service]
+    Type=oneshot
+    EnvironmentFile=/etc/tailscale/tailscale.env
+    ExecStart=/usr/bin/tailscale up --auth-key=$${TS_AUTHKEY} $${TS_EXTRA_ARGS}
+    ExecStartPost=/bin/sh -c 'install -m 0600 /dev/null /var/lib/tailscale/.knuckle-up-done'
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target`, nil)
+	b.AddSystemdUnit(tsFrag)
+}
+
 func filterSelected(sysexts []model.SysextEntry) []model.SysextEntry {
 	var selected []model.SysextEntry
 	for _, s := range sysexts {

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -207,7 +207,8 @@ func (g *Generator) GenerateFCOSButane(cfg *model.InstallConfig) (string, error)
 	return b.BuildFCOS(), nil
 }
 
-const zincatiTemplate = `- path: /etc/zincati/config.d/55-updates.toml
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var zincatiTemplate = `- path: /etc/zincati/config.d/55-updates.toml
   mode: 0644
   overwrite: true
   contents:
@@ -215,14 +216,50 @@ const zincatiTemplate = `- path: /etc/zincati/config.d/55-updates.toml
       [updates]
       strategy = "{{.FCOSUpdateStrategy | yamlEscape}}"`
 
-// addSharedFragments adds storage files, links, and passwd entries that are
-// common to both Flatcar and FCOS variants.
-func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
-	hostnameFrag, err := renderTemplate("hostname", `- path: /etc/hostname
+// Fragment templates used by addSharedFragments. Vars (not const) to allow
+// test injection of error paths, following the same pattern as butaneTemplate.
+//
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var (
+	hostnameTemplate = `- path: /etc/hostname
   mode: 0644
   overwrite: true
   contents:
-    inline: "{{.Hostname | yamlEscape}}"`, struct{ Hostname string }{Hostname: cfg.Hostname})
+    inline: "{{.Hostname | yamlEscape}}"`
+
+	sshHardeningTemplate = `- path: /etc/ssh/sshd_config.d/99-knuckle-hardening.conf
+  mode: 0600
+  overwrite: true
+  contents:
+    inline: |
+      PasswordAuthentication {{if .HasPassword}}yes{{else}}no{{end}}
+      PermitRootLogin no
+      PubkeyAuthentication yes`
+
+	staticNetTemplate = `- path: /etc/systemd/network/10-static.network
+  mode: 0644
+  contents:
+    inline: |
+      [Match]
+      Name={{.Interface}}
+
+      [Network]
+      Address={{.Address}}
+      Gateway={{.Gateway}}
+{{- range .DNS}}
+      DNS={{.}}
+{{- end}}`
+
+	timezoneTemplate = `- path: /etc/localtime
+  target: "/usr/share/zoneinfo/{{.Timezone | yamlEscape}}"
+  overwrite: true`
+)
+
+// addSharedFragments adds storage files, links, and passwd entries that are
+// common to both Flatcar and FCOS variants.
+func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
+	hostnameFrag, err := renderTemplate("hostname", hostnameTemplate,
+		struct{ Hostname string }{Hostname: cfg.Hostname})
 	if err != nil {
 		return fmt.Errorf("rendering hostname: %w", err)
 	}
@@ -235,33 +272,15 @@ func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
 			break
 		}
 	}
-	sshFrag, err := renderTemplate("ssh-hardening", `- path: /etc/ssh/sshd_config.d/99-knuckle-hardening.conf
-  mode: 0600
-  overwrite: true
-  contents:
-    inline: |
-      PasswordAuthentication {{if .HasPassword}}yes{{else}}no{{end}}
-      PermitRootLogin no
-      PubkeyAuthentication yes`, struct{ HasPassword bool }{HasPassword: hasPassword})
+	sshFrag, err := renderTemplate("ssh-hardening", sshHardeningTemplate,
+		struct{ HasPassword bool }{HasPassword: hasPassword})
 	if err != nil {
 		return fmt.Errorf("rendering ssh hardening: %w", err)
 	}
 	b.AddStorageFile(sshFrag)
 
 	if cfg.Network.Mode == model.NetworkStatic {
-		netFrag, err := renderTemplate("static-net", `- path: /etc/systemd/network/10-static.network
-  mode: 0644
-  contents:
-    inline: |
-      [Match]
-      Name={{.Interface}}
-
-      [Network]
-      Address={{.Address}}
-      Gateway={{.Gateway}}
-{{- range .DNS}}
-      DNS={{.}}
-{{- end}}`, cfg.Network)
+		netFrag, err := renderTemplate("static-net", staticNetTemplate, cfg.Network)
 		if err != nil {
 			return fmt.Errorf("rendering static network: %w", err)
 		}
@@ -309,9 +328,8 @@ func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
 	}
 
 	if cfg.Timezone != "" {
-		tzFrag, err := renderTemplate("timezone", `- path: /etc/localtime
-  target: "/usr/share/zoneinfo/{{.Timezone | yamlEscape}}"
-  overwrite: true`, struct{ Timezone string }{Timezone: cfg.Timezone})
+		tzFrag, err := renderTemplate("timezone", timezoneTemplate,
+			struct{ Timezone string }{Timezone: cfg.Timezone})
 		if err != nil {
 			return fmt.Errorf("rendering timezone: %w", err)
 		}
@@ -330,7 +348,8 @@ func addSharedFragments(b *Builder, cfg *model.InstallConfig) error {
 	return nil
 }
 
-const sysextTemplate = `- path: /etc/extensions/{{.Name}}.raw
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var sysextTemplate = `- path: /etc/extensions/{{.Name}}.raw
   contents:
     source: "{{.URL | yamlEscape}}"
 {{- if .Sha256}}
@@ -338,7 +357,8 @@ const sysextTemplate = `- path: /etc/extensions/{{.Name}}.raw
       hash: "sha256-{{.Sha256}}"
 {{- end}}`
 
-const tailscaleEnvTemplate = `- path: /etc/tailscale/tailscale.env
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var tailscaleEnvTemplate = `- path: /etc/tailscale/tailscale.env
   mode: 0600
   overwrite: true
   contents:
@@ -349,7 +369,8 @@ const tailscaleEnvTemplate = `- path: /etc/tailscale/tailscale.env
       TS_EXTRA_ARGS={{.TailscaleExtraArgs | yamlEscape}}
 {{- end}}`
 
-const passwdTemplate = `{{- if .Users}}{{- range .Users}}- name: "{{.Username | yamlEscape}}"
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var passwdTemplate = `{{- if .Users}}{{- range .Users}}- name: "{{.Username | yamlEscape}}"
 {{- if .Groups}}
   groups:
 {{- range .Groups}}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -188,7 +188,13 @@ func (g *Generator) GenerateFCOSButane(cfg *model.InstallConfig) (string, error)
 		fcosStrategy = model.FCOSStrategyImmediate
 	}
 
-	zincatiTOML, err := renderTemplate("zincati", zincatiTemplate, struct{ FCOSUpdateStrategy string }{
+	var zincatiTmpl string
+	if fcosStrategy == model.FCOSStrategyDisabled {
+		zincatiTmpl = zincatiDisabledTemplate
+	} else {
+		zincatiTmpl = zincatiTemplate
+	}
+	zincatiTOML, err := renderTemplate("zincati", zincatiTmpl, struct{ FCOSUpdateStrategy string }{
 		FCOSUpdateStrategy: fcosStrategy,
 	})
 	if err != nil {
@@ -215,6 +221,15 @@ var zincatiTemplate = `- path: /etc/zincati/config.d/55-updates.toml
     inline: |
       [updates]
       strategy = "{{.FCOSUpdateStrategy | yamlEscape}}"`
+
+//nolint:gochecknoglobals // var to allow test injection of error paths.
+var zincatiDisabledTemplate = `- path: /etc/zincati/config.d/55-updates.toml
+  mode: 0644
+  overwrite: true
+  contents:
+    inline: |
+      [updates]
+      enabled = false`
 
 // Fragment templates used by addSharedFragments. Vars (not const) to allow
 // test injection of error paths, following the same pattern as butaneTemplate.

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1429,3 +1429,355 @@ func TestBuilderBuildWithVariant(t *testing.T) {
 		t.Error("expected storage file in output")
 	}
 }
+
+// ── FCOS error path coverage ─────────────────────────────────────────────────
+
+func TestGenerateFCOSButane_ZincatiTemplateError(t *testing.T) {
+	orig := zincatiTemplate
+	zincatiTemplate = "{{unclosed"
+	t.Cleanup(func() { zincatiTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected zincati template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering zincati config") {
+		t.Errorf("error should mention zincati config, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_PasswdTemplateError(t *testing.T) {
+	orig := passwdTemplate
+	passwdTemplate = "{{unclosed"
+	t.Cleanup(func() { passwdTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-passwd-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected passwd template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering passwd") {
+		t.Errorf("error should mention rendering passwd, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_SysextTemplateError(t *testing.T) {
+	orig := sysextTemplate
+	sysextTemplate = "{{unclosed"
+	t.Cleanup(func() { sysextTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-sysext-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "docker", URL: "https://example.com/docker.raw", Selected: true},
+		},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected sysext template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering sysext") {
+		t.Errorf("error should mention rendering sysext, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_TailscaleEnvTemplateError(t *testing.T) {
+	orig := tailscaleEnvTemplate
+	tailscaleEnvTemplate = "{{unclosed"
+	t.Cleanup(func() { tailscaleEnvTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-ts-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abc-secret",
+			Mode:    model.TailscaleModeConnect,
+		},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected tailscale env template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering tailscale env") {
+		t.Errorf("error should mention rendering tailscale env, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_HostnameTemplateError(t *testing.T) {
+	orig := hostnameTemplate
+	hostnameTemplate = "{{unclosed"
+	t.Cleanup(func() { hostnameTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected hostname template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering hostname") {
+		t.Errorf("error should mention rendering hostname, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_SSHHardeningTemplateError(t *testing.T) {
+	orig := sshHardeningTemplate
+	sshHardeningTemplate = "{{unclosed"
+	t.Cleanup(func() { sshHardeningTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected ssh hardening template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering ssh hardening") {
+		t.Errorf("error should mention rendering ssh hardening, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_StaticNetTemplateError(t *testing.T) {
+	orig := staticNetTemplate
+	staticNetTemplate = "{{unclosed"
+	t.Cleanup(func() { staticNetTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-err",
+		Network: model.NetworkConfig{
+			Mode:      model.NetworkStatic,
+			Interface: "eth0",
+			Address:   "10.0.0.1/24",
+			Gateway:   "10.0.0.254",
+			DNS:       []string{"8.8.8.8"},
+		},
+		Users: []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected static network template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering static network") {
+		t.Errorf("error should mention rendering static network, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_TimezoneTemplateError(t *testing.T) {
+	orig := timezoneTemplate
+	timezoneTemplate = "{{unclosed"
+	t.Cleanup(func() { timezoneTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-err",
+		Timezone: "UTC",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected timezone template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering timezone") {
+		t.Errorf("error should mention rendering timezone, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_PasswordUser(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-pw",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users: []model.UserConfig{
+			{
+				Username:     "admin",
+				PasswordHash: "$2a$10$somehash",
+				SSHKeys:      []string{"ssh-ed25519 AAAA test"},
+				Groups:       []string{"sudo", "docker"},
+			},
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "PasswordAuthentication yes") {
+		t.Error("expected PasswordAuthentication yes when user has password")
+	}
+	if !strings.Contains(output, `password_hash: "$2a$10$somehash"`) {
+		t.Error("expected password_hash in output")
+	}
+	if !strings.Contains(output, `- "sudo"`) {
+		t.Error("expected sudo group in output")
+	}
+}
+
+func TestGenerateFCOSButane_NoSysextsNoSysextService(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-nosysext",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(output, "systemd-sysext.service") {
+		t.Error("systemd-sysext.service must NOT appear when no sysexts are selected")
+	}
+}
+
+func TestGenerateFCOSButane_SubnetRouter(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-subnet",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abc-secret",
+			Mode:    model.TailscaleModeSubnetRouter,
+			Routes:  "10.0.0.0/24",
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "--advertise-routes=10.0.0.0/24") {
+		t.Error("expected advertise-routes in output")
+	}
+	if !strings.Contains(output, "net.ipv4.ip_forward") {
+		t.Error("expected ip_forward for subnet router")
+	}
+}
+
+func TestGenerateFCOSButane_SwapDefaultSize(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-swap-default",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 0},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, fmt.Sprintf("fallocate -l %dM", model.DefaultSwapSizeMB)) {
+		t.Errorf("expected default swap size %d MiB", model.DefaultSwapSizeMB)
+	}
+}
+
+func TestGenerateFCOSButane_SwapDisabled(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-noswap",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: false},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(output, "/var/swapfile") {
+		t.Error("/var/swapfile must not appear when swap is disabled")
+	}
+}
+
+func TestGenerateFCOSButane_TailscaleSkippedNoAuthKey(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:        model.OSFCOS,
+		Hostname:  "fcos-nots",
+		Network:   model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:     []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(output, "tailscale.env") {
+		t.Error("tailscale.env must not appear when AuthKey is empty")
+	}
+	if strings.Contains(output, "tailscaled.service") {
+		t.Error("tailscaled.service must not appear when AuthKey is empty")
+	}
+}
+
+func TestGenerateFCOSButane_SysextSHA256(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-sha",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{
+				Name:     "wasmtime",
+				URL:      "https://example.com/wasmtime.raw",
+				Sha256:   "abc123def456",
+				Selected: true,
+			},
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "sha256-abc123def456") {
+		t.Error("expected sha256 verification hash in output")
+	}
+}

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1178,15 +1178,15 @@ func TestGenerateFCOSButane_NilConfig(t *testing.T) {
 	}
 }
 
-func TestGenerateFCOSButane_ZincatiStrategyNever(t *testing.T) {
+func TestGenerateFCOSButane_ZincatiStrategyDisabled(t *testing.T) {
 	g := NewGenerator()
 	cfg := &model.InstallConfig{
 		OS:       model.OSFCOS,
-		Hostname: "fcos-never",
+		Hostname: "fcos-disabled",
 		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
 		Users:    []model.UserConfig{{Username: "core"}},
 		UpdateStrategy: model.UpdateStrategy{
-			FCOSUpdateStrategy: model.FCOSStrategyNever,
+			FCOSUpdateStrategy: model.FCOSStrategyDisabled,
 		},
 	}
 
@@ -1195,8 +1195,14 @@ func TestGenerateFCOSButane_ZincatiStrategyNever(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(output, `strategy = "never"`) {
-		t.Errorf("expected zincati strategy 'never', got:\n%s", output)
+	if !strings.Contains(output, `enabled = false`) {
+		t.Errorf("expected zincati 'enabled = false' for disabled strategy, got:\n%s", output)
+	}
+	if strings.Contains(output, `strategy = "never"`) {
+		t.Error("disabled strategy must NOT produce strategy = \"never\" (not a valid zincati value)")
+	}
+	if strings.Contains(output, `strategy = "disabled"`) {
+		t.Error("disabled strategy must NOT produce strategy = \"disabled\" (not a valid zincati value)")
 	}
 }
 
@@ -1401,8 +1407,8 @@ func TestFCOSStrategyConstants(t *testing.T) {
 	if model.FCOSStrategyImmediate != "immediate" {
 		t.Errorf("FCOSStrategyImmediate = %q, want %q", model.FCOSStrategyImmediate, "immediate")
 	}
-	if model.FCOSStrategyNever != "never" {
-		t.Errorf("FCOSStrategyNever = %q, want %q", model.FCOSStrategyNever, "never")
+	if model.FCOSStrategyDisabled != "disabled" {
+		t.Errorf("FCOSStrategyDisabled = %q, want %q", model.FCOSStrategyDisabled, "disabled")
 	}
 }
 
@@ -1447,6 +1453,30 @@ func TestGenerateFCOSButane_ZincatiTemplateError(t *testing.T) {
 	_, err := g.GenerateFCOSButane(cfg)
 	if err == nil {
 		t.Fatal("expected zincati template error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rendering zincati config") {
+		t.Errorf("error should mention zincati config, got: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_ZincatiDisabledTemplateError(t *testing.T) {
+	orig := zincatiDisabledTemplate
+	zincatiDisabledTemplate = "{{unclosed"
+	t.Cleanup(func() { zincatiDisabledTemplate = orig })
+
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-disabled-err",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		UpdateStrategy: model.UpdateStrategy{
+			FCOSUpdateStrategy: model.FCOSStrategyDisabled,
+		},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Fatal("expected zincati disabled template error, got nil")
 	}
 	if !strings.Contains(err.Error(), "rendering zincati config") {
 		t.Errorf("error should mention zincati config, got: %v", err)

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1109,3 +1109,323 @@ func TestGenerateButane_TemplateExecuteError(t *testing.T) {
 		t.Errorf("error should mention 'executing template', got: %v", err)
 	}
 }
+
+// ── GenerateFCOSButane tests ─────────────────────────────────────────────────
+
+func TestGenerateFCOSButane_BasicDHCP(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-node01",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users: []model.UserConfig{
+			{
+				Username: "core",
+				SSHKeys:  []string{"ssh-ed25519 AAAAC3test core@host"},
+				Groups:   []string{"sudo", "docker"},
+			},
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "variant: fcos") {
+		t.Error("missing variant: fcos header")
+	}
+	if !strings.Contains(output, "version: 1.5.0") {
+		t.Error("missing version: 1.5.0 header")
+	}
+	if strings.Contains(output, "variant: flatcar") {
+		t.Error("FCOS output must not contain variant: flatcar")
+	}
+	if !strings.Contains(output, `/etc/zincati/config.d/55-updates.toml`) {
+		t.Error("missing zincati config path")
+	}
+	if !strings.Contains(output, `strategy = "immediate"`) {
+		t.Error("missing default zincati strategy (immediate)")
+	}
+	if !strings.Contains(output, "zincati.service") {
+		t.Error("missing zincati.service unit")
+	}
+	if strings.Contains(output, "update-engine.service") {
+		t.Error("FCOS output must not contain update-engine.service")
+	}
+	if strings.Contains(output, "/etc/flatcar/update.conf") {
+		t.Error("FCOS output must not contain /etc/flatcar/update.conf")
+	}
+	if strings.Contains(output, "/etc/flatcar/enabled-sysext.conf") {
+		t.Error("FCOS output must not contain /etc/flatcar/enabled-sysext.conf")
+	}
+	if !strings.Contains(output, `inline: "fcos-node01"`) {
+		t.Error("missing hostname")
+	}
+	if !strings.Contains(output, `name: "core"`) {
+		t.Error("missing user")
+	}
+}
+
+func TestGenerateFCOSButane_NilConfig(t *testing.T) {
+	g := NewGenerator()
+	_, err := g.GenerateFCOSButane(nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if !strings.Contains(err.Error(), "config cannot be nil") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestGenerateFCOSButane_ZincatiStrategyNever(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-never",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		UpdateStrategy: model.UpdateStrategy{
+			FCOSUpdateStrategy: model.FCOSStrategyNever,
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, `strategy = "never"`) {
+		t.Errorf("expected zincati strategy 'never', got:\n%s", output)
+	}
+}
+
+func TestGenerateFCOSButane_NoFlatcarPaths(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:                  model.OSFCOS,
+		Hostname:            "fcos-clean",
+		Network:             model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:               []model.UserConfig{{Username: "core"}},
+		NvidiaDriverVersion: "570-open",
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	flatcarPaths := []string{
+		"/etc/flatcar/update.conf",
+		"/etc/flatcar/enabled-sysext.conf",
+		"update-engine.service",
+		"nvidia-drivers-",
+	}
+	for _, p := range flatcarPaths {
+		if strings.Contains(output, p) {
+			t.Errorf("FCOS output must not contain Flatcar-specific path %q", p)
+		}
+	}
+}
+
+func TestGenerateFCOSButane_WithSysexts(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-sysext",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "docker", Version: "24.0.7", URL: "https://example.com/docker.raw", Selected: true},
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "/etc/extensions/docker.raw") {
+		t.Error("missing sysext file entry")
+	}
+	if !strings.Contains(output, "systemd-sysext.service") {
+		t.Error("missing systemd-sysext.service for sysexts")
+	}
+}
+
+func TestGenerateFCOSButane_StaticNetwork(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-static",
+		Network: model.NetworkConfig{
+			Mode:      model.NetworkStatic,
+			Interface: "eth0",
+			Address:   "192.168.1.50/24",
+			Gateway:   "192.168.1.1",
+			DNS:       []string{"8.8.8.8"},
+		},
+		Users: []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "10-static.network") {
+		t.Error("missing static network config")
+	}
+	if !strings.Contains(output, "Address=192.168.1.50/24") {
+		t.Error("missing address in static config")
+	}
+}
+
+func TestGenerateFCOSButane_SwapEnabled(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-swap",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Swap:     model.SwapConfig{Enabled: true, SizeMB: 2048},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "/var/swapfile") {
+		t.Error("missing /var/swapfile")
+	}
+	if !strings.Contains(output, "fallocate -l 2048M") {
+		t.Error("missing swap fallocate with correct size")
+	}
+	if !strings.Contains(output, "var-swapfile.swap") {
+		t.Error("missing var-swapfile.swap unit")
+	}
+}
+
+func TestGenerateFCOSButane_Tailscale(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-ts",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Tailscale: model.TailscaleConfig{
+			AuthKey: "tskey-auth-abc123-secret",
+			Mode:    model.TailscaleModeExitNode,
+		},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "/etc/tailscale/tailscale.env") {
+		t.Error("missing tailscale env file")
+	}
+	if !strings.Contains(output, "tailscaled.service") {
+		t.Error("missing tailscaled.service")
+	}
+	if !strings.Contains(output, "--advertise-exit-node") {
+		t.Error("missing exit node flag")
+	}
+	if !strings.Contains(output, "net.ipv4.ip_forward") {
+		t.Error("missing ip_forward sysctl for exit node")
+	}
+}
+
+func TestGenerateFCOSButane_Timezone(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-tz",
+		Timezone: "America/Chicago",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "/usr/share/zoneinfo/America/Chicago") {
+		t.Error("missing timezone link target")
+	}
+}
+
+func TestGenerateFCOSButane_HTTPSysextRejected(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-bad-url",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "bad", URL: "http://evil.example.com/bad.raw", Selected: true},
+		},
+	}
+	_, err := g.GenerateFCOSButane(cfg)
+	if err == nil {
+		t.Error("expected error for non-HTTPS sysext URL, got nil")
+	}
+}
+
+func TestGenerateFCOSButane_DefaultCoreUser(t *testing.T) {
+	g := NewGenerator()
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Hostname: "fcos-default",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		SSHKeys:  []string{"ssh-ed25519 AAAA user@laptop"},
+	}
+
+	output, err := g.GenerateFCOSButane(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, `name: "core"`) {
+		t.Error("expected default 'core' user when no users specified")
+	}
+}
+
+// ── FCOS strategy constants ──────────────────────────────────────────────────
+
+func TestFCOSStrategyConstants(t *testing.T) {
+	if model.FCOSStrategyImmediate != "immediate" {
+		t.Errorf("FCOSStrategyImmediate = %q, want %q", model.FCOSStrategyImmediate, "immediate")
+	}
+	if model.FCOSStrategyNever != "never" {
+		t.Errorf("FCOSStrategyNever = %q, want %q", model.FCOSStrategyNever, "never")
+	}
+}
+
+// ── Builder FCOS variant ─────────────────────────────────────────────────────
+
+func TestBuilderBuildFCOS(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	got := b.BuildFCOS()
+	wantPrefix := "variant: fcos\nversion: 1.5.0\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected document to start with %q, got %q", wantPrefix, got)
+	}
+}
+
+func TestBuilderBuildWithVariant(t *testing.T) {
+	b := NewBuilder(&model.InstallConfig{})
+	b.AddStorageFile(`- path: /etc/test
+  mode: 0644`)
+	got := b.BuildWithVariant("variant: fcos\nversion: 1.5.0\n")
+	if !strings.Contains(got, "variant: fcos") {
+		t.Error("expected variant: fcos in output")
+	}
+	if !strings.Contains(got, "/etc/test") {
+		t.Error("expected storage file in output")
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -68,9 +68,15 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 		// External ignition URL mode — pass directly to flatcar-install
 		progress("Using external Ignition config...")
 	} else {
-		// Generate Butane YAML
+		// Generate Butane YAML — dispatch based on target OS.
 		progress("Generating Butane config...")
-		butaneYAML, err := i.Generator.GenerateButane(cfg)
+		var butaneYAML string
+		var err error
+		if cfg.OS == model.OSFCOS {
+			butaneYAML, err = i.Generator.GenerateFCOSButane(cfg)
+		} else {
+			butaneYAML, err = i.Generator.GenerateButane(cfg)
+		}
 		if err != nil {
 			return fmt.Errorf("generating butane config: %w", err)
 		}

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -773,3 +773,57 @@ func TestCleanupIgnitionFile_RemoveFailsNonNotExist(t *testing.T) {
 		t.Error("ignitionPath should be cleared after cleanupIgnitionFile, even on Remove failure")
 	}
 }
+
+func TestInstallFCOSDispatch(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-install-test",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify flatcar-install was called (install flow works for FCOS too)
+	found := false
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "flatcar-install" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("flatcar-install was not called for FCOS config")
+	}
+}
+
+func TestInstallFCOS_GenerateButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFlatcarInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-err-test",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "bad", URL: "http://insecure.example.com/bad.raw", Selected: true},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from FCOS butane generation, got nil")
+	}
+	if !strings.Contains(err.Error(), "generating butane config") {
+		t.Errorf("error should mention generating butane config, got: %v", err)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -118,12 +118,19 @@ const (
 	TailscaleModeSubnetRouter = "subnet-router"
 )
 
+// FCOS zincati update strategy constants.
+const (
+	FCOSStrategyImmediate = "immediate" // reboot immediately after update
+	FCOSStrategyNever     = "never"     // disable automatic updates
+)
+
 // UpdateStrategy holds OS update and reboot settings.
 // Flatcar uses update-engine; FCOS uses zincati instead.
 type UpdateStrategy struct {
-	RebootStrategy string // "reboot", "off", "etcd-lock"
-	RebootWindow   string // optional: "Mon-Fri 04:00-05:00" format
-	LocksmithGroup string // optional: used with etcd-lock
+	RebootStrategy     string // "reboot", "off", "etcd-lock" (Flatcar)
+	FCOSUpdateStrategy string // "immediate", "never" (FCOS zincati)
+	RebootWindow       string // optional: "Mon-Fri 04:00-05:00" format
+	LocksmithGroup     string // optional: used with etcd-lock
 }
 
 // NetworkConfig holds network settings.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -119,16 +119,18 @@ const (
 )
 
 // FCOS zincati update strategy constants.
+// Valid zincati [updates].strategy values: "immediate", "periodic", "fleet_lock".
+// To disable updates, zincati uses [updates] enabled = false (not a strategy value).
 const (
 	FCOSStrategyImmediate = "immediate" // reboot immediately after update
-	FCOSStrategyNever     = "never"     // disable automatic updates
+	FCOSStrategyDisabled  = "disabled"  // disable automatic updates via [updates] enabled = false
 )
 
 // UpdateStrategy holds OS update and reboot settings.
 // Flatcar uses update-engine; FCOS uses zincati instead.
 type UpdateStrategy struct {
 	RebootStrategy     string // "reboot", "off", "etcd-lock" (Flatcar)
-	FCOSUpdateStrategy string // "immediate", "never" (FCOS zincati)
+	FCOSUpdateStrategy string // "immediate" or "disabled" (FCOS zincati)
 	RebootWindow       string // optional: "Mon-Fri 04:00-05:00" format
 	LocksmithGroup     string // optional: used with etcd-lock
 }


### PR DESCRIPTION
## Summary

- Add `GenerateFCOSButane()` method producing `variant: fcos` / `version: 1.5.0` Butane configs
- Add zincati update config at `/etc/zincati/config.d/55-updates.toml` with `FCOSStrategyImmediate` / `FCOSStrategyNever` constants
- Add `FCOSUpdateStrategy` field to `UpdateStrategy` struct in model
- Extract shared fragments (hostname, SSH hardening, network, sysexts, swap, tailscale, timezone, passwd) into `addSharedFragments()` for reuse by both Flatcar and FCOS generators
- Add `BuildWithVariant()` / `BuildFCOS()` to Builder for FCOS header support
- Dispatch to `GenerateFCOSButane()` in `install.go` when `cfg.OS == "fcos"`
- Exclude all Flatcar-specific paths (`/etc/flatcar/*`, `update-engine.service`) from FCOS output
- Add comprehensive FCOS ignition tests (11 new test functions)

## Test plan

- [ ] `go test ./internal/ignition/...` — new FCOS tests pass
- [ ] `go test ./internal/install/...` — existing install tests still pass
- [ ] `go test ./internal/model/...` — model tests pass with new constants
- [ ] `just ci` green
- [ ] Verify `variant: fcos` header in FCOS output
- [ ] Verify zincati TOML config at correct path
- [ ] Verify no Flatcar-specific paths in FCOS output
- [ ] Verify `FCOSStrategyImmediate` / `FCOSStrategyNever` constants exist in `internal/model`

Closes #639

Depends on #636 (model OS discriminator) and #637 (validate FCOS stream), both merged.
Part of epic #500.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `65a766c`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fedora CoreOS (FCOS) support with variant-specific configuration generation.
  * Introduced FCOS update strategy options and zincati integration for update management.
  * Enabled swap, Tailscale, timezone, SSH hardening, static networking, and systemd-sysext support for FCOS.
  * Added HTTPS-only validation for system extension URLs.

* **Tests**
  * Comprehensive test coverage for FCOS functionality and update strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->