### PR TITLE
feat(install): FCOSInstaller using coreos-installer

### DIFF
--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -78,7 +78,7 @@ This document is the authoritative reference for every field in that file.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. **FCOS limitation:** version pinning is not supported for FCOS — `coreos-installer` does not have a version flag equivalent; the stream's latest release is always used. If `version` is set with `os: "fcos"`, it is logged as a warning and ignored. |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -13,10 +12,9 @@ import (
 
 // FCOSInstaller runs coreos-installer via the runner.
 type FCOSInstaller struct {
-	Runner       runner.Runner
-	Generator    *ignition.Generator
-	Logger       *slog.Logger
-	ignitionPath string
+	Runner    runner.Runner
+	Generator *ignition.Generator
+	Logger    *slog.Logger
 }
 
 // NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
@@ -41,6 +39,8 @@ func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, p
 		i.Logger.Warn("version pinning is not supported for FCOS; coreos-installer uses stream latest", "version", cfg.Version)
 	}
 
+	var ignitionPath string
+
 	if cfg.IgnitionURL != "" {
 		progress("Using external Ignition config...")
 	} else {
@@ -57,15 +57,15 @@ func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, p
 		}
 
 		progress("Writing Ignition config...")
-		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		ignPath, err := writeIgnitionFile(i.Logger, ignitionJSON)
 		if err != nil {
 			return fmt.Errorf("writing ignition file: %w", err)
 		}
-		i.ignitionPath = ignPath
-		defer i.cleanupIgnitionFile()
+		ignitionPath = ignPath
+		defer removeIgnitionTempFile(i.Logger, ignitionPath)
 	}
 
-	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+	args := buildFCOSInstallArgs(cfg, ignitionPath)
 
 	progress("Running coreos-installer...")
 	i.Logger.Info("executing coreos-installer", "args", args)
@@ -94,37 +94,4 @@ func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []strin
 	}
 
 	return args
-}
-
-// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
-func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
-	f, err := newIgnitionTempFile()
-	if err != nil {
-		return "", fmt.Errorf("creating temp ignition file: %w", err)
-	}
-	path := f.Name()
-
-	if _, err := f.WriteString(ignitionJSON); err != nil {
-		_ = f.Close()
-		_ = removeIgnitionFile(path)
-		return "", fmt.Errorf("writing ignition content: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		_ = removeIgnitionFile(path)
-		return "", fmt.Errorf("closing ignition file: %w", err)
-	}
-
-	i.Logger.Info("ignition file written", "path", path)
-	return path, nil
-}
-
-func (i *FCOSInstaller) cleanupIgnitionFile() {
-	if i.ignitionPath == "" {
-		return
-	}
-	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
-		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
-	}
-	i.ignitionPath = ""
 }

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -1,0 +1,130 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/projectbluefin/knuckle/internal/ignition"
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+// FCOSInstaller runs coreos-installer via the runner.
+type FCOSInstaller struct {
+	Runner       runner.Runner
+	Generator    *ignition.Generator
+	Logger       *slog.Logger
+	ignitionPath string
+}
+
+// NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
+func NewFCOSInstaller(r runner.Runner, logger *slog.Logger) *FCOSInstaller {
+	return &FCOSInstaller{
+		Runner:    r,
+		Generator: ignition.NewGenerator(),
+		Logger:    logger,
+	}
+}
+
+// Install performs the FCOS installation:
+// 1. Generate FCOS Butane → compile Ignition JSON
+// 2. Write ignition to secure temp file
+// 3. Run: coreos-installer install --stream <stream> [--ignition-file <path>] <disk>
+func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	if cfg.Version != "" {
+		i.Logger.Warn("version pinning is not supported for FCOS; coreos-installer uses stream latest", "version", cfg.Version)
+	}
+
+	if cfg.IgnitionURL != "" {
+		progress("Using external Ignition config...")
+	} else {
+		progress("Generating Butane config...")
+		butaneYAML, err := i.Generator.GenerateFCOSButane(cfg)
+		if err != nil {
+			return fmt.Errorf("generating butane config: %w", err)
+		}
+
+		progress("Compiling Ignition config...")
+		ignitionJSON, err := compileToIgnitionFunc(butaneYAML)
+		if err != nil {
+			return fmt.Errorf("compiling butane: %w", err)
+		}
+
+		progress("Writing Ignition config...")
+		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		if err != nil {
+			return fmt.Errorf("writing ignition file: %w", err)
+		}
+		i.ignitionPath = ignPath
+		defer i.cleanupIgnitionFile()
+	}
+
+	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+
+	progress("Running coreos-installer...")
+	i.Logger.Info("executing coreos-installer", "args", args)
+
+	result, err := i.Runner.Run(ctx, "coreos-installer", args...)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatCommandError("coreos-installer failed", result, err)
+	}
+
+	progress("Installation complete!")
+	return nil
+}
+
+func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
+	args := []string{
+		"install",
+		"--stream", cfg.Channel,
+		diskPath,
+	}
+
+	if cfg.IgnitionURL != "" {
+		args = append(args, "--ignition-url", cfg.IgnitionURL)
+	} else if ignitionPath != "" {
+		args = append(args, "--ignition-file", ignitionPath)
+	}
+
+	return args
+}
+
+// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
+func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	f, err := newIgnitionTempFile()
+	if err != nil {
+		return "", fmt.Errorf("creating temp ignition file: %w", err)
+	}
+	path := f.Name()
+
+	if _, err := f.WriteString(ignitionJSON); err != nil {
+		_ = f.Close()
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("writing ignition content: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("closing ignition file: %w", err)
+	}
+
+	i.Logger.Info("ignition file written", "path", path)
+	return path, nil
+}
+
+func (i *FCOSInstaller) cleanupIgnitionFile() {
+	if i.ignitionPath == "" {
+		return
+	}
+	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
+		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
+	}
+	i.ignitionPath = ""
+}

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -1,0 +1,339 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func TestFCOSInstallWithGeneratedConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	if installCall.Args[0] != "install" {
+		t.Errorf("first arg = %q, want \"install\"", installCall.Args[0])
+	}
+	if installCall.Args[1] != "--stream" || installCall.Args[2] != "stable" {
+		t.Errorf("expected --stream stable, got %v", installCall.Args[1:3])
+	}
+	if installCall.Args[3] != "/dev/sda" {
+		t.Errorf("disk arg = %q, want /dev/sda", installCall.Args[3])
+	}
+
+	hasIgnitionFile := false
+	for _, arg := range installCall.Args {
+		if arg == "--ignition-file" {
+			hasIgnitionFile = true
+			break
+		}
+	}
+	if !hasIgnitionFile {
+		t.Error("expected --ignition-file flag in coreos-installer args")
+	}
+}
+
+func TestFCOSInstallWithExternalURL(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:          model.OSFCOS,
+		Channel:     "testing",
+		Hostname:    "ext-fcos",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	wantArgs := []string{"install", "--stream", "testing", "/dev/vda", "--ignition-url", "https://example.com/fcos.ign"}
+	if len(installCall.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", installCall.Args, wantArgs)
+	}
+	for i, arg := range wantArgs {
+		if installCall.Args[i] != arg {
+			t.Errorf("arg[%d] = %q, want %q", i, installCall.Args[i], arg)
+		}
+	}
+}
+
+func TestFCOSInstallNoWipefs(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "no-wipe-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, call := range spy.Calls {
+		if call.Name == "wipefs" {
+			t.Error("wipefs must NOT be called by FCOSInstaller")
+		}
+		if call.Name == "sfdisk" {
+			t.Error("sfdisk must NOT be called by FCOSInstaller")
+		}
+		if call.Name == "flatcar-install" {
+			t.Error("flatcar-install must NOT be called by FCOSInstaller")
+		}
+	}
+}
+
+func TestFCOSInstallNilConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+
+	err := installer.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if got := err.Error(); got != "install config cannot be nil" {
+		t.Errorf("error = %q, want %q", got, "install config cannot be nil")
+	}
+}
+
+func TestFCOSInstallFailure(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.AllError = fmt.Errorf("command exited with code 1")
+
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fail-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when coreos-installer fails")
+	}
+	if !strings.Contains(err.Error(), "coreos-installer failed") {
+		t.Errorf("error = %q, want coreos-installer context", err.Error())
+	}
+}
+
+func TestFCOSInstallProgressSteps(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "progress-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+
+	var steps []string
+	err := installer.Install(context.Background(), cfg, func(step string) {
+		steps = append(steps, step)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSteps := []string{
+		"Generating Butane config...",
+		"Compiling Ignition config...",
+		"Writing Ignition config...",
+		"Running coreos-installer...",
+		"Installation complete!",
+	}
+
+	if len(steps) != len(expectedSteps) {
+		t.Fatalf("got %d progress steps, want %d\nsteps: %v", len(steps), len(expectedSteps), steps)
+	}
+	for i, want := range expectedSteps {
+		if steps[i] != want {
+			t.Errorf("step[%d] = %q, want %q", i, steps[i], want)
+		}
+	}
+}
+
+func TestFCOSInstallPrefersByIDPath(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "byid-fcos",
+		Disk: model.DiskInfo{
+			DevPath: "/dev/sda",
+			Path:    "/dev/disk/by-id/ata-test-disk",
+		},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+	if installCall.Args[3] != "/dev/disk/by-id/ata-test-disk" {
+		t.Errorf("disk path = %q, want by-id path", installCall.Args[3])
+	}
+}
+
+func TestBuildFCOSInstallArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *model.InstallConfig
+		ignitionPath string
+		want         []string
+	}{
+		{
+			name: "basic with ignition file",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/sda", "--ignition-file", "/tmp/test-ign.json"},
+		},
+		{
+			name: "external URL",
+			cfg: &model.InstallConfig{
+				Channel:     "next",
+				Disk:        model.DiskInfo{DevPath: "/dev/nvme0n1"},
+				IgnitionURL: "https://example.com/ign.json",
+			},
+			want: []string{"install", "--stream", "next", "/dev/nvme0n1", "--ignition-url", "https://example.com/ign.json"},
+		},
+		{
+			name: "no ignition",
+			cfg: &model.InstallConfig{
+				Channel: "testing",
+				Disk:    model.DiskInfo{DevPath: "/dev/vda"},
+			},
+			want: []string{"install", "--stream", "testing", "/dev/vda"},
+		},
+		{
+			name: "prefers by-id path",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk: model.DiskInfo{
+					DevPath: "/dev/sda",
+					Path:    "/dev/disk/by-id/ata-Samsung",
+				},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/disk/by-id/ata-Samsung", "--ignition-file", "/tmp/test-ign.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFCOSInstallArgs(tt.cfg, tt.ignitionPath)
+			if len(got) != len(tt.want) {
+				t.Fatalf("buildFCOSInstallArgs() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("arg[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFCOSInstallVersionWarning(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Version:  "38.20230514.3.0",
+		Hostname: "version-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	for _, arg := range installCall.Args {
+		if arg == "38.20230514.3.0" || arg == "-V" || arg == "--image-url" {
+			t.Errorf("version pinning args should not be passed to coreos-installer, found %q", arg)
+		}
+	}
+}
+
+// Compile-time check that FCOSInstaller implements Installer.
+var _ Installer = (*FCOSInstaller)(nil)

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -333,6 +334,114 @@ func TestFCOSInstallVersionWarning(t *testing.T) {
 			t.Errorf("version pinning args should not be passed to coreos-installer, found %q", arg)
 		}
 	}
+}
+
+func TestFCOSInstall_GenerateButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-err-test",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "bad", URL: "http://insecure.example.com/bad.raw", Selected: true},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from FCOS butane generation, got nil")
+	}
+	if !strings.Contains(err.Error(), "generating butane config") {
+		t.Errorf("error should mention generating butane config, got: %v", err)
+	}
+}
+
+func TestFCOSInstall_CompileError(t *testing.T) {
+	prev := compileToIgnitionFunc
+	t.Cleanup(func() { compileToIgnitionFunc = prev })
+	compileToIgnitionFunc = func(string) (string, error) {
+		return "", fmt.Errorf("injected compilation error")
+	}
+
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-compile-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from compileToIgnitionFunc, got nil")
+	}
+	if !strings.Contains(err.Error(), "compiling butane") {
+		t.Errorf("error = %q, want 'compiling butane' prefix", err.Error())
+	}
+}
+
+func TestFCOSInstall_WriteIgnitionError(t *testing.T) {
+	prev := newIgnitionTempFile
+	t.Cleanup(func() { newIgnitionTempFile = prev })
+	newIgnitionTempFile = func() (ignitionTempFile, error) {
+		return nil, fmt.Errorf("injected temp file error")
+	}
+
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-write-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from writeIgnitionFile, got nil")
+	}
+	if !strings.Contains(err.Error(), "writing ignition file") {
+		t.Errorf("error = %q, want 'writing ignition file' prefix", err.Error())
+	}
+}
+
+func TestRemoveIgnitionTempFile_EmptyPath(t *testing.T) {
+	removeIgnitionTempFile(testLogger(), "")
+}
+
+func TestRemoveIgnitionTempFile_NonExistentPath(t *testing.T) {
+	removeIgnitionTempFile(testLogger(), "/nonexistent-path-xyz")
+}
+
+func TestRemoveIgnitionTempFile_RemoveFailsNonNotExist(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission checks don't apply")
+	}
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "ignition-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	removeIgnitionTempFile(testLogger(), path)
 }
 
 // Compile-time check that FCOSInstaller implements Installer.

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -91,7 +91,7 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 
 		// Write ignition JSON to secure temp file for flatcar-install
 		progress("Writing Ignition config...")
-		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		ignPath, err := writeIgnitionFile(i.Logger, ignitionJSON)
 		if err != nil {
 			return fmt.Errorf("writing ignition file: %w", err)
 		}
@@ -193,6 +193,11 @@ func installDiskPath(cfg *model.InstallConfig) string {
 // the file is never readable by other users, even between creation and content write.
 // Returns the path to the created temp file.
 func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	return writeIgnitionFile(i.Logger, ignitionJSON)
+}
+
+// writeIgnitionFile is the shared implementation for writing ignition JSON to a secure temp file.
+func writeIgnitionFile(logger *slog.Logger, ignitionJSON string) (string, error) {
 	f, err := newIgnitionTempFile()
 	if err != nil {
 		return "", fmt.Errorf("creating temp ignition file: %w", err)
@@ -210,7 +215,7 @@ func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error
 		return "", fmt.Errorf("closing ignition file: %w", err)
 	}
 
-	i.Logger.Info("ignition file written", "path", path)
+	logger.Info("ignition file written", "path", path)
 	return path, nil
 }
 
@@ -219,8 +224,16 @@ func (i *FlatcarInstaller) cleanupIgnitionFile() {
 	if i.ignitionPath == "" {
 		return
 	}
-	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
-		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
-	}
+	removeIgnitionTempFile(i.Logger, i.ignitionPath)
 	i.ignitionPath = ""
+}
+
+// removeIgnitionTempFile removes a temp ignition file at the given path.
+func removeIgnitionTempFile(logger *slog.Logger, path string) {
+	if path == "" {
+		return
+	}
+	if err := removeIgnitionFile(path); err != nil && !os.IsNotExist(err) {
+		logger.Warn("failed to clean up ignition file", "path", path, "error", err)
+	}
 }


### PR DESCRIPTION
## Summary

Implements `FCOSInstaller` that uses `coreos-installer` instead of `flatcar-install` for Fedora CoreOS installations.

- `FCOSInstaller` implements the `Installer` interface
- Calls `coreos-installer install --stream <channel> <disk>` with correct CLI semantics (positional disk arg, `--stream` instead of `-C`)
- Supports `--ignition-file` and `--ignition-url` for ignition delivery
- **No `wipefs` or `sfdisk` calls** — `coreos-installer` handles disk preparation internally
- Version pinning logs a warning and is ignored (not supported by `coreos-installer`)
- Documents FCOS version pinning limitation in `HEADLESS-CONFIG.md`

## Test plan

- [x] `coreos-installer install` called with correct args (SpyRunner)
- [x] `--stream stable` present in args
- [x] `--ignition-file <tempfile>` present in args
- [x] `wipefs` NOT called
- [x] `sfdisk` NOT called
- [x] `flatcar-install` NOT called
- [x] External ignition URL uses `--ignition-url`
- [x] Nil config returns error
- [x] Prefers `/dev/disk/by-id/` path
- [x] Version field logged as warning, not passed to coreos-installer
- [x] Progress steps are correct (no wipe/GPT repair steps)
- [x] Compile-time `Installer` interface check
- [x] `go test ./...` all pass
- [x] `go vet ./...` clean

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)