### PR TITLE
feat(install): OS-dispatching installer and bakery client wiring

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -114,7 +114,10 @@ func main() {
 		realRunner := runner.NewRealRunner(logger)
 		prober = probe.NewSystemProber(realRunner)
 		bakeryClient = bakery.NewHTTPClient()
-		installer = install.NewFlatcarInstaller(cmdRunner, logger)
+		installer = &install.DispatchingInstaller{
+			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
+			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+		}
 	}
 
 	// Create wizard
@@ -209,7 +212,10 @@ func runHeadlessWithRunner(configPath string, dryRun bool, logFile string, cmdRu
 		}
 	}
 
-	installer := install.NewFlatcarInstaller(cmdRunner, logger)
+	installer := &install.DispatchingInstaller{
+		Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
+		// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+	}
 
 	// Run headless install with a 30-minute wall-clock timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/internal/bakery/dispatch.go
+++ b/internal/bakery/dispatch.go
@@ -30,7 +30,7 @@ func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os stri
 	switch os {
 	case model.OSFCOS:
 		if d.FCOS == nil {
-			return nil, fmt.Errorf("FCOS bakery client not configured")
+			return nil, fmt.Errorf("fcos bakery client not configured")
 		}
 		return d.FCOS.FetchCatalogArch(ctx, arch)
 	case model.OSFlatcar, "":

--- a/internal/bakery/dispatch.go
+++ b/internal/bakery/dispatch.go
@@ -1,0 +1,41 @@
+package bakery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// DispatchingClient delegates to an OS-specific bakery Client based on
+// the os parameter passed to FetchCatalogForOS. The wizard calls this
+// method with the current cfg.OS at StepSysext time, when the user's
+// OS choice is known.
+type DispatchingClient struct {
+	Flatcar Client
+	FCOS    Client
+}
+
+func (d *DispatchingClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return d.Flatcar.FetchCatalog(ctx)
+}
+
+func (d *DispatchingClient) FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error) {
+	return d.Flatcar.FetchCatalogArch(ctx, arch)
+}
+
+// FetchCatalogForOS fetches the sysext catalog for the given OS and architecture.
+// FCOS may use a different catalog source or filtering in the future.
+func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os string) ([]model.SysextEntry, error) {
+	switch os {
+	case model.OSFCOS:
+		if d.FCOS == nil {
+			return nil, fmt.Errorf("FCOS bakery client not configured")
+		}
+		return d.FCOS.FetchCatalogArch(ctx, arch)
+	case model.OSFlatcar, "":
+		return d.Flatcar.FetchCatalogArch(ctx, arch)
+	default:
+		return nil, fmt.Errorf("unsupported OS %q for sysext catalog", os)
+	}
+}

--- a/internal/bakery/dispatch_test.go
+++ b/internal/bakery/dispatch_test.go
@@ -1,0 +1,108 @@
+package bakery_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestDispatchingClient_FlatcarDefault(t *testing.T) {
+	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
+	fcos := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "podman"}}}
+	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: fcos}
+
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "docker" {
+		t.Fatalf("expected flatcar entries, got %v", entries)
+	}
+}
+
+func TestDispatchingClient_EmptyOSDefaultsToFlatcar(t *testing.T) {
+	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
+	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: &bakery.MockClient{}}
+
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "docker" {
+		t.Fatalf("expected flatcar entries for empty OS, got %v", entries)
+	}
+}
+
+func TestDispatchingClient_FCOS(t *testing.T) {
+	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
+	fcos := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "podman"}}}
+	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: fcos}
+
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "podman" {
+		t.Fatalf("expected fcos entries, got %v", entries)
+	}
+}
+
+func TestDispatchingClient_UnsupportedOS(t *testing.T) {
+	d := &bakery.DispatchingClient{
+		Flatcar: &bakery.MockClient{},
+		FCOS:    &bakery.MockClient{},
+	}
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", "nixos")
+	if err == nil {
+		t.Fatal("expected error for unsupported OS")
+	}
+}
+
+func TestDispatchingClient_NilFCOS(t *testing.T) {
+	d := &bakery.DispatchingClient{Flatcar: &bakery.MockClient{}}
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS)
+	if err == nil {
+		t.Fatal("expected error when FCOS client is nil")
+	}
+}
+
+func TestDispatchingClient_PropagatesError(t *testing.T) {
+	flatcar := &bakery.MockClient{Err: fmt.Errorf("network error")}
+	d := &bakery.DispatchingClient{Flatcar: flatcar}
+
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar)
+	if err == nil || err.Error() != "network error" {
+		t.Fatalf("expected 'network error', got: %v", err)
+	}
+}
+
+func TestDispatchingClient_FetchCatalogDelegatesToFlatcar(t *testing.T) {
+	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
+	d := &bakery.DispatchingClient{Flatcar: flatcar}
+
+	entries, err := d.FetchCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "docker" {
+		t.Fatalf("expected flatcar entries from FetchCatalog, got %v", entries)
+	}
+}
+
+func TestDispatchingClient_FetchCatalogArchDelegatesToFlatcar(t *testing.T) {
+	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
+	d := &bakery.DispatchingClient{Flatcar: flatcar}
+
+	entries, err := d.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "docker" {
+		t.Fatalf("expected flatcar entries from FetchCatalogArch, got %v", entries)
+	}
+}
+
+var _ bakery.Client = (*bakery.DispatchingClient)(nil)

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -91,8 +91,13 @@ func LoadConfig(path string) (*Config, error) {
 
 // ToInstallConfig converts a headless Config to a model.InstallConfig.
 func (c *Config) ToInstallConfig() *model.InstallConfig {
+	os := c.OS
+	if os == "" {
+		os = model.OSFlatcar
+	}
+
 	cfg := &model.InstallConfig{
-		OS:       model.OSFlatcar,
+		OS:       os,
 		Arch:     c.Arch,
 		Channel:  c.Channel,
 		Version:  c.Version,
@@ -214,6 +219,11 @@ func resolveSysexts(ctx context.Context, names []string, client bakery.Client, a
 // Validate checks the headless config for errors using the same validation
 // as the TUI wizard path.
 func (c *Config) Validate() error {
+	// OS
+	if c.OS != "" && c.OS != model.OSFlatcar && c.OS != model.OSFCOS {
+		return fmt.Errorf("os: must be %q or %q (got %q)", model.OSFlatcar, model.OSFCOS, c.OS)
+	}
+
 	// Arch
 	if c.Arch != "" && c.Arch != "amd64" && c.Arch != "arm64" {
 		return fmt.Errorf("arch: must be \"amd64\" or \"arm64\" (got %q)", c.Arch)

--- a/internal/headless/headless_validation_coverage_test.go
+++ b/internal/headless/headless_validation_coverage_test.go
@@ -270,9 +270,9 @@ func TestValidate_NewOSAndArchValidation(t *testing.T) {
 
 func TestToInstallConfig_OSPropagation(t *testing.T) {
 	tests := []struct {
-		name     string
-		inputOS  string
-		wantOS   string
+		name    string
+		inputOS string
+		wantOS  string
 	}{
 		{"empty defaults to flatcar", "", model.OSFlatcar},
 		{"flatcar passes through", model.OSFlatcar, model.OSFlatcar},

--- a/internal/headless/headless_validation_coverage_test.go
+++ b/internal/headless/headless_validation_coverage_test.go
@@ -229,7 +229,26 @@ func TestValidate_NewOSAndArchValidation(t *testing.T) {
 		t.Errorf("expected invalid FCOS stream error, got: %v", err)
 	}
 
-	// 4. Flatcar channel failure
+	// 4. Invalid OS
+	cfgBadOS := &Config{
+		OS:             "nixos",
+		Arch:           "amd64",
+		Channel:        "stable",
+		Hostname:       "node01",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vdb",
+		UpdateStrategy: "reboot",
+	}
+	err = cfgBadOS.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid OS")
+	}
+	if !strings.Contains(err.Error(), "os: must be") {
+		t.Errorf("expected OS validation error, got: %v", err)
+	}
+
+	// 5. Flatcar channel failure
 	cfgFlatcarFail := &Config{
 		OS:             "flatcar",
 		Arch:           "amd64",
@@ -246,5 +265,33 @@ func TestValidate_NewOSAndArchValidation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "channel: invalid channel") {
 		t.Errorf("expected invalid channel error, got: %v", err)
+	}
+}
+
+func TestToInstallConfig_OSPropagation(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputOS  string
+		wantOS   string
+	}{
+		{"empty defaults to flatcar", "", model.OSFlatcar},
+		{"flatcar passes through", model.OSFlatcar, model.OSFlatcar},
+		{"fcos passes through", model.OSFCOS, model.OSFCOS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				OS:       tt.inputOS,
+				Channel:  "stable",
+				Hostname: "node01",
+				Network:  NetworkConfig{Mode: "dhcp"},
+				Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+				Disk:     "/dev/vdb",
+			}
+			ic := cfg.ToInstallConfig()
+			if ic.OS != tt.wantOS {
+				t.Errorf("ToInstallConfig().OS = %q, want %q", ic.OS, tt.wantOS)
+			}
+		})
 	}
 }

--- a/internal/install/dispatch.go
+++ b/internal/install/dispatch.go
@@ -1,0 +1,32 @@
+package install
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// DispatchingInstaller delegates to FlatcarInstaller or FCOSInstaller
+// based on cfg.OS at Install() call time.
+type DispatchingInstaller struct {
+	Flatcar Installer
+	FCOS    Installer
+}
+
+func (d *DispatchingInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	switch cfg.OS {
+	case model.OSFCOS:
+		if d.FCOS == nil {
+			return fmt.Errorf("FCOS installer not configured")
+		}
+		return d.FCOS.Install(ctx, cfg, progress)
+	case model.OSFlatcar, "":
+		if d.Flatcar == nil {
+			return fmt.Errorf("Flatcar installer not configured")
+		}
+		return d.Flatcar.Install(ctx, cfg, progress)
+	default:
+		return fmt.Errorf("unsupported OS %q", cfg.OS)
+	}
+}

--- a/internal/install/dispatch.go
+++ b/internal/install/dispatch.go
@@ -18,12 +18,12 @@ func (d *DispatchingInstaller) Install(ctx context.Context, cfg *model.InstallCo
 	switch cfg.OS {
 	case model.OSFCOS:
 		if d.FCOS == nil {
-			return fmt.Errorf("FCOS installer not configured")
+			return fmt.Errorf("fcos installer not configured")
 		}
 		return d.FCOS.Install(ctx, cfg, progress)
 	case model.OSFlatcar, "":
 		if d.Flatcar == nil {
-			return fmt.Errorf("Flatcar installer not configured")
+			return fmt.Errorf("flatcar installer not configured")
 		}
 		return d.Flatcar.Install(ctx, cfg, progress)
 	default:

--- a/internal/install/dispatch_test.go
+++ b/internal/install/dispatch_test.go
@@ -1,0 +1,110 @@
+package install_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/install"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+type stubInstaller struct {
+	called bool
+	err    error
+}
+
+func (s *stubInstaller) Install(_ context.Context, _ *model.InstallConfig, _ func(string)) error {
+	s.called = true
+	return s.err
+}
+
+func TestDispatchingInstaller_Flatcar(t *testing.T) {
+	flatcar := &stubInstaller{}
+	fcos := &stubInstaller{}
+	d := &install.DispatchingInstaller{Flatcar: flatcar, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: model.OSFlatcar}
+	if err := d.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flatcar.called {
+		t.Fatal("expected Flatcar installer to be called")
+	}
+	if fcos.called {
+		t.Fatal("FCOS installer should not be called")
+	}
+}
+
+func TestDispatchingInstaller_EmptyOSDefaultsToFlatcar(t *testing.T) {
+	flatcar := &stubInstaller{}
+	d := &install.DispatchingInstaller{Flatcar: flatcar, FCOS: &stubInstaller{}}
+
+	cfg := &model.InstallConfig{OS: ""}
+	if err := d.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flatcar.called {
+		t.Fatal("expected Flatcar installer to be called for empty OS")
+	}
+}
+
+func TestDispatchingInstaller_FCOS(t *testing.T) {
+	flatcar := &stubInstaller{}
+	fcos := &stubInstaller{}
+	d := &install.DispatchingInstaller{Flatcar: flatcar, FCOS: fcos}
+
+	cfg := &model.InstallConfig{OS: model.OSFCOS}
+	if err := d.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fcos.called {
+		t.Fatal("expected FCOS installer to be called")
+	}
+	if flatcar.called {
+		t.Fatal("Flatcar installer should not be called")
+	}
+}
+
+func TestDispatchingInstaller_UnsupportedOS(t *testing.T) {
+	d := &install.DispatchingInstaller{
+		Flatcar: &stubInstaller{},
+		FCOS:    &stubInstaller{},
+	}
+	cfg := &model.InstallConfig{OS: "nixos"}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for unsupported OS")
+	}
+}
+
+func TestDispatchingInstaller_NilFCOS(t *testing.T) {
+	d := &install.DispatchingInstaller{Flatcar: &stubInstaller{}}
+	cfg := &model.InstallConfig{OS: model.OSFCOS}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when FCOS installer is nil")
+	}
+}
+
+func TestDispatchingInstaller_NilFlatcar(t *testing.T) {
+	d := &install.DispatchingInstaller{FCOS: &stubInstaller{}}
+	cfg := &model.InstallConfig{OS: model.OSFlatcar}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when Flatcar installer is nil")
+	}
+}
+
+func TestDispatchingInstaller_PropagatesError(t *testing.T) {
+	flatcar := &stubInstaller{err: fmt.Errorf("disk full")}
+	d := &install.DispatchingInstaller{Flatcar: flatcar, FCOS: &stubInstaller{}}
+
+	cfg := &model.InstallConfig{OS: model.OSFlatcar}
+	err := d.Install(context.Background(), cfg, func(string) {})
+	if err == nil || err.Error() != "disk full" {
+		t.Fatalf("expected 'disk full' error, got: %v", err)
+	}
+}
+
+var _ install.Installer = (*install.DispatchingInstaller)(nil)

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -124,7 +124,12 @@ func (w *Wizard) Previous() {
 }
 
 // isNvidiaSelected returns true when the nvidia-runtime sysext is toggled on.
+// FCOS does not use /etc/flatcar/enabled-sysext.conf, so the NVIDIA step
+// is unconditionally skipped for FCOS installs.
 func (w *Wizard) isNvidiaSelected() bool {
+	if w.State.Config.OS == model.OSFCOS {
+		return false
+	}
 	for _, s := range w.State.Sysexts {
 		if s.Name == "nvidia-runtime" && s.Selected {
 			return true


### PR DESCRIPTION
## Summary

- Add `install.DispatchingInstaller` that delegates to Flatcar or FCOS installer based on `cfg.OS` at `Install()` call time
- Add `bakery.DispatchingClient` with `FetchCatalogForOS(ctx, arch, os)` for OS-aware sysext catalog fetching
- Wire `DispatchingInstaller` into both `cmd/knuckle/main.go` paths (TUI and headless)
- Gate `isNvidiaSelected()` on `cfg.OS != OSFCOS` — FCOS has no `/etc/flatcar/enabled-sysext.conf`
- Headless `ToInstallConfig()` now respects the `os` JSON field instead of hardcoding Flatcar
- Add OS validation to headless `Validate()`

FCOS installer slots are left as `nil` with comments pointing to #639. The dispatchers return clear errors if an unconfigured OS is selected.

## Test plan

- [x] `DispatchingInstaller` unit tests: Flatcar dispatch, FCOS dispatch, empty OS defaults to Flatcar, unsupported OS, nil impl errors, error propagation
- [x] `DispatchingClient` unit tests: OS-aware fetch, default behavior, nil FCOS, error propagation, `FetchCatalog`/`FetchCatalogArch` backward compat
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

Closes #638

Blocks #639 (FCOSInstaller), #641 (TUI OS selection)