### PR TITLE
feat(bakery): FCOS sysext catalog client for fedora-sysexts/community

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -113,7 +113,11 @@ func main() {
 	} else {
 		realRunner := runner.NewRealRunner(logger)
 		prober = probe.NewSystemProber(realRunner)
-		bakeryClient = bakery.NewHTTPClient()
+		bakeryClient = &bakery.DispatchingClient{
+			Flatcar: bakery.NewHTTPClient(),
+			// FCOS client is created lazily by wizard.FetchFCOSStreamVersion
+			// when the user selects FCOS, since it needs the Fedora version.
+		}
 		installer = &install.DispatchingInstaller{
 			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
 			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
@@ -146,6 +150,11 @@ func main() {
 		// Fetch sysext catalog (non-fatal if it fails)
 		if err := w.FetchSysexts(ctx); err != nil {
 			logger.Warn("sysext catalog fetch failed", "error", err)
+		}
+
+		// Fetch FCOS stream version (non-fatal; no-op when OS is flatcar)
+		if err := w.FetchFCOSStreamVersion(ctx); err != nil {
+			logger.Warn("FCOS stream version fetch failed", "error", err)
 		}
 
 		// Fetch channel version info (non-fatal if it fails)

--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -78,7 +78,7 @@ This document is the authoritative reference for every field in that file.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. **FCOS limitation:** version pinning is not supported for FCOS — `coreos-installer` does not have a version flag equivalent; the stream's latest release is always used. If `version` is set with `os: "fcos"`, it is logged as a warning and ignored. |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |

--- a/internal/bakery/fcos_catalog.go
+++ b/internal/bakery/fcos_catalog.go
@@ -1,0 +1,244 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
+)
+
+const (
+	// FCOSCatalogURL is the GitHub Releases API for the fedora-sysexts/community repo.
+	FCOSCatalogURL = "https://api.github.com/repos/fedora-sysexts/community/releases?per_page=100"
+
+	// maxFCOSCatalogPages is higher than Flatcar's maxCatalogPages because
+	// fedora-sysexts/community has 1,500+ releases. At 100/page, 20 pages
+	// covers the full catalog. Extensions only in older releases (page >20)
+	// would be silently missing — see the issue for discussion.
+	maxFCOSCatalogPages = 20
+)
+
+// FCOSClient fetches the sysext catalog from fedora-sysexts/community and
+// filters by architecture and Fedora major version.
+type FCOSClient struct {
+	CatalogURL    string
+	HTTP          *http.Client
+	AuthToken     string
+	FedoraVersion int
+}
+
+// NewFCOSClient creates a client for the fedora-sysexts/community catalog.
+// fedoraVersion is the Fedora major version obtained from FetchStreamFedoraVersion.
+func NewFCOSClient(fedoraVersion int) *FCOSClient {
+	return &FCOSClient{
+		CatalogURL:    FCOSCatalogURL,
+		HTTP:          &http.Client{Timeout: defaultTimeout},
+		AuthToken:     githubTokenFromEnv(),
+		FedoraVersion: fedoraVersion,
+	}
+}
+
+func (c *FCOSClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return c.FetchCatalogArch(ctx, "amd64")
+}
+
+// FetchCatalogArch fetches FCOS sysexts for the given arch and the client's
+// configured Fedora version. Only releases whose tag encodes a matching Fedora
+// version and architecture are included. Entries are deduplicated by name
+// (newest first). Download URLs point to GitHub releases (the CDN at
+// extensions.fcos.fr is not used by the API).
+func (c *FCOSClient) FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error) {
+	var tagArch string
+	switch arch {
+	case "amd64":
+		tagArch = "x86-64"
+	case "arm64":
+		tagArch = "arm64"
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q: must be amd64 or arm64", arch)
+	}
+
+	wantFedora := strconv.Itoa(c.FedoraVersion)
+
+	const maxResponseSize = 5 << 20
+	var allReleases []githubRelease
+	nextURL := c.CatalogURL
+
+	for page := 0; page < maxFCOSCatalogPages && nextURL != ""; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request (page %d): %w", page+1, err)
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "knuckle/1.0")
+		if c.AuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+c.AuthToken)
+		}
+
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching FCOS catalog (page %d): %w", page+1, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("FCOS catalog returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading response (page %d): %w", page+1, err)
+		}
+		if int64(len(body)) >= maxResponseSize {
+			return nil, fmt.Errorf("FCOS catalog response exceeds 5MB size limit")
+		}
+
+		var releases []githubRelease
+		if err := json.Unmarshal(body, &releases); err != nil {
+			return nil, fmt.Errorf("parsing FCOS catalog JSON (page %d): %w", page+1, err)
+		}
+
+		if len(releases) == 0 {
+			break
+		}
+		allReleases = append(allReleases, releases...)
+
+		nextURL, _ = parseLinkNext(resp.Header.Get("Link"))
+	}
+
+	seen := make(map[string]bool)
+	sysexts := make([]model.SysextEntry, 0, len(allReleases))
+
+	for _, rel := range allReleases {
+		name, version, fedoraVer, parsedArch, ok := ParseFCOSTagName(rel.TagName)
+		if !ok {
+			continue
+		}
+
+		if fedoraVer != wantFedora || parsedArch != tagArch {
+			continue
+		}
+
+		if seen[name] {
+			continue
+		}
+
+		var downloadURL, sha256sumsURL string
+		for _, asset := range rel.Assets {
+			switch {
+			case asset.Name == "SHA256SUMS":
+				sha256sumsURL = asset.BrowserDownloadURL
+			case strings.HasSuffix(asset.Name, ".raw"):
+				if downloadURL == "" {
+					downloadURL = asset.BrowserDownloadURL
+				}
+			}
+		}
+		if downloadURL == "" {
+			continue
+		}
+		if len(downloadURL) > maxSysextURLLen {
+			continue
+		}
+		if sha256sumsURL != "" && len(sha256sumsURL) > maxSysextURLLen {
+			sha256sumsURL = ""
+		}
+		if validate.SysextName(name) != nil {
+			continue
+		}
+
+		seen[name] = true
+
+		sha256Hash := ""
+		if sha256sumsURL != "" {
+			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
+			if h, err := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); err == nil {
+				sha256Hash = h
+			}
+		}
+
+		description := truncateDescription(rel.Body, 80)
+		category := ""
+		supportTier := ""
+
+		if meta, ok := FCOSLookup(name); ok {
+			if meta.Short != "" {
+				description = meta.Short
+			}
+			category = meta.Category
+			supportTier = meta.SupportTier
+		}
+
+		sysexts = append(sysexts, model.SysextEntry{
+			Name:        name,
+			Description: description,
+			Version:     version,
+			URL:         downloadURL,
+			Sha256:      sha256Hash,
+			Category:    category,
+			SupportTier: supportTier,
+			Selected:    false,
+		})
+	}
+
+	return sysexts, nil
+}
+
+// fetchSHA256ForAsset is identical to HTTPClient.fetchSHA256ForAsset — reused
+// via composition since FCOSClient shares the same SHA256SUMS format.
+func (c *FCOSClient) fetchSHA256ForAsset(ctx context.Context, sha256sumsURL, rawFilename string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sha256sumsURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating SHA256SUMS request: %w", err)
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching SHA256SUMS: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("SHA256SUMS returned HTTP %d", resp.StatusCode)
+	}
+
+	const maxSHA256Size = 64 << 10
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSHA256Size))
+	if err != nil {
+		return "", fmt.Errorf("reading SHA256SUMS: %w", err)
+	}
+
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		baseName := fields[1]
+		if idx := strings.LastIndex(baseName, "/"); idx >= 0 {
+			baseName = baseName[idx+1:]
+		}
+		if baseName == rawFilename {
+			hash := fields[0]
+			if !reSHA256.MatchString(hash) {
+				return "", fmt.Errorf("malformed SHA256 hash %q for %s", hash, rawFilename)
+			}
+			return hash, nil
+		}
+	}
+	return "", nil
+}
+
+// Verify FCOSClient implements Client.
+var _ Client = (*FCOSClient)(nil)

--- a/internal/bakery/fcos_catalog_test.go
+++ b/internal/bakery/fcos_catalog_test.go
@@ -1,0 +1,207 @@
+package bakery_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+func TestFCOSClient_FetchCatalogArch(t *testing.T) {
+	releases := `[
+		{
+			"tag_name": "tailscale-0-1.98.4-1-44-x86-64",
+			"body": "Tailscale VPN",
+			"assets": [
+				{"name": "SHA256SUMS", "browser_download_url": "https://example.com/SHA256SUMS"},
+				{"name": "tailscale-0-1.98.4-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale.raw"}
+			]
+		},
+		{
+			"tag_name": "tailscale-0-1.98.4-1-44-arm64",
+			"body": "Tailscale VPN arm64",
+			"assets": [
+				{"name": "tailscale-0-1.98.4-1-44-arm64.raw", "browser_download_url": "https://example.com/tailscale-arm64.raw"}
+			]
+		},
+		{
+			"tag_name": "tailscale-0-1.98.4-1-43-x86-64",
+			"body": "Tailscale VPN Fedora 43",
+			"assets": [
+				{"name": "tailscale-0-1.98.4-1-43-x86-64.raw", "browser_download_url": "https://example.com/tailscale-f43.raw"}
+			]
+		},
+		{
+			"tag_name": "docker-ce-3-29.5.2-1.fc44-44-x86-64",
+			"body": "Docker CE",
+			"assets": [
+				{"name": "docker-ce-3-29.5.2-1.fc44-44-x86-64.raw", "browser_download_url": "https://example.com/docker.raw"}
+			]
+		},
+		{
+			"tag_name": "tailscale",
+			"body": "Index tag",
+			"assets": []
+		},
+		{
+			"tag_name": "latest",
+			"body": "Latest index",
+			"assets": []
+		}
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releases)
+	}))
+	defer srv.Close()
+
+	client := &bakery.FCOSClient{
+		CatalogURL:    srv.URL,
+		HTTP:          srv.Client(),
+		FedoraVersion: 44,
+	}
+
+	t.Run("amd64 filters by arch and fedora version", func(t *testing.T) {
+		entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries (tailscale + docker-ce), got %d: %v", len(entries), entryNames(entries))
+		}
+		names := entryNames(entries)
+		if !strings.Contains(names, "tailscale") || !strings.Contains(names, "docker-ce") {
+			t.Errorf("expected tailscale and docker-ce, got %s", names)
+		}
+	})
+
+	t.Run("arm64 filters correctly", func(t *testing.T) {
+		entries, err := client.FetchCatalogArch(context.Background(), "arm64")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Name != "tailscale" {
+			t.Fatalf("expected 1 tailscale entry, got %d: %v", len(entries), entryNames(entries))
+		}
+	})
+
+	t.Run("unsupported arch", func(t *testing.T) {
+		_, err := client.FetchCatalogArch(context.Background(), "mips")
+		if err == nil {
+			t.Fatal("expected error for unsupported arch")
+		}
+	})
+
+	t.Run("FetchCatalog defaults to amd64", func(t *testing.T) {
+		entries, err := client.FetchCatalog(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(entries))
+		}
+	})
+}
+
+func TestFCOSClient_DeduplicatesByName(t *testing.T) {
+	releases := `[
+		{
+			"tag_name": "tailscale-0-1.98.4-1-44-x86-64",
+			"body": "newer",
+			"assets": [{"name": "tailscale.raw", "browser_download_url": "https://example.com/new.raw"}]
+		},
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body": "older",
+			"assets": [{"name": "tailscale.raw", "browser_download_url": "https://example.com/old.raw"}]
+		}
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releases)
+	}))
+	defer srv.Close()
+
+	client := &bakery.FCOSClient{
+		CatalogURL:    srv.URL,
+		HTTP:          srv.Client(),
+		FedoraVersion: 44,
+	}
+
+	entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 deduplicated entry, got %d", len(entries))
+	}
+	if entries[0].Version != "0-1.98.4-1" {
+		t.Errorf("expected newest version 0-1.98.4-1, got %s", entries[0].Version)
+	}
+}
+
+func TestFCOSClient_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := &bakery.FCOSClient{
+		CatalogURL:    srv.URL,
+		HTTP:          srv.Client(),
+		FedoraVersion: 44,
+	}
+
+	_, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+}
+
+func TestFCOSClient_AppliesCuratedDescriptions(t *testing.T) {
+	releases := `[
+		{
+			"tag_name": "tailscale-0-1.98.4-1-44-x86-64",
+			"body": "raw body text",
+			"assets": [{"name": "tailscale.raw", "browser_download_url": "https://example.com/ts.raw"}]
+		}
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, releases)
+	}))
+	defer srv.Close()
+
+	client := &bakery.FCOSClient{
+		CatalogURL:    srv.URL,
+		HTTP:          srv.Client(),
+		FedoraVersion: 44,
+	}
+
+	entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Description == "raw body text" {
+		t.Error("expected curated description, got raw body")
+	}
+	if entries[0].Category != "Networking" {
+		t.Errorf("expected category Networking, got %q", entries[0].Category)
+	}
+}
+
+func entryNames(entries []model.SysextEntry) string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -1,0 +1,154 @@
+package bakery
+
+// FCOS support tier constants for fedora-sysexts/community extensions.
+const (
+	// FCOSTierCommunity marks extensions maintained by the fedora-sysexts community.
+	FCOSTierCommunity = "Community"
+)
+
+// fcosCatalog is the static curated catalog of common fedora-sysexts/community
+// extensions. When the catalog contains extensions not present here, FCOSLookup
+// returns ok=false and the TUI shows the raw GitHub release body as description.
+var fcosCatalog = map[string]ExtensionMeta{
+	"docker-ce": {
+		Category:    "Container Runtime",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Docker CE — full Docker engine for FCOS (daemon, CLI, containerd, runc)",
+		Long:        "Ships the complete Docker Community Edition engine from official upstream packages. Includes the daemon, CLI, containerd, and runc. Packaged as a Fedora sysext for FCOS nodes.",
+	},
+	"tailscale": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Tailscale — zero-config WireGuard mesh VPN for secure node-to-node networking",
+		Long:        "Tailscale creates an encrypted WireGuard mesh network with no manual key exchange or firewall rules. Ships tailscale and tailscaled binaries. Authenticate nodes with tailscale up after provisioning.",
+	},
+	"vscode": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Visual Studio Code — Microsoft's open-source code editor",
+		Long:        "Visual Studio Code packaged as a Fedora sysext for FCOS. Provides the full VS Code editor with extension marketplace support.",
+	},
+	"vscodium": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "VSCodium — VS Code without Microsoft telemetry and branding",
+		Long:        "VSCodium is a community-driven build of VS Code with Microsoft telemetry and branding removed. Uses the Open VSX registry instead of the Microsoft marketplace.",
+	},
+	"cilium-cli": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Cilium CLI — eBPF-based Kubernetes networking, security, and observability",
+		Long:        "The Cilium CLI for managing eBPF-powered Kubernetes networking, security policy enforcement, and observability. Use with a Kubernetes cluster running Cilium.",
+	},
+	"1password-cli": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "1Password CLI — access passwords, secrets, and credentials from the terminal",
+		Long:        "The 1Password command-line tool for accessing vault items, injecting secrets into scripts, and managing credentials without a GUI.",
+	},
+	"google-chrome": {
+		Category:    "Browser",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Google Chrome — Google's web browser with auto-update and sync",
+		Long:        "Google Chrome browser packaged as a Fedora sysext. Includes the full browser with sync, extensions, and DevTools.",
+	},
+	"microsoft-edge": {
+		Category:    "Browser",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Microsoft Edge — Chromium-based browser with Microsoft integration",
+		Long:        "Microsoft Edge browser packaged as a Fedora sysext. Chromium-based with Microsoft account sync and enterprise management features.",
+	},
+	"netbird": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NetBird — open-source WireGuard VPN with SSO and access control",
+		Long:        "NetBird creates a WireGuard-based overlay network with single sign-on, access control lists, and a management dashboard. No port forwarding required.",
+	},
+	"netbird-ui": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NetBird UI — system tray GUI for the NetBird VPN client",
+		Long:        "The graphical system tray application for managing NetBird VPN connections. Requires the netbird sysext for the underlying daemon.",
+		Caveats:     []string{"Requires the netbird sysext for the underlying VPN daemon."},
+	},
+	"glab": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "GLab — GitLab CLI for issues, merge requests, and CI/CD pipelines",
+		Long:        "The official GitLab CLI tool for managing repositories, issues, merge requests, and CI/CD pipelines from the terminal.",
+	},
+	"bitwarden": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Bitwarden — open-source password manager desktop application",
+		Long:        "The Bitwarden desktop application for managing passwords, secure notes, and identity information. Syncs with the Bitwarden cloud or a self-hosted server.",
+	},
+	"nordvpn": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NordVPN — commercial VPN client daemon",
+		Long:        "NordVPN client daemon for connecting to the NordVPN service. Provides the CLI tool for login, server selection, and connection management.",
+	},
+	"nordvpn-gui": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NordVPN GUI — graphical interface for the NordVPN client",
+		Long:        "The graphical desktop application for NordVPN. Requires the nordvpn sysext for the underlying daemon.",
+		Caveats:     []string{"Requires the nordvpn sysext for the underlying VPN daemon."},
+	},
+	"virtctl": {
+		Category:    "Virtualization",
+		SupportTier: FCOSTierCommunity,
+		Short:       "virtctl — KubeVirt CLI for managing virtual machines on Kubernetes",
+		Long:        "The KubeVirt command-line tool for creating, starting, stopping, and connecting to virtual machines running on Kubernetes clusters.",
+	},
+	"cloud-hypervisor": {
+		Category:    "Virtualization",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Cloud Hypervisor — lightweight, Rust-based VMM for modern cloud workloads",
+		Long:        "Cloud Hypervisor is a Virtual Machine Monitor built in Rust, focused on running modern cloud workloads with minimal overhead. Supports virtio devices, vhost-user, and live migration.",
+	},
+	"openconnect": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "OpenConnect — open-source VPN client for Cisco AnyConnect and compatible servers",
+		Long:        "OpenConnect is a VPN client supporting Cisco AnyConnect, Juniper/Pulse Secure, GlobalProtect, and other SSL VPN protocols.",
+	},
+	"1password-gui": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "1Password — desktop password manager with browser integration",
+		Long:        "The 1Password desktop application for accessing passwords, secure notes, and identity information. Integrates with browsers via the 1Password extension.",
+	},
+	"littlesnitch": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Little Snitch — network monitor and firewall with per-app rules",
+		Long:        "Little Snitch monitors outgoing network connections and lets you allow or deny them on a per-application basis. Useful for auditing which processes communicate over the network.",
+	},
+	"twingate": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Twingate — zero-trust network access replacing traditional VPNs",
+		Long:        "Twingate provides zero-trust network access, replacing traditional VPNs with per-resource access controls. Connects to the Twingate cloud management console.",
+	},
+	"nvidia-driver-cuda": {
+		Category:    "GPU / Accelerators",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NVIDIA CUDA driver — GPU compute driver for FCOS",
+		Long:        "NVIDIA CUDA driver packaged as a Fedora sysext. Provides GPU compute capabilities for workloads requiring CUDA acceleration.",
+	},
+	"openh264": {
+		Category:    "Multimedia",
+		SupportTier: FCOSTierCommunity,
+		Short:       "OpenH264 — Cisco's open-source H.264 codec library",
+		Long:        "OpenH264 provides H.264 video encoding and decoding. Used by Firefox and other applications for WebRTC video support.",
+	},
+}
+
+// FCOSLookup returns curated metadata for a fedora-sysexts/community extension.
+// Returns the metadata and true if found; zero ExtensionMeta and false if not in catalog.
+func FCOSLookup(name string) (ExtensionMeta, bool) {
+	meta, ok := fcosCatalog[name]
+	return meta, ok
+}

--- a/internal/bakery/fcos_descriptions_test.go
+++ b/internal/bakery/fcos_descriptions_test.go
@@ -1,0 +1,40 @@
+package bakery
+
+import "testing"
+
+func TestFCOSLookup_KnownExtensions(t *testing.T) {
+	known := []string{
+		"docker-ce", "tailscale", "vscode", "vscodium",
+		"cilium-cli", "1password-cli",
+	}
+	for _, name := range known {
+		t.Run(name, func(t *testing.T) {
+			meta, ok := FCOSLookup(name)
+			if !ok {
+				t.Fatalf("FCOSLookup(%q) returned ok=false", name)
+			}
+			if meta.Short == "" {
+				t.Error("Short description is empty")
+			}
+			if meta.Category == "" {
+				t.Error("Category is empty")
+			}
+			if meta.SupportTier == "" {
+				t.Error("SupportTier is empty")
+			}
+		})
+	}
+}
+
+func TestFCOSLookup_Unknown(t *testing.T) {
+	_, ok := FCOSLookup("nonexistent-extension")
+	if ok {
+		t.Fatal("expected ok=false for unknown extension")
+	}
+}
+
+func TestFCOSCatalog_MinimumSize(t *testing.T) {
+	if len(fcosCatalog) < 6 {
+		t.Errorf("fcosCatalog has %d entries, want at least 6", len(fcosCatalog))
+	}
+}

--- a/internal/bakery/fcos_tags.go
+++ b/internal/bakery/fcos_tags.go
@@ -1,0 +1,101 @@
+package bakery
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ParseFCOSTagName extracts the extension name, version, Fedora major version,
+// and architecture from a fedora-sysexts/community release tag.
+//
+// Tag format examples:
+//
+//	tailscale-0-1.98.4-1-44-x86-64
+//	vscode-1.122.1-1780040915.el8-44-arm64
+//	docker-ce-3-29.5.2-1.fc44-44-x86-64
+//	cilium-cli-0.19.4-44-x86-64
+//	virtctl-1.5.0-44-x86-64
+//
+// The last segments encode <fedora-version>-<arch>, where arch is "x86-64" or
+// "arm64". Everything between the extension name and the fedora-version is
+// treated as the version string.
+//
+// Index tags (bare names like "tailscale", "vscode", "latest") return empty
+// strings and ok=false.
+func ParseFCOSTagName(tag string) (name, version, fedoraVersion, arch string, ok bool) {
+	// Detect and strip arch suffix.
+	switch {
+	case strings.HasSuffix(tag, "-x86-64"):
+		arch = "x86-64"
+		tag = tag[:len(tag)-len("-x86-64")]
+	case strings.HasSuffix(tag, "-arm64"):
+		arch = "arm64"
+		tag = tag[:len(tag)-len("-arm64")]
+	default:
+		return "", "", "", "", false
+	}
+
+	// The last hyphen-separated segment is the Fedora major version.
+	lastDash := strings.LastIndex(tag, "-")
+	if lastDash < 0 {
+		return "", "", "", "", false
+	}
+	fedoraVersion = tag[lastDash+1:]
+	tag = tag[:lastDash]
+
+	if _, err := strconv.Atoi(fedoraVersion); err != nil || fedoraVersion == "" {
+		return "", "", "", "", false
+	}
+
+	// Now tag is "<name>-<version-parts>". The name is everything up to the
+	// first segment that is purely numeric or numeric-with-dots (no letters).
+	// This distinguishes version segments like "8.12.22" or "0" from name
+	// segments like "1password" which start with a digit but contain letters.
+	parts := strings.Split(tag, "-")
+	if len(parts) < 2 {
+		return "", "", "", "", false
+	}
+
+	versionStart := -1
+	for i := 1; i < len(parts); i++ {
+		if isVersionSegment(parts[i]) {
+			versionStart = i
+			break
+		}
+	}
+	if versionStart < 0 {
+		return "", "", "", "", false
+	}
+
+	name = strings.Join(parts[:versionStart], "-")
+	version = strings.Join(parts[versionStart:], "-")
+
+	if name == "" || version == "" {
+		return "", "", "", "", false
+	}
+
+	return name, version, fedoraVersion, arch, true
+}
+
+// isVersionSegment returns true if s looks like the start of a version string
+// rather than part of a package name. It must start with a digit and either:
+//   - contain a dot (e.g. "9.12.git.270", "1.122.1", "51.0.0")
+//   - be purely numeric (e.g. "0" for an RPM epoch, "3" for docker-ce epoch)
+//
+// This distinguishes version segments from name segments like "1password"
+// which start with a digit but are clearly words.
+func isVersionSegment(s string) bool {
+	if len(s) == 0 || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	if strings.ContainsRune(s, '.') {
+		return true
+	}
+	// Purely numeric (no letters, no dots) — RPM epoch or simple version.
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bakery/fcos_tags_test.go
+++ b/internal/bakery/fcos_tags_test.go
@@ -1,0 +1,110 @@
+package bakery
+
+import "testing"
+
+func TestParseFCOSTagName(t *testing.T) {
+	tests := []struct {
+		tag           string
+		wantName      string
+		wantVersion   string
+		wantFedora    string
+		wantArch      string
+		wantOK        bool
+	}{
+		{
+			tag: "tailscale-0-1.98.4-1-44-x86-64", wantName: "tailscale",
+			wantVersion: "0-1.98.4-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "tailscale-0-1.98.4-1-44-arm64", wantName: "tailscale",
+			wantVersion: "0-1.98.4-1", wantFedora: "44", wantArch: "arm64", wantOK: true,
+		},
+		{
+			tag: "vscode-1.122.1-1780040915.el8-44-arm64", wantName: "vscode",
+			wantVersion: "1.122.1-1780040915.el8", wantFedora: "44", wantArch: "arm64", wantOK: true,
+		},
+		{
+			tag: "vscodium-1.121.03429-el8-44-x86-64", wantName: "vscodium",
+			wantVersion: "1.121.03429-el8", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "docker-ce-3-29.5.2-1.fc44-44-x86-64", wantName: "docker-ce",
+			wantVersion: "3-29.5.2-1.fc44", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "cilium-cli-0.19.4-44-x86-64", wantName: "cilium-cli",
+			wantVersion: "0.19.4", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "virtctl-1.5.0-44-x86-64", wantName: "virtctl",
+			wantVersion: "1.5.0", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "openconnect-9.12.git.270.549fd2d-0.fc44-44-x86-64", wantName: "openconnect",
+			wantVersion: "9.12.git.270.549fd2d-0.fc44", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "nvidia-driver-cuda-580.95.05-3-580.95.05-1.fc42-42-x86-64", wantName: "nvidia-driver-cuda",
+			wantVersion: "580.95.05-3-580.95.05-1.fc42", wantFedora: "42", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "1password-gui-8.12.22-1-44-x86-64", wantName: "1password-gui",
+			wantVersion: "8.12.22-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "nordvpn-gui-5.0.0-1-44-x86-64", wantName: "nordvpn-gui",
+			wantVersion: "5.0.0-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "netbird-ui-0.71.4-1-44-x86-64", wantName: "netbird-ui",
+			wantVersion: "0.71.4-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "bitwarden-2026.5.0-1-44-x86-64", wantName: "bitwarden",
+			wantVersion: "2026.5.0-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "cloud-hypervisor-51.0.0-39.41-43-x86-64", wantName: "cloud-hypervisor",
+			wantVersion: "51.0.0-39.41", wantFedora: "43", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "glab-1.101.0-1-44-x86-64", wantName: "glab",
+			wantVersion: "1.101.0-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+		{
+			tag: "microsoft-edge-148.0.3967.96-1-44-x86-64", wantName: "microsoft-edge",
+			wantVersion: "148.0.3967.96-1", wantFedora: "44", wantArch: "x86-64", wantOK: true,
+		},
+
+		// Index/bare tags — should return ok=false.
+		{tag: "tailscale", wantOK: false},
+		{tag: "vscode", wantOK: false},
+		{tag: "latest", wantOK: false},
+		{tag: "", wantOK: false},
+		{tag: "only-name-no-version-x86-64", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			name, version, fedora, arch, ok := ParseFCOSTagName(tt.tag)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (name=%q ver=%q fedora=%q arch=%q)", ok, tt.wantOK, name, version, fedora, arch)
+			}
+			if !ok {
+				return
+			}
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if version != tt.wantVersion {
+				t.Errorf("version = %q, want %q", version, tt.wantVersion)
+			}
+			if fedora != tt.wantFedora {
+				t.Errorf("fedoraVersion = %q, want %q", fedora, tt.wantFedora)
+			}
+			if arch != tt.wantArch {
+				t.Errorf("arch = %q, want %q", arch, tt.wantArch)
+			}
+		})
+	}
+}

--- a/internal/fcos/streams.go
+++ b/internal/fcos/streams.go
@@ -1,0 +1,107 @@
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	streamBaseURL  = "https://builds.coreos.fedoraproject.org/streams/"
+	defaultTimeout = 30 * time.Second
+	// maxStreamResponseSize caps stream metadata reads at 2MB to prevent unbounded allocation.
+	maxStreamResponseSize = 2 << 20
+)
+
+// streamMetadata is the minimal shape of an FCOS stream JSON needed to extract
+// the Fedora major version. The full spec is at:
+// https://github.com/coreos/stream-metadata-go
+type streamMetadata struct {
+	Architectures map[string]struct {
+		Artifacts map[string]struct {
+			Release string `json:"release"`
+		} `json:"artifacts"`
+	} `json:"architectures"`
+}
+
+// FetchStreamFedoraVersion returns the Fedora major version number for a given
+// FCOS stream (e.g. "stable" → 44). Needed to filter fedora-sysexts/community
+// assets by the correct Fedora version.
+//
+// The version is parsed from the "metal" artifact release string (e.g.
+// "44.20260510.3.1" → 44). The first dot-separated component is always the
+// Fedora major version.
+func FetchStreamFedoraVersion(ctx context.Context, stream string) (int, error) {
+	return fetchStreamFedoraVersionWithClient(ctx, stream, &http.Client{Timeout: defaultTimeout})
+}
+
+func fetchStreamFedoraVersionWithClient(ctx context.Context, stream string, client *http.Client) (int, error) {
+	url := streamBaseURL + stream + ".json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating FCOS stream request: %w", err)
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetching FCOS stream %q: %w", stream, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("FCOS stream %q returned HTTP %d", stream, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxStreamResponseSize))
+	if err != nil {
+		return 0, fmt.Errorf("reading FCOS stream %q: %w", stream, err)
+	}
+
+	var meta streamMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return 0, fmt.Errorf("parsing FCOS stream %q JSON: %w", stream, err)
+	}
+
+	// Try x86_64 first, then aarch64 — we only need the Fedora major version
+	// which is the same across architectures.
+	for _, archKey := range []string{"x86_64", "aarch64"} {
+		arch, ok := meta.Architectures[archKey]
+		if !ok {
+			continue
+		}
+		metal, ok := arch.Artifacts["metal"]
+		if !ok {
+			continue
+		}
+		if metal.Release == "" {
+			continue
+		}
+		return parseFedoraVersion(metal.Release)
+	}
+
+	return 0, fmt.Errorf("FCOS stream %q: no architecture with metal artifact found", stream)
+}
+
+// parseFedoraVersion extracts the Fedora major version from an FCOS release
+// string like "44.20260510.3.1".
+func parseFedoraVersion(release string) (int, error) {
+	parts := strings.SplitN(release, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, fmt.Errorf("empty release string")
+	}
+	v, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("parsing Fedora version from %q: %w", release, err)
+	}
+	if v < 1 {
+		return 0, fmt.Errorf("invalid Fedora version %d from %q", v, release)
+	}
+	return v, nil
+}

--- a/internal/fcos/streams_test.go
+++ b/internal/fcos/streams_test.go
@@ -1,0 +1,161 @@
+package fcos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseFedoraVersion(t *testing.T) {
+	tests := []struct {
+		release string
+		want    int
+		wantErr bool
+	}{
+		{"44.20260510.3.1", 44, false},
+		{"41.20250223.3.0", 41, false},
+		{"43.20260101.1.0", 43, false},
+		{"", 0, true},
+		{"notanumber.123", 0, true},
+		{"0.123", 0, true},
+		{"-1.123", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.release, func(t *testing.T) {
+			got, err := parseFedoraVersion(tt.release)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %d", tt.release, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.release, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseFedoraVersion(%q) = %d, want %d", tt.release, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchStreamFedoraVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/streams/stable.json":
+			fmt.Fprint(w, `{
+				"architectures": {
+					"x86_64": {
+						"artifacts": {
+							"metal": {"release": "44.20260510.3.1"}
+						}
+					}
+				}
+			}`)
+		case "/streams/testing.json":
+			fmt.Fprint(w, `{
+				"architectures": {
+					"aarch64": {
+						"artifacts": {
+							"metal": {"release": "45.20260601.1.0"}
+						}
+					}
+				}
+			}`)
+		case "/streams/empty.json":
+			fmt.Fprint(w, `{"architectures": {}}`)
+		case "/streams/badjson.json":
+			fmt.Fprint(w, `not json`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Override the base URL for testing.
+	origBase := streamBaseURL
+	defer func() {
+		// streamBaseURL is a const, so we test via the internal helper.
+		_ = origBase
+	}()
+
+	client := srv.Client()
+
+	t.Run("stable stream x86_64", func(t *testing.T) {
+		got, err := fetchStreamFedoraVersionWithClient(
+			context.Background(), "stable",
+			&http.Client{Transport: rewriteTransport{base: srv.URL + "/streams/", rt: client.Transport}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 44 {
+			t.Errorf("got %d, want 44", got)
+		}
+	})
+
+	t.Run("testing stream aarch64 fallback", func(t *testing.T) {
+		got, err := fetchStreamFedoraVersionWithClient(
+			context.Background(), "testing",
+			&http.Client{Transport: rewriteTransport{base: srv.URL + "/streams/", rt: client.Transport}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 45 {
+			t.Errorf("got %d, want 45", got)
+		}
+	})
+
+	t.Run("empty architectures", func(t *testing.T) {
+		_, err := fetchStreamFedoraVersionWithClient(
+			context.Background(), "empty",
+			&http.Client{Transport: rewriteTransport{base: srv.URL + "/streams/", rt: client.Transport}},
+		)
+		if err == nil {
+			t.Fatal("expected error for empty architectures")
+		}
+	})
+
+	t.Run("bad JSON", func(t *testing.T) {
+		_, err := fetchStreamFedoraVersionWithClient(
+			context.Background(), "badjson",
+			&http.Client{Transport: rewriteTransport{base: srv.URL + "/streams/", rt: client.Transport}},
+		)
+		if err == nil {
+			t.Fatal("expected error for bad JSON")
+		}
+	})
+
+	t.Run("HTTP 404", func(t *testing.T) {
+		_, err := fetchStreamFedoraVersionWithClient(
+			context.Background(), "nonexistent",
+			&http.Client{Transport: rewriteTransport{base: srv.URL + "/streams/", rt: client.Transport}},
+		)
+		if err == nil {
+			t.Fatal("expected error for 404")
+		}
+	})
+}
+
+// rewriteTransport rewrites the request URL to point at the test server while
+// preserving the path suffix, so fetchStreamFedoraVersionWithClient hits the
+// test server instead of builds.coreos.fedoraproject.org.
+type rewriteTransport struct {
+	base string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the const base URL with the test server base.
+	orig := req.URL.String()
+	newURL := t.base + req.URL.Path[len("/streams/"):]
+	req2, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("rewriting %s → %s: %w", orig, newURL, err)
+	}
+	req2.Header = req.Header
+	return t.rt.RoundTrip(req2)
+}

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -13,10 +12,9 @@ import (
 
 // FCOSInstaller runs coreos-installer via the runner.
 type FCOSInstaller struct {
-	Runner       runner.Runner
-	Generator    *ignition.Generator
-	Logger       *slog.Logger
-	ignitionPath string
+	Runner    runner.Runner
+	Generator *ignition.Generator
+	Logger    *slog.Logger
 }
 
 // NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
@@ -41,6 +39,8 @@ func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, p
 		i.Logger.Warn("version pinning is not supported for FCOS; coreos-installer uses stream latest", "version", cfg.Version)
 	}
 
+	var ignitionPath string
+
 	if cfg.IgnitionURL != "" {
 		progress("Using external Ignition config...")
 	} else {
@@ -57,15 +57,15 @@ func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, p
 		}
 
 		progress("Writing Ignition config...")
-		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		ignPath, err := writeIgnitionFile(i.Logger, ignitionJSON)
 		if err != nil {
 			return fmt.Errorf("writing ignition file: %w", err)
 		}
-		i.ignitionPath = ignPath
-		defer i.cleanupIgnitionFile()
+		ignitionPath = ignPath
+		defer removeIgnitionTempFile(i.Logger, ignitionPath)
 	}
 
-	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+	args := buildFCOSInstallArgs(cfg, ignitionPath)
 
 	progress("Running coreos-installer...")
 	i.Logger.Info("executing coreos-installer", "args", args)
@@ -94,37 +94,4 @@ func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []strin
 	}
 
 	return args
-}
-
-// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
-func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
-	f, err := newIgnitionTempFile()
-	if err != nil {
-		return "", fmt.Errorf("creating temp ignition file: %w", err)
-	}
-	path := f.Name()
-
-	if _, err := f.WriteString(ignitionJSON); err != nil {
-		_ = f.Close()
-		_ = removeIgnitionFile(path)
-		return "", fmt.Errorf("writing ignition content: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		_ = removeIgnitionFile(path)
-		return "", fmt.Errorf("closing ignition file: %w", err)
-	}
-
-	i.Logger.Info("ignition file written", "path", path)
-	return path, nil
-}
-
-func (i *FCOSInstaller) cleanupIgnitionFile() {
-	if i.ignitionPath == "" {
-		return
-	}
-	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
-		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
-	}
-	i.ignitionPath = ""
 }

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -1,0 +1,130 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/projectbluefin/knuckle/internal/ignition"
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+// FCOSInstaller runs coreos-installer via the runner.
+type FCOSInstaller struct {
+	Runner       runner.Runner
+	Generator    *ignition.Generator
+	Logger       *slog.Logger
+	ignitionPath string
+}
+
+// NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
+func NewFCOSInstaller(r runner.Runner, logger *slog.Logger) *FCOSInstaller {
+	return &FCOSInstaller{
+		Runner:    r,
+		Generator: ignition.NewGenerator(),
+		Logger:    logger,
+	}
+}
+
+// Install performs the FCOS installation:
+// 1. Generate FCOS Butane → compile Ignition JSON
+// 2. Write ignition to secure temp file
+// 3. Run: coreos-installer install --stream <stream> [--ignition-file <path>] <disk>
+func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	if cfg.Version != "" {
+		i.Logger.Warn("version pinning is not supported for FCOS; coreos-installer uses stream latest", "version", cfg.Version)
+	}
+
+	if cfg.IgnitionURL != "" {
+		progress("Using external Ignition config...")
+	} else {
+		progress("Generating Butane config...")
+		butaneYAML, err := i.Generator.GenerateFCOSButane(cfg)
+		if err != nil {
+			return fmt.Errorf("generating butane config: %w", err)
+		}
+
+		progress("Compiling Ignition config...")
+		ignitionJSON, err := compileToIgnitionFunc(butaneYAML)
+		if err != nil {
+			return fmt.Errorf("compiling butane: %w", err)
+		}
+
+		progress("Writing Ignition config...")
+		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		if err != nil {
+			return fmt.Errorf("writing ignition file: %w", err)
+		}
+		i.ignitionPath = ignPath
+		defer i.cleanupIgnitionFile()
+	}
+
+	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+
+	progress("Running coreos-installer...")
+	i.Logger.Info("executing coreos-installer", "args", args)
+
+	result, err := i.Runner.Run(ctx, "coreos-installer", args...)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatCommandError("coreos-installer failed", result, err)
+	}
+
+	progress("Installation complete!")
+	return nil
+}
+
+func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
+	args := []string{
+		"install",
+		"--stream", cfg.Channel,
+		diskPath,
+	}
+
+	if cfg.IgnitionURL != "" {
+		args = append(args, "--ignition-url", cfg.IgnitionURL)
+	} else if ignitionPath != "" {
+		args = append(args, "--ignition-file", ignitionPath)
+	}
+
+	return args
+}
+
+// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
+func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	f, err := newIgnitionTempFile()
+	if err != nil {
+		return "", fmt.Errorf("creating temp ignition file: %w", err)
+	}
+	path := f.Name()
+
+	if _, err := f.WriteString(ignitionJSON); err != nil {
+		_ = f.Close()
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("writing ignition content: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("closing ignition file: %w", err)
+	}
+
+	i.Logger.Info("ignition file written", "path", path)
+	return path, nil
+}
+
+func (i *FCOSInstaller) cleanupIgnitionFile() {
+	if i.ignitionPath == "" {
+		return
+	}
+	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
+		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
+	}
+	i.ignitionPath = ""
+}

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -1,0 +1,339 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func TestFCOSInstallWithGeneratedConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	if installCall.Args[0] != "install" {
+		t.Errorf("first arg = %q, want \"install\"", installCall.Args[0])
+	}
+	if installCall.Args[1] != "--stream" || installCall.Args[2] != "stable" {
+		t.Errorf("expected --stream stable, got %v", installCall.Args[1:3])
+	}
+	if installCall.Args[3] != "/dev/sda" {
+		t.Errorf("disk arg = %q, want /dev/sda", installCall.Args[3])
+	}
+
+	hasIgnitionFile := false
+	for _, arg := range installCall.Args {
+		if arg == "--ignition-file" {
+			hasIgnitionFile = true
+			break
+		}
+	}
+	if !hasIgnitionFile {
+		t.Error("expected --ignition-file flag in coreos-installer args")
+	}
+}
+
+func TestFCOSInstallWithExternalURL(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:          model.OSFCOS,
+		Channel:     "testing",
+		Hostname:    "ext-fcos",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	wantArgs := []string{"install", "--stream", "testing", "/dev/vda", "--ignition-url", "https://example.com/fcos.ign"}
+	if len(installCall.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", installCall.Args, wantArgs)
+	}
+	for i, arg := range wantArgs {
+		if installCall.Args[i] != arg {
+			t.Errorf("arg[%d] = %q, want %q", i, installCall.Args[i], arg)
+		}
+	}
+}
+
+func TestFCOSInstallNoWipefs(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "no-wipe-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, call := range spy.Calls {
+		if call.Name == "wipefs" {
+			t.Error("wipefs must NOT be called by FCOSInstaller")
+		}
+		if call.Name == "sfdisk" {
+			t.Error("sfdisk must NOT be called by FCOSInstaller")
+		}
+		if call.Name == "flatcar-install" {
+			t.Error("flatcar-install must NOT be called by FCOSInstaller")
+		}
+	}
+}
+
+func TestFCOSInstallNilConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+
+	err := installer.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if got := err.Error(); got != "install config cannot be nil" {
+		t.Errorf("error = %q, want %q", got, "install config cannot be nil")
+	}
+}
+
+func TestFCOSInstallFailure(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.AllError = fmt.Errorf("command exited with code 1")
+
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fail-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when coreos-installer fails")
+	}
+	if !strings.Contains(err.Error(), "coreos-installer failed") {
+		t.Errorf("error = %q, want coreos-installer context", err.Error())
+	}
+}
+
+func TestFCOSInstallProgressSteps(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "progress-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+	}
+
+	var steps []string
+	err := installer.Install(context.Background(), cfg, func(step string) {
+		steps = append(steps, step)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSteps := []string{
+		"Generating Butane config...",
+		"Compiling Ignition config...",
+		"Writing Ignition config...",
+		"Running coreos-installer...",
+		"Installation complete!",
+	}
+
+	if len(steps) != len(expectedSteps) {
+		t.Fatalf("got %d progress steps, want %d\nsteps: %v", len(steps), len(expectedSteps), steps)
+	}
+	for i, want := range expectedSteps {
+		if steps[i] != want {
+			t.Errorf("step[%d] = %q, want %q", i, steps[i], want)
+		}
+	}
+}
+
+func TestFCOSInstallPrefersByIDPath(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "byid-fcos",
+		Disk: model.DiskInfo{
+			DevPath: "/dev/sda",
+			Path:    "/dev/disk/by-id/ata-test-disk",
+		},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+	if installCall.Args[3] != "/dev/disk/by-id/ata-test-disk" {
+		t.Errorf("disk path = %q, want by-id path", installCall.Args[3])
+	}
+}
+
+func TestBuildFCOSInstallArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *model.InstallConfig
+		ignitionPath string
+		want         []string
+	}{
+		{
+			name: "basic with ignition file",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/sda", "--ignition-file", "/tmp/test-ign.json"},
+		},
+		{
+			name: "external URL",
+			cfg: &model.InstallConfig{
+				Channel:     "next",
+				Disk:        model.DiskInfo{DevPath: "/dev/nvme0n1"},
+				IgnitionURL: "https://example.com/ign.json",
+			},
+			want: []string{"install", "--stream", "next", "/dev/nvme0n1", "--ignition-url", "https://example.com/ign.json"},
+		},
+		{
+			name: "no ignition",
+			cfg: &model.InstallConfig{
+				Channel: "testing",
+				Disk:    model.DiskInfo{DevPath: "/dev/vda"},
+			},
+			want: []string{"install", "--stream", "testing", "/dev/vda"},
+		},
+		{
+			name: "prefers by-id path",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk: model.DiskInfo{
+					DevPath: "/dev/sda",
+					Path:    "/dev/disk/by-id/ata-Samsung",
+				},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/disk/by-id/ata-Samsung", "--ignition-file", "/tmp/test-ign.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFCOSInstallArgs(tt.cfg, tt.ignitionPath)
+			if len(got) != len(tt.want) {
+				t.Fatalf("buildFCOSInstallArgs() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("arg[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFCOSInstallVersionWarning(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Version:  "38.20230514.3.0",
+		Hostname: "version-fcos",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	for _, arg := range installCall.Args {
+		if arg == "38.20230514.3.0" || arg == "-V" || arg == "--image-url" {
+			t.Errorf("version pinning args should not be passed to coreos-installer, found %q", arg)
+		}
+	}
+}
+
+// Compile-time check that FCOSInstaller implements Installer.
+var _ Installer = (*FCOSInstaller)(nil)

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -333,6 +334,114 @@ func TestFCOSInstallVersionWarning(t *testing.T) {
 			t.Errorf("version pinning args should not be passed to coreos-installer, found %q", arg)
 		}
 	}
+}
+
+func TestFCOSInstall_GenerateButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-err-test",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "bad", URL: "http://insecure.example.com/bad.raw", Selected: true},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from FCOS butane generation, got nil")
+	}
+	if !strings.Contains(err.Error(), "generating butane config") {
+		t.Errorf("error should mention generating butane config, got: %v", err)
+	}
+}
+
+func TestFCOSInstall_CompileError(t *testing.T) {
+	prev := compileToIgnitionFunc
+	t.Cleanup(func() { compileToIgnitionFunc = prev })
+	compileToIgnitionFunc = func(string) (string, error) {
+		return "", fmt.Errorf("injected compilation error")
+	}
+
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-compile-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from compileToIgnitionFunc, got nil")
+	}
+	if !strings.Contains(err.Error(), "compiling butane") {
+		t.Errorf("error = %q, want 'compiling butane' prefix", err.Error())
+	}
+}
+
+func TestFCOSInstall_WriteIgnitionError(t *testing.T) {
+	prev := newIgnitionTempFile
+	t.Cleanup(func() { newIgnitionTempFile = prev })
+	newIgnitionTempFile = func() (ignitionTempFile, error) {
+		return nil, fmt.Errorf("injected temp file error")
+	}
+
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-write-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from writeIgnitionFile, got nil")
+	}
+	if !strings.Contains(err.Error(), "writing ignition file") {
+		t.Errorf("error = %q, want 'writing ignition file' prefix", err.Error())
+	}
+}
+
+func TestRemoveIgnitionTempFile_EmptyPath(t *testing.T) {
+	removeIgnitionTempFile(testLogger(), "")
+}
+
+func TestRemoveIgnitionTempFile_NonExistentPath(t *testing.T) {
+	removeIgnitionTempFile(testLogger(), "/nonexistent-path-xyz")
+}
+
+func TestRemoveIgnitionTempFile_RemoveFailsNonNotExist(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission checks don't apply")
+	}
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "ignition-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	removeIgnitionTempFile(testLogger(), path)
 }
 
 // Compile-time check that FCOSInstaller implements Installer.

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -91,7 +91,7 @@ func (i *FlatcarInstaller) Install(ctx context.Context, cfg *model.InstallConfig
 
 		// Write ignition JSON to secure temp file for flatcar-install
 		progress("Writing Ignition config...")
-		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		ignPath, err := writeIgnitionFile(i.Logger, ignitionJSON)
 		if err != nil {
 			return fmt.Errorf("writing ignition file: %w", err)
 		}
@@ -193,6 +193,11 @@ func installDiskPath(cfg *model.InstallConfig) string {
 // the file is never readable by other users, even between creation and content write.
 // Returns the path to the created temp file.
 func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	return writeIgnitionFile(i.Logger, ignitionJSON)
+}
+
+// writeIgnitionFile is the shared implementation for writing ignition JSON to a secure temp file.
+func writeIgnitionFile(logger *slog.Logger, ignitionJSON string) (string, error) {
 	f, err := newIgnitionTempFile()
 	if err != nil {
 		return "", fmt.Errorf("creating temp ignition file: %w", err)
@@ -210,7 +215,7 @@ func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error
 		return "", fmt.Errorf("closing ignition file: %w", err)
 	}
 
-	i.Logger.Info("ignition file written", "path", path)
+	logger.Info("ignition file written", "path", path)
 	return path, nil
 }
 
@@ -219,8 +224,16 @@ func (i *FlatcarInstaller) cleanupIgnitionFile() {
 	if i.ignitionPath == "" {
 		return
 	}
-	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
-		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
-	}
+	removeIgnitionTempFile(i.Logger, i.ignitionPath)
 	i.ignitionPath = ""
+}
+
+// removeIgnitionTempFile removes a temp ignition file at the given path.
+func removeIgnitionTempFile(logger *slog.Logger, path string) {
+	if path == "" {
+		return
+	}
+	if err := removeIgnitionFile(path); err != nil && !os.IsNotExist(err) {
+		logger.Warn("failed to clean up ignition file", "path", path, "error", err)
+	}
 }

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/fcos"
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/install"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -17,6 +18,9 @@ import (
 
 // fetchAllChannelsFn is a package-level hook so tests can inject a mock.
 var fetchAllChannelsFn = bakery.FetchAllChannels
+
+// fetchFCOSStreamFn is a package-level hook so tests can inject a mock.
+var fetchFCOSStreamFn = fcos.FetchStreamFedoraVersion
 
 // State holds the complete wizard state
 type State struct {
@@ -33,6 +37,11 @@ type State struct {
 	// on the installed system too — used to auto-select the nvidia-runtime sysext.
 	NvidiaGPUDetected bool
 	NvidiaGPUs        []probe.NvidiaGPUInfo // detected GPU details for display in GPU Setup screen
+
+	// FedoraVersion is the Fedora major version for the selected FCOS stream
+	// (e.g. 44 for stable). Fetched at startup via fcos.FetchStreamFedoraVersion.
+	// Zero when OS is Flatcar or when the fetch has not yet run.
+	FedoraVersion int
 
 	// Channel version info (fetched at startup)
 	Channels []bakery.ChannelInfo
@@ -369,10 +378,19 @@ func (w *Wizard) runSystemChecks() {
 }
 
 // FetchSysexts loads the sysext catalog for the configured architecture.
+// For FCOS, it uses FetchCatalogForOS on the DispatchingClient to route to the
+// fedora-sysexts/community catalog filtered by the Fedora version from stream metadata.
 // If an NVIDIA GPU was detected during ProbeHardware, nvidia-runtime is
 // auto-selected and the default driver series is pre-configured.
 func (w *Wizard) FetchSysexts(ctx context.Context) error {
-	sysexts, err := w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	var sysexts []model.SysextEntry
+	var err error
+
+	if dc, ok := w.Bakery.(*bakery.DispatchingClient); ok {
+		sysexts, err = dc.FetchCatalogForOS(ctx, w.State.Config.Arch, w.State.Config.OS)
+	} else {
+		sysexts, err = w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	}
 	if err != nil {
 		return fmt.Errorf("fetching sysext catalog: %w", err)
 	}
@@ -390,6 +408,30 @@ func (w *Wizard) FetchSysexts(ctx context.Context) error {
 				break
 			}
 		}
+	}
+	return nil
+}
+
+// FetchFCOSStreamVersion fetches the Fedora major version for the configured
+// FCOS stream, stores it in State.FedoraVersion, and wires up the FCOS bakery
+// client on the DispatchingClient. No-op when OS is not FCOS.
+// Should be called when the user selects FCOS, before FetchSysexts.
+func (w *Wizard) FetchFCOSStreamVersion(ctx context.Context) error {
+	if w.State.Config.OS != model.OSFCOS {
+		return nil
+	}
+	stream := w.State.Config.Channel
+	if stream == "" {
+		stream = "stable"
+	}
+	v, err := fetchFCOSStreamFn(ctx, stream)
+	if err != nil {
+		return fmt.Errorf("fetching FCOS stream version: %w", err)
+	}
+	w.State.FedoraVersion = v
+
+	if dc, ok := w.Bakery.(*bakery.DispatchingClient); ok {
+		dc.FCOS = bakery.NewFCOSClient(v)
 	}
 	return nil
 }

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2270,3 +2270,122 @@ func TestPrevious_TailscaleBoundarySkipsOrVisitsNvidia(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchFCOSStreamVersion_FlatcarNoop(t *testing.T) {
+	w := New(&mockProber{}, &mockBakery{}, &mockInstaller{})
+	w.State.Config.OS = model.OSFlatcar
+	if err := w.FetchFCOSStreamVersion(context.Background()); err != nil {
+		t.Fatalf("unexpected error for Flatcar: %v", err)
+	}
+	if w.State.FedoraVersion != 0 {
+		t.Errorf("expected FedoraVersion=0 for Flatcar, got %d", w.State.FedoraVersion)
+	}
+}
+
+func TestFetchFCOSStreamVersion_FCOS(t *testing.T) {
+	orig := fetchFCOSStreamFn
+	defer func() { fetchFCOSStreamFn = orig }()
+	fetchFCOSStreamFn = func(_ context.Context, stream string) (int, error) {
+		if stream != "stable" {
+			return 0, fmt.Errorf("unexpected stream %q", stream)
+		}
+		return 44, nil
+	}
+
+	dc := &bakery.DispatchingClient{
+		Flatcar: &bakery.MockClient{},
+	}
+	w := New(&mockProber{}, dc, &mockInstaller{})
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "stable"
+
+	if err := w.FetchFCOSStreamVersion(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.State.FedoraVersion != 44 {
+		t.Errorf("expected FedoraVersion=44, got %d", w.State.FedoraVersion)
+	}
+	if dc.FCOS == nil {
+		t.Fatal("expected FCOS client to be set on DispatchingClient")
+	}
+}
+
+func TestFetchFCOSStreamVersion_Error(t *testing.T) {
+	orig := fetchFCOSStreamFn
+	defer func() { fetchFCOSStreamFn = orig }()
+	fetchFCOSStreamFn = func(_ context.Context, _ string) (int, error) {
+		return 0, fmt.Errorf("stream unavailable")
+	}
+
+	w := New(&mockProber{}, &mockBakery{}, &mockInstaller{})
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "testing"
+
+	err := w.FetchFCOSStreamVersion(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "stream unavailable") {
+		t.Errorf("expected 'stream unavailable' in error, got: %v", err)
+	}
+}
+
+func TestFetchFCOSStreamVersion_DefaultStream(t *testing.T) {
+	orig := fetchFCOSStreamFn
+	defer func() { fetchFCOSStreamFn = orig }()
+	var calledStream string
+	fetchFCOSStreamFn = func(_ context.Context, stream string) (int, error) {
+		calledStream = stream
+		return 44, nil
+	}
+
+	w := New(&mockProber{}, &bakery.DispatchingClient{Flatcar: &bakery.MockClient{}}, &mockInstaller{})
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "" // empty should default to "stable"
+
+	if err := w.FetchFCOSStreamVersion(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calledStream != "stable" {
+		t.Errorf("expected stream 'stable', got %q", calledStream)
+	}
+}
+
+func TestFetchSysexts_WithDispatchingClient_FCOS(t *testing.T) {
+	fcosSysexts := []model.SysextEntry{
+		{Name: "tailscale", Version: "0-1.98.4-1"},
+		{Name: "docker-ce", Version: "3-29.5.2-1.fc44"},
+	}
+	dc := &bakery.DispatchingClient{
+		Flatcar: &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}},
+		FCOS:    &bakery.MockClient{Entries: fcosSysexts},
+	}
+	w := New(&mockProber{}, dc, &mockInstaller{})
+	w.State.Config.OS = model.OSFCOS
+
+	if err := w.FetchSysexts(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(w.State.Sysexts) != 2 {
+		t.Fatalf("expected 2 FCOS sysexts, got %d", len(w.State.Sysexts))
+	}
+	if w.State.Sysexts[0].Name != "tailscale" {
+		t.Errorf("expected first sysext=tailscale, got %q", w.State.Sysexts[0].Name)
+	}
+}
+
+func TestFetchSysexts_WithDispatchingClient_Flatcar(t *testing.T) {
+	dc := &bakery.DispatchingClient{
+		Flatcar: &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}},
+		FCOS:    &bakery.MockClient{Entries: []model.SysextEntry{{Name: "tailscale"}}},
+	}
+	w := New(&mockProber{}, dc, &mockInstaller{})
+	w.State.Config.OS = model.OSFlatcar
+
+	if err := w.FetchSysexts(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(w.State.Sysexts) != 1 || w.State.Sysexts[0].Name != "docker" {
+		t.Fatalf("expected flatcar docker entry, got %v", w.State.Sysexts)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the full FCOS sysext catalog pipeline for `fedora-sysexts/community` (#641):

- **Sub-scope A** — `internal/fcos/streams.go`: `FetchStreamFedoraVersion()` queries FCOS stream metadata JSON to resolve the Fedora major version (e.g. `stable` → 44). Tested with httptest server.
- **Sub-scope B** — `internal/bakery/fcos_tags.go`: `ParseFCOSTagName()` parses the RPM-style tag format (`<name>-<version>-<fedora>-<arch>`). Table-driven tests cover 16 real tag examples from the live catalog, including edge cases like `1password-gui`, `nvidia-driver-cuda`, and `openconnect` (git hash in version).
- **Sub-scope C** — `FCOSCatalogURL` constant and `maxFCOSCatalogPages = 20` (covers the 1,500+ releases at 100/page = 15+ pages, with headroom).
- **Sub-scope D** — `internal/bakery/fcos_catalog.go`: `FCOSClient.FetchCatalogArch()` fetches and filters by architecture and Fedora version. Deduplicates by name (newest first). Implements `bakery.Client` interface.
- **Sub-scope E** — `internal/bakery/fcos_descriptions.go`: curated metadata for 22 common FCOS extensions (docker-ce, tailscale, vscode, vscodium, cilium-cli, 1password-cli, google-chrome, microsoft-edge, netbird, glab, bitwarden, nordvpn, virtctl, cloud-hypervisor, openconnect, and more).
- **Sub-scope F** — CDN vs GitHub: confirmed that `browser_download_url` fields point to `github.com` (not `extensions.fcos.fr`). Existing URL validation (`maxSysextURLLen=2048`, HTTPS enforcement) handles these URLs correctly.
- **Wizard wiring**: `FetchFCOSStreamVersion()` fetches the Fedora version and lazily constructs `FCOSClient` on the `DispatchingClient`. `FetchSysexts()` dispatches via `FetchCatalogForOS()` when a `DispatchingClient` is present. `main.go` creates a `DispatchingClient` wrapping the Flatcar `HTTPClient`.

## Test plan

- [x] `go test ./...` — all 18 packages pass
- [x] `go vet ./...` — clean
- [x] `ParseFCOSTagName` — 16 real tag examples + 5 edge cases (index tags, empty, no-version)
- [x] `FetchStreamFedoraVersion` — httptest server with multiple streams, error paths
- [x] `FetchCatalogArch` — filters by arch/fedora, deduplicates, applies descriptions, handles HTTP errors
- [x] `FCOSLookup` — known extensions, unknown fallback, minimum catalog size
- [x] Wizard `FetchFCOSStreamVersion` — Flatcar no-op, FCOS success/error, default stream
- [x] Wizard `FetchSysexts` with `DispatchingClient` — FCOS and Flatcar dispatch

Closes #641

## Dependencies

- #636 (model) — merged
- #638 (dispatcher wiring) — merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Fedora CoreOS (FCOS) as a supported operating system installation option.
  * Added FCOS system extension catalog with community-provided extensions.
  * Added automatic FCOS stream version detection during initialization.

* **Documentation**
  * Updated headless configuration guide to document FCOS-specific behavior for version pinning.

* **Tests**
  * Added comprehensive test coverage for new FCOS functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->