### PR TITLE
ci: add curl retry to Flatcar PXE artifact downloads

### DIFF
--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -209,11 +209,11 @@ KERNEL="$BUILD_DIR/vmlinuz"
 INITRD="$BUILD_DIR/initrd.cpio.gz"
 
 if [[ ! -f "$KERNEL" ]]; then
-    curl -fsSL -o "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz"
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz"
     verify_pxe_file "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz" "flatcar_production_pxe.vmlinuz"
 fi
 if [[ ! -f "$INITRD" ]]; then
-    curl -fsSL -o "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz"
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz"
     verify_pxe_file "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz" "flatcar_production_pxe_image.cpio.gz"
 fi
 

--- a/scripts/qa-test-pr.sh
+++ b/scripts/qa-test-pr.sh
@@ -75,6 +75,9 @@ _fetch_artifacts() {
   _scp_from -r "$GHOST:${WORK_REMOTE}/" "${RUNDIR}/ghost/" 2>/dev/null || true
 }
 
+# _file_issue_on_fail: writes a local issue body file for the operator to review.
+# Does NOT auto-file issues — projectbluefin/knuckle is public; infra/lab failures
+# belong in the private testlab repo, filed manually by the operator.
 _file_issue_on_fail() {
   local report="$1" rundir="$2" summary="$3"
   local issue_file="${rundir}/issue-body.md"


### PR DESCRIPTION
## Summary

The headless ISO boot smoke CI job intermittently fails when the Flatcar CDN returns a transient 404 for PXE artifact downloads. Adding `--retry 3 --retry-delay 5 --retry-all-errors` to the curl invocations makes the downloads resilient to brief CDN hiccups.

Closes #681