### PR TITLE
fix: use flatcar CDN directly for PXE artifact downloads (#681)

### DIFF
--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -62,11 +62,7 @@ fi
 
 # Flatcar release server arch directory: "amd64-usr" or "arm64-usr"
 ARCH_DIR="${ARCH}-usr"
-if [[ "$CHANNEL" == "lts" ]]; then
-    BASE_URL="https://lts.release.flatcar-linux.net/${ARCH_DIR}/current"
-else
-    BASE_URL="https://${CHANNEL}.release.flatcar-linux.net/${ARCH_DIR}/current"
-fi
+BASE_URL="https://flatcar.cdn.cncf.io/${CHANNEL}/${ARCH_DIR}/current"
 
 # ── Dependency check ─────────────────────────────────────────────────────────
 for cmd in xorriso mformat mcopy mmd cpio gzip; do
@@ -209,11 +205,11 @@ KERNEL="$BUILD_DIR/vmlinuz"
 INITRD="$BUILD_DIR/initrd.cpio.gz"
 
 if [[ ! -f "$KERNEL" ]]; then
-    curl -fsSL -o "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz"
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz"
     verify_pxe_file "$KERNEL" "$BASE_URL/flatcar_production_pxe.vmlinuz" "flatcar_production_pxe.vmlinuz"
 fi
 if [[ ! -f "$INITRD" ]]; then
-    curl -fsSL -o "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz"
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz"
     verify_pxe_file "$INITRD" "$BASE_URL/flatcar_production_pxe_image.cpio.gz" "flatcar_production_pxe_image.cpio.gz"
 fi
 


### PR DESCRIPTION
## Problem

The ISO smoke CI job was failing with HTTP 404 on PXE artifact downloads.

Root cause: `*.release.flatcar-linux.net/{arch}/current/` does a 302 redirect to a **versioned** CDN URL (e.g. `flatcar.cdn.cncf.io/stable/amd64-usr/4593.2.2/flatcar_production_pxe.vmlinuz`). That versioned URL returns 404. The CDN's own `/current/` path works correctly (HTTP 200).

## Fix

Replace `BASE_URL` construction (which had a separate code path for `lts` vs other channels) with a single CDN URL pattern that bypasses the broken redirect:

```bash
# Before (broken redirect)
if [[ "$CHANNEL" == "lts" ]]; then
    BASE_URL="https://lts.release.flatcar-linux.net/${ARCH_DIR}/current"
else
    BASE_URL="https://${CHANNEL}.release.flatcar-linux.net/${ARCH_DIR}/current"
fi

# After (CDN direct — HTTP 200 for all channels)
BASE_URL="https://flatcar.cdn.cncf.io/${CHANNEL}/${ARCH_DIR}/current"
```

Also adds `--retry 3 --retry-delay 5 --retry-all-errors` to the curl calls for transient network resilience.

Verified: stable ✅, beta ✅, alpha ✅, lts ✅, edge ✅ all return HTTP 200 via CDN.

Closes #681
Supersedes #710 (retry-only fix was insufficient — root cause was the broken redirect)