### PR TITLE
feat(headless): add os field, FCOS stream validation, NvidiaDriverVersion guard

### DIFF
--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -1,7 +1,8 @@
 # Headless Mode — JSON Config Schema
 
 Knuckle's headless mode (`--headless --config <file.json>`) performs a fully
-automated, non-interactive Flatcar install driven by a JSON configuration file.
+automated, non-interactive install driven by a JSON configuration file.
+It supports both Flatcar Container Linux and Fedora CoreOS.
 This document is the authoritative reference for every field in that file.
 
 ## Quick-start examples
@@ -69,6 +70,31 @@ This document is the authoritative reference for every field in that file.
 }
 ```
 
+### Fedora CoreOS (FCOS) install
+
+```json
+{
+  "os": "fcos",
+  "channel": "stable",
+  "hostname": "fcos-node-1",
+  "disk": "/dev/disk/by-id/ata-VBOX_HARDDISK_VB12345678-90abcdef",
+  "network": { "mode": "dhcp" },
+  "users": [
+    {
+      "username": "core",
+      "ssh_keys": ["ssh-ed25519 AAAA... you@host"]
+    }
+  ],
+  "update_strategy": "immediate"
+}
+```
+
+**FCOS limitations:**
+- **No version pinning** — the `version` field is ignored for FCOS. `coreos-installer` v1 does not support stream version pinning.
+- **No NVIDIA kernel driver** — `nvidia_driver_version` must not be set for FCOS.
+- **No etcd-lock** — FCOS uses zincati for updates. Valid strategies are `immediate` (default) and `disabled`.
+- **Streams, not channels** — FCOS uses `stable`, `testing`, and `next` (not `beta`, `alpha`, `lts`, `edge`).
+
 ---
 
 ## Full field reference
@@ -77,17 +103,18 @@ This document is the authoritative reference for every field in that file.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `os` | string | no | `"flatcar"` | Target operating system. One of `flatcar` or `fcos`. |
+| `channel` | string | no | `"stable"` | Release channel/stream. Flatcar: `stable`, `beta`, `alpha`, `lts`, `edge`. FCOS: `stable`, `testing`, `next`. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Ignored for FCOS (version pinning not supported). |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |
 | `users` | array | yes* | — | One or more user accounts. `*` Not required when `ignition_url` is set. |
-| `update_strategy` | string | no | `"reboot"` | Flatcar update strategy. One of `reboot`, `off`, `etcd-lock`. |
+| `update_strategy` | string | no | `"reboot"` / `"immediate"` | Flatcar: `reboot`, `off`, `etcd-lock`. FCOS: `immediate`, `disabled`. |
 | `arch` | string | no | `"amd64"` | CPU architecture. One of `amd64`, `arm64`. `arm64` is not available on the `lts` channel. |
 | `timezone` | string | no | `"UTC"` | System timezone (IANA format, e.g. `"America/New_York"`). |
 | `sysexts` | string[] | no | `[]` | List of system extension names from the bakery catalog (e.g. `["docker", "kubernetes"]`). |
-| `nvidia_driver_version` | string | no | _(none)_ | NVIDIA kernel driver series. One of `570-open` (default/recommended), `550-open`, `535-open`, `460`. Omit to skip NVIDIA setup. |
+| `nvidia_driver_version` | string | no | _(none)_ | NVIDIA kernel driver series (Flatcar only). One of `570-open` (recommended), `550-open`, `535-open`, `460`. Must not be set for FCOS. |
 | `tailscale` | object | no | — | See [Tailscale](#tailscale). Omit or leave `auth_key` blank to skip. |
 | `swap` | object | no | _(enabled, 4 GiB)_ | See [Swap](#swap). Omit for the default (4 GiB enabled). |
 | `ignition_url` | string | no | — | URL of an external Ignition config. When set, knuckle downloads this config instead of generating one — only `disk` is then required. Must be HTTPS. |

--- a/internal/headless/fcos_headless_test.go
+++ b/internal/headless/fcos_headless_test.go
@@ -1,0 +1,209 @@
+package headless
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestValidate_FCOS_ValidConfig(t *testing.T) {
+	cfg := &Config{
+		OS:             model.OSFCOS,
+		Channel:        "stable",
+		Hostname:       "fcos-node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vda",
+		UpdateStrategy: "immediate",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid FCOS config, got: %v", err)
+	}
+}
+
+func TestValidate_FCOS_DisabledStrategy(t *testing.T) {
+	cfg := &Config{
+		OS:             model.OSFCOS,
+		Channel:        "stable",
+		Hostname:       "fcos-node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vda",
+		UpdateStrategy: "disabled",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid FCOS config with disabled strategy, got: %v", err)
+	}
+}
+
+func TestValidate_FCOS_RejectFlatcarStrategy(t *testing.T) {
+	for _, strategy := range []string{"reboot", "off", "etcd-lock"} {
+		t.Run(strategy, func(t *testing.T) {
+			cfg := &Config{
+				OS:             model.OSFCOS,
+				Channel:        "stable",
+				Hostname:       "fcos-node",
+				Network:        NetworkConfig{Mode: "dhcp"},
+				Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+				Disk:           "/dev/vda",
+				UpdateStrategy: strategy,
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected error for FCOS with Flatcar strategy %q", strategy)
+			}
+			if !strings.Contains(err.Error(), "update_strategy") {
+				t.Errorf("error should mention update_strategy, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_FCOS_RejectNvidiaDriver(t *testing.T) {
+	cfg := &Config{
+		OS:                  model.OSFCOS,
+		Channel:             "stable",
+		Hostname:            "fcos-node",
+		Network:             NetworkConfig{Mode: "dhcp"},
+		Users:               []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:                "/dev/vda",
+		UpdateStrategy:      "immediate",
+		NvidiaDriverVersion: "570-open",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for FCOS with nvidia_driver_version")
+	}
+	if !strings.Contains(err.Error(), "nvidia_driver_version") || !strings.Contains(err.Error(), "FCOS") {
+		t.Errorf("error should mention nvidia_driver_version and FCOS, got: %v", err)
+	}
+}
+
+func TestValidate_FCOS_VersionFieldIgnored(t *testing.T) {
+	cfg := &Config{
+		OS:             model.OSFCOS,
+		Channel:        "stable",
+		Version:        "38.20230514.3.0",
+		Hostname:       "fcos-node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vda",
+		UpdateStrategy: "immediate",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("FCOS version field should be accepted (ignored), got: %v", err)
+	}
+}
+
+func TestValidate_FCOS_Streams(t *testing.T) {
+	for _, stream := range []string{"stable", "testing", "next"} {
+		t.Run(stream, func(t *testing.T) {
+			cfg := &Config{
+				OS:             model.OSFCOS,
+				Channel:        stream,
+				Hostname:       "fcos-node",
+				Network:        NetworkConfig{Mode: "dhcp"},
+				Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+				Disk:           "/dev/vda",
+				UpdateStrategy: "immediate",
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("expected valid FCOS stream %q, got: %v", stream, err)
+			}
+		})
+	}
+}
+
+func TestValidate_FCOS_InvalidStream(t *testing.T) {
+	cfg := &Config{
+		OS:             model.OSFCOS,
+		Channel:        "lts",
+		Hostname:       "fcos-node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vda",
+		UpdateStrategy: "immediate",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for FCOS with lts channel")
+	}
+}
+
+func TestToInstallConfig_FCOS(t *testing.T) {
+	cfg := &Config{
+		OS:             model.OSFCOS,
+		Channel:        "stable",
+		Version:        "44.20260510.3.1",
+		Hostname:       "fcos-node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		Disk:           "/dev/vda",
+		UpdateStrategy: "immediate",
+	}
+
+	ic := cfg.ToInstallConfig()
+
+	if ic.OS != model.OSFCOS {
+		t.Errorf("OS = %q, want %q", ic.OS, model.OSFCOS)
+	}
+	if ic.Version != "" {
+		t.Errorf("Version should be empty for FCOS, got %q", ic.Version)
+	}
+	if ic.UpdateStrategy.FCOSUpdateStrategy != model.FCOSStrategyImmediate {
+		t.Errorf("FCOSUpdateStrategy = %q, want %q", ic.UpdateStrategy.FCOSUpdateStrategy, model.FCOSStrategyImmediate)
+	}
+	if ic.UpdateStrategy.RebootStrategy != "" {
+		t.Errorf("RebootStrategy should be empty for FCOS, got %q", ic.UpdateStrategy.RebootStrategy)
+	}
+}
+
+func TestToInstallConfig_FCOS_DefaultsToImmediate(t *testing.T) {
+	cfg := &Config{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Network:  NetworkConfig{Mode: "dhcp"},
+		Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		Disk:     "/dev/vda",
+	}
+
+	ic := cfg.ToInstallConfig()
+	if ic.UpdateStrategy.FCOSUpdateStrategy != model.FCOSStrategyImmediate {
+		t.Errorf("default FCOSUpdateStrategy = %q, want %q", ic.UpdateStrategy.FCOSUpdateStrategy, model.FCOSStrategyImmediate)
+	}
+}
+
+func TestToInstallConfig_DefaultFlatcar(t *testing.T) {
+	cfg := &Config{
+		Channel:  "stable",
+		Hostname: "flatcar-node",
+		Network:  NetworkConfig{Mode: "dhcp"},
+		Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		Disk:     "/dev/vda",
+	}
+
+	ic := cfg.ToInstallConfig()
+
+	if ic.OS != model.OSFlatcar {
+		t.Errorf("OS = %q, want %q (default)", ic.OS, model.OSFlatcar)
+	}
+	if ic.UpdateStrategy.RebootStrategy != "reboot" {
+		t.Errorf("default RebootStrategy = %q, want %q", ic.UpdateStrategy.RebootStrategy, "reboot")
+	}
+}
+
+func TestValidate_FCOS_EmptyStrategyAllowed(t *testing.T) {
+	cfg := &Config{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Network:  NetworkConfig{Mode: "dhcp"},
+		Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:     "/dev/vda",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("FCOS with empty strategy should be valid, got: %v", err)
+	}
+}

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -96,11 +96,16 @@ func (c *Config) ToInstallConfig() *model.InstallConfig {
 		os = model.OSFlatcar
 	}
 
+	version := c.Version
+	if os == model.OSFCOS {
+		version = "" // FCOS v1 does not support version pinning
+	}
+
 	cfg := &model.InstallConfig{
 		OS:       os,
 		Arch:     c.Arch,
 		Channel:  c.Channel,
-		Version:  c.Version,
+		Version:  version,
 		Hostname: c.Hostname,
 		Timezone: c.Timezone,
 		DryRun:   c.DryRun,
@@ -180,11 +185,19 @@ func (c *Config) ToInstallConfig() *model.InstallConfig {
 		cfg.SSHKeys = append(cfg.SSHKeys, u.SSHKeys...)
 	}
 
-	// Update strategy
-	if c.UpdateStrategy != "" {
-		cfg.UpdateStrategy.RebootStrategy = c.UpdateStrategy
+	// Update strategy — FCOS uses FCOSUpdateStrategy; Flatcar uses RebootStrategy
+	if os == model.OSFCOS {
+		if c.UpdateStrategy != "" {
+			cfg.UpdateStrategy.FCOSUpdateStrategy = c.UpdateStrategy
+		} else {
+			cfg.UpdateStrategy.FCOSUpdateStrategy = model.FCOSStrategyImmediate
+		}
 	} else {
-		cfg.UpdateStrategy.RebootStrategy = "reboot"
+		if c.UpdateStrategy != "" {
+			cfg.UpdateStrategy.RebootStrategy = c.UpdateStrategy
+		} else {
+			cfg.UpdateStrategy.RebootStrategy = "reboot"
+		}
 	}
 
 	return cfg
@@ -246,8 +259,10 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Version
-	if err := validate.FlatcarVersion(c.Version); err != nil {
+	// Version — FCOS does not support version pinning via coreos-installer
+	if c.OS == model.OSFCOS {
+		// Silently accept empty; non-empty is validated below at CheckConsistency
+	} else if err := validate.FlatcarVersion(c.Version); err != nil {
 		return fmt.Errorf("version: %w", err)
 	}
 
@@ -344,10 +359,18 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Update strategy
-	validStrategies := map[string]bool{"reboot": true, "off": true, "etcd-lock": true, "": true}
-	if !validStrategies[c.UpdateStrategy] {
-		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
+	// Update strategy — OS-specific valid values
+	if c.OS == model.OSFCOS {
+		validFCOS := map[string]bool{model.FCOSStrategyImmediate: true, model.FCOSStrategyDisabled: true, "": true}
+		if !validFCOS[c.UpdateStrategy] {
+			return fmt.Errorf("update_strategy: must be %q or %q for FCOS (got %q)",
+				model.FCOSStrategyImmediate, model.FCOSStrategyDisabled, c.UpdateStrategy)
+		}
+	} else {
+		validStrategies := map[string]bool{"reboot": true, "off": true, "etcd-lock": true, "": true}
+		if !validStrategies[c.UpdateStrategy] {
+			return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
+		}
 	}
 
 	// Swap size must be within [0, MaxSwapSizeMB]
@@ -380,8 +403,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// NVIDIA driver version must be a known series
+	// NVIDIA driver version — not supported on FCOS
 	if c.NvidiaDriverVersion != "" {
+		if c.OS == model.OSFCOS {
+			return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
+		}
 		valid := false
 		for _, opt := range model.NvidiaDriverOptions {
 			if opt.ID == c.NvidiaDriverVersion {
@@ -407,11 +433,16 @@ func (c *Config) Validate() error {
 // 6. Optionally reboot
 func Run(ctx context.Context, cfg *Config, installer install.Installer, logger *slog.Logger) error {
 	logger.Info("headless install starting",
+		"os", cfg.OS,
 		"channel", cfg.Channel,
 		"disk", cfg.Disk,
 		"hostname", cfg.Hostname,
 		"dry_run", cfg.DryRun,
 	)
+
+	if cfg.OS == model.OSFCOS && cfg.Version != "" {
+		logger.Warn("FCOS version pinning is not supported; ignoring version field", "version", cfg.Version)
+	}
 
 	// Step 1: Validate input config
 	fmt.Println("→ Validating configuration...")

--- a/internal/headless/headless_validation_coverage_test.go
+++ b/internal/headless/headless_validation_coverage_test.go
@@ -204,7 +204,7 @@ func TestValidate_NewOSAndArchValidation(t *testing.T) {
 		Network:        NetworkConfig{Mode: "dhcp"},
 		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
 		Disk:           "/dev/vdb",
-		UpdateStrategy: "reboot",
+		UpdateStrategy: "immediate",
 	}
 	if err := cfgFCOSSuccess.Validate(); err != nil {
 		t.Errorf("expected no error for FCOS stable channel, got: %v", err)
@@ -219,7 +219,7 @@ func TestValidate_NewOSAndArchValidation(t *testing.T) {
 		Network:        NetworkConfig{Mode: "dhcp"},
 		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
 		Disk:           "/dev/vdb",
-		UpdateStrategy: "reboot",
+		UpdateStrategy: "immediate",
 	}
 	err = cfgFCOSFail.Validate()
 	if err == nil {

--- a/internal/validate/fcos_validate_test.go
+++ b/internal/validate/fcos_validate_test.go
@@ -1,0 +1,59 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestCheckConsistency_FCOS_RejectNvidiaDriver(t *testing.T) {
+	cfg := &model.InstallConfig{
+		OS:                  model.OSFCOS,
+		Channel:             "stable",
+		Hostname:            "fcos-node",
+		NvidiaDriverVersion: "570-open",
+		Disk:                model.DiskInfo{DevPath: "/dev/vda"},
+		Users:               []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		SSHKeys:             []string{"ssh-ed25519 AAAA test"},
+	}
+
+	err := CheckConsistency(cfg)
+	if err == nil {
+		t.Fatal("expected error for FCOS with NvidiaDriverVersion")
+	}
+	if !strings.Contains(err.Error(), "nvidia_driver_version") {
+		t.Errorf("error should mention nvidia_driver_version, got: %v", err)
+	}
+}
+
+func TestCheckConsistency_FCOS_NoNvidiaOK(t *testing.T) {
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/vda"},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		SSHKeys:  []string{"ssh-ed25519 AAAA test"},
+	}
+
+	if err := CheckConsistency(cfg); err != nil {
+		t.Errorf("expected no error for FCOS without NVIDIA, got: %v", err)
+	}
+}
+
+func TestCheckConsistency_Flatcar_NvidiaOK(t *testing.T) {
+	cfg := &model.InstallConfig{
+		OS:                  model.OSFlatcar,
+		Channel:             "stable",
+		Hostname:            "flatcar-node",
+		NvidiaDriverVersion: "570-open",
+		Disk:                model.DiskInfo{DevPath: "/dev/vda"},
+		Users:               []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		SSHKeys:             []string{"ssh-ed25519 AAAA test"},
+	}
+
+	if err := CheckConsistency(cfg); err != nil {
+		t.Errorf("expected no error for Flatcar with valid NVIDIA driver, got: %v", err)
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -291,6 +291,11 @@ func CheckConsistency(cfg *model.InstallConfig) error {
 		return fmt.Errorf("no channel selected")
 	}
 
+	// NVIDIA driver version — not supported on FCOS
+	if cfg.OS == model.OSFCOS && cfg.NvidiaDriverVersion != "" {
+		return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
+	}
+
 	// NVIDIA driver version must be a known series if set
 	if cfg.NvidiaDriverVersion != "" {
 		valid := false


### PR DESCRIPTION
## Summary

Wires the headless install path for full FCOS end-to-end support:

- **FCOS update strategies**: `Validate()` enforces `immediate`/`disabled` for FCOS; rejects Flatcar strategies (`reboot`/`off`/`etcd-lock`) with a clear error message
- **NvidiaDriverVersion guard**: rejected for FCOS in both `Validate()` and `CheckConsistency()` — FCOS has no `/etc/flatcar/enabled-sysext.conf`
- **FCOS version field**: accepted in `Validate()` (not checked against Flatcar regex) but cleared in `ToInstallConfig()` since `coreos-installer` v1 doesn't support stream version pinning. `Run()` logs a warning when set.
- **ToInstallConfig()**: populates `FCOSUpdateStrategy` (not `RebootStrategy`) for FCOS; defaults to `immediate`
- **docs/HEADLESS-CONFIG.md**: `os` field added to reference table, FCOS example with limitations section, channel/strategy/nvidia descriptions updated

## Test plan

- [x] FCOS valid config with `immediate` strategy passes validation
- [x] FCOS valid config with `disabled` strategy passes validation
- [x] FCOS with Flatcar strategies (`reboot`, `off`, `etcd-lock`) rejected
- [x] FCOS with `nvidia_driver_version` rejected in `Validate()`
- [x] FCOS with `nvidia_driver_version` rejected in `CheckConsistency()`
- [x] Flatcar with `nvidia_driver_version` still accepted
- [x] FCOS version field accepted (not rejected by Flatcar version regex)
- [x] FCOS streams (`stable`, `testing`, `next`) all accepted
- [x] FCOS invalid stream (`lts`) rejected
- [x] `ToInstallConfig()` clears version for FCOS, sets `FCOSUpdateStrategy`
- [x] `ToInstallConfig()` defaults to `immediate` for FCOS when empty
- [x] Empty OS defaults to Flatcar (backward compatible)
- [x] All existing tests pass (17 packages)
- [x] `go vet ./...` clean

Closes #642

Part of epic #500
---
🐝 **Hive Agent**: `contributor` | **SHA:** `unknown`