### PR TITLE
feat(install): OS-dispatching installer and bakery client wiring

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -114,7 +114,11 @@ func main() {
 		realRunner := runner.NewRealRunner(logger)
 		prober = probe.NewSystemProber(realRunner)
 		bakeryClient = bakery.NewHTTPClient()
-		installer = install.NewFlatcarInstaller(cmdRunner, logger)
+		flatcarInstaller := install.NewFlatcarInstaller(cmdRunner, logger)
+		installer = &install.DispatchingInstaller{
+			Flatcar: flatcarInstaller,
+			FCOS:    flatcarInstaller, // FCOS installer reuses FlatcarInstaller until #639 lands
+		}
 	}
 
 	// Create wizard
@@ -209,7 +213,11 @@ func runHeadlessWithRunner(configPath string, dryRun bool, logFile string, cmdRu
 		}
 	}
 
-	installer := install.NewFlatcarInstaller(cmdRunner, logger)
+	flatcarInstaller := install.NewFlatcarInstaller(cmdRunner, logger)
+	installer := &install.DispatchingInstaller{
+		Flatcar: flatcarInstaller,
+		FCOS:    flatcarInstaller, // FCOS installer reuses FlatcarInstaller until #639 lands
+	}
 
 	// Run headless install with a 30-minute wall-clock timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/internal/install/dispatch.go
+++ b/internal/install/dispatch.go
@@ -1,0 +1,36 @@
+package install
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// DispatchingInstaller delegates to FlatcarInstaller or a future FCOSInstaller
+// based on cfg.OS at Install() call time. This allows construction before the
+// user selects an OS (in the wizard or headless config).
+type DispatchingInstaller struct {
+	Flatcar Installer
+	FCOS    Installer
+}
+
+// Install delegates to the appropriate installer based on cfg.OS.
+func (d *DispatchingInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	switch cfg.OS {
+	case model.OSFCOS:
+		if d.FCOS == nil {
+			return fmt.Errorf("FCOS installer not configured")
+		}
+		return d.FCOS.Install(ctx, cfg, progress)
+	default:
+		if d.Flatcar == nil {
+			return fmt.Errorf("Flatcar installer not configured")
+		}
+		return d.Flatcar.Install(ctx, cfg, progress)
+	}
+}

--- a/internal/install/dispatch_test.go
+++ b/internal/install/dispatch_test.go
@@ -1,0 +1,148 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+type spyInstaller struct {
+	called bool
+	cfg    *model.InstallConfig
+	err    error
+}
+
+func (s *spyInstaller) Install(_ context.Context, cfg *model.InstallConfig, _ func(string)) error {
+	s.called = true
+	s.cfg = cfg
+	return s.err
+}
+
+func TestDispatchingInstaller_DelegatesToFlatcar(t *testing.T) {
+	flatcar := &spyInstaller{}
+	fcos := &spyInstaller{}
+	d := &DispatchingInstaller{Flatcar: flatcar, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: model.OSFlatcar, Hostname: "flatcar-node"}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flatcar.called {
+		t.Error("expected Flatcar installer to be called")
+	}
+	if fcos.called {
+		t.Error("FCOS installer should not be called for Flatcar OS")
+	}
+	if flatcar.cfg.Hostname != "flatcar-node" {
+		t.Errorf("expected hostname 'flatcar-node', got %q", flatcar.cfg.Hostname)
+	}
+}
+
+func TestDispatchingInstaller_DelegatesToFCOS(t *testing.T) {
+	flatcar := &spyInstaller{}
+	fcos := &spyInstaller{}
+	d := &DispatchingInstaller{Flatcar: flatcar, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: model.OSFCOS, Hostname: "fcos-node"}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fcos.called {
+		t.Error("expected FCOS installer to be called")
+	}
+	if flatcar.called {
+		t.Error("Flatcar installer should not be called for FCOS OS")
+	}
+}
+
+func TestDispatchingInstaller_DefaultsToFlatcar(t *testing.T) {
+	flatcar := &spyInstaller{}
+	fcos := &spyInstaller{}
+	d := &DispatchingInstaller{Flatcar: flatcar, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: "", Hostname: "default-node"}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flatcar.called {
+		t.Error("expected Flatcar installer for empty OS (default)")
+	}
+}
+
+func TestDispatchingInstaller_NilConfig(t *testing.T) {
+	d := &DispatchingInstaller{
+		Flatcar: &spyInstaller{},
+		FCOS:    &spyInstaller{},
+	}
+	err := d.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if !strings.Contains(err.Error(), "config cannot be nil") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDispatchingInstaller_NilFCOSInstaller(t *testing.T) {
+	d := &DispatchingInstaller{
+		Flatcar: &spyInstaller{},
+		FCOS:    nil,
+	}
+	cfg := &model.InstallConfig{OS: model.OSFCOS}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil FCOS installer")
+	}
+	if !strings.Contains(err.Error(), "FCOS installer not configured") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDispatchingInstaller_NilFlatcarInstaller(t *testing.T) {
+	d := &DispatchingInstaller{
+		Flatcar: nil,
+		FCOS:    &spyInstaller{},
+	}
+	cfg := &model.InstallConfig{OS: model.OSFlatcar}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil Flatcar installer")
+	}
+	if !strings.Contains(err.Error(), "Flatcar installer not configured") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDispatchingInstaller_PropagatesFlatcarError(t *testing.T) {
+	flatcar := &spyInstaller{err: fmt.Errorf("flatcar install failed")}
+	d := &DispatchingInstaller{Flatcar: flatcar, FCOS: &spyInstaller{}}
+
+	cfg := &model.InstallConfig{OS: model.OSFlatcar}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if !strings.Contains(err.Error(), "flatcar install failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDispatchingInstaller_PropagatesFCOSError(t *testing.T) {
+	fcos := &spyInstaller{err: fmt.Errorf("fcos install failed")}
+	d := &DispatchingInstaller{Flatcar: &spyInstaller{}, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: model.OSFCOS}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if !strings.Contains(err.Error(), "fcos install failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -123,8 +123,14 @@ func (w *Wizard) Previous() {
 	}
 }
 
-// isNvidiaSelected returns true when the nvidia-runtime sysext is toggled on.
+// isNvidiaSelected returns true when the nvidia-runtime sysext is toggled on
+// AND the target OS supports the Flatcar NVIDIA kernel driver sysext mechanism.
+// FCOS has no /etc/flatcar/enabled-sysext.conf equivalent, so the NVIDIA step
+// is skipped entirely for FCOS targets.
 func (w *Wizard) isNvidiaSelected() bool {
+	if w.State.Config.OS == model.OSFCOS {
+		return false
+	}
 	for _, s := range w.State.Sysexts {
 		if s.Name == "nvidia-runtime" && s.Selected {
 			return true

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -705,6 +705,28 @@ func TestNextVisitsNvidiaWhenSelected(t *testing.T) {
 	}
 }
 
+func TestNextSkipsNvidiaForFCOS(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Network.Mode = model.NetworkDHCP
+	w.State.Config.Disk.DevPath = "/dev/sda"
+	w.State.Config.Users = []model.UserConfig{
+		{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test"}},
+	}
+	w.State.Config.Channel = "stable"
+	w.State.Sysexts = []model.SysextEntry{
+		{Name: "nvidia-runtime", Selected: true},
+	}
+	w.State.CurrentStep = model.StepSysext
+
+	if err := w.Next(); err != nil {
+		t.Fatalf("Next from Sysext: %v", err)
+	}
+	if w.State.CurrentStep == model.StepNvidia {
+		t.Error("FCOS should skip StepNvidia even when nvidia-runtime is selected")
+	}
+}
+
 func TestGoToStepRefusesNvidiaWhenNotSelected(t *testing.T) {
 	w, _, _, _ := newTestWizard()
 	w.State.CurrentStep = model.StepSysext


### PR DESCRIPTION
## Summary

- Add `install.DispatchingInstaller` that delegates to `FlatcarInstaller` or a future `FCOSInstaller` based on `cfg.OS` at `Install()` call time
- Wire `DispatchingInstaller` in both TUI and headless paths in `cmd/knuckle/main.go`
- Gate `isNvidiaSelected()` on `cfg.OS != model.OSFCOS` — FCOS has no `/etc/flatcar/enabled-sysext.conf`, so the NVIDIA step is skipped entirely for FCOS targets
- Both Flatcar and FCOS slots currently point to `FlatcarInstaller` (which already handles FCOS via `GenerateFCOSButane` in #703); a dedicated `FCOSInstaller` can be swapped in via #639

## Test plan

- [ ] `go test ./internal/install/...` — dispatcher tests pass (delegation, nil config, nil installers, error propagation)
- [ ] `go test ./internal/wizard/...` — FCOS NVIDIA skip test passes
- [ ] `go test ./cmd/knuckle/...` — existing main tests pass with DispatchingInstaller wiring
- [ ] `just ci` green
- [ ] Verify `isNvidiaSelected()` returns false when `cfg.OS == "fcos"` even with nvidia-runtime selected

Closes #638

Depends on #636 (model OS discriminator, merged).
Blocks #639 (FCOS Butane variant) and #641 (TUI OS selection).
Part of epic #500.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `80f9a12`