### PR TITLE
fix(ci): bump Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           check-latest: true
 
       - name: go mod tidy (must be clean)
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
 
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
         continue-on-error: true
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -198,7 +198,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -259,7 +259,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
           check-latest: true
 
       - name: build arm64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbluefin/knuckle
 
-go 1.26.2
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
Bumps Go toolchain from 1.26.2 → 1.26.4 to resolve two stdlib CVEs flagged by govulncheck:
- GO-2026-5039: net/textproto (fixed in go1.26.4)
- GO-2026-5037: crypto/x509 (fixed in go1.26.4)

go.sum is unchanged — directives only. Unblocks #700 and all future PRs that run govulncheck.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>