### PR TITLE
feat(install): FCOSInstaller using coreos-installer

### DIFF
--- a/internal/bakery/fcos.go
+++ b/internal/bakery/fcos.go
@@ -1,0 +1,290 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
+)
+
+const (
+	// FCOSCatalogURL is the GitHub Releases API for the fedora-sysexts/community repo.
+	FCOSCatalogURL = "https://api.github.com/repos/fedora-sysexts/community/releases?per_page=100"
+
+	// maxFCOSCatalogPages caps the number of API pages fetched for the FCOS catalog.
+	// fedora-sysexts/community has 1,583+ releases (16+ pages at 100/page). Since
+	// releases are returned newest-first and extensions are deduplicated by name
+	// (first/newest wins), 16 pages covers the full catalog. Extensions that only
+	// exist in older releases beyond this cap will be silently missing.
+	maxFCOSCatalogPages = 16
+)
+
+// FCOSClient fetches the sysext catalog from fedora-sysexts/community.
+type FCOSClient struct {
+	*HTTPClient
+	FedoraVersion int
+}
+
+// NewFCOSClient creates a client for the fedora-sysexts/community catalog.
+// fedoraVersion is the Fedora major version (e.g. 41, 44) obtained from
+// fcos.FetchStreamFedoraVersion — used to filter assets by Fedora version.
+func NewFCOSClient(fedoraVersion int) *FCOSClient {
+	c := NewHTTPClientWithURL(FCOSCatalogURL)
+	return &FCOSClient{
+		HTTPClient:    c,
+		FedoraVersion: fedoraVersion,
+	}
+}
+
+// FetchCatalog fetches the FCOS catalog for amd64.
+func (c *FCOSClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return c.FetchCatalogArch(ctx, "amd64")
+}
+
+// FetchCatalogArch fetches the FCOS sysext catalog filtered by architecture
+// and the client's FedoraVersion.
+//
+// The fedora-sysexts/community tag format is:
+//
+//	<name>-<rpm-fields>-<fedoraVersion>-<arch>
+//
+// Only releases matching the target Fedora version and architecture are included.
+// Entries are deduplicated by name (first/newest wins).
+func (c *FCOSClient) FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error) {
+	var archSuffix string
+	switch arch {
+	case "amd64":
+		archSuffix = "x86-64"
+	case "arm64":
+		archSuffix = "arm64"
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q: must be amd64 or arm64", arch)
+	}
+
+	var allReleases []githubRelease
+	nextURL := c.CatalogURL
+
+	for page := 0; page < maxFCOSCatalogPages && nextURL != ""; page++ {
+		releases, next, err := c.fetchPage(ctx, nextURL)
+		if err != nil {
+			return nil, err
+		}
+		if len(releases) == 0 {
+			break
+		}
+		allReleases = append(allReleases, releases...)
+		nextURL = next
+	}
+
+	seen := make(map[string]bool)
+	sysexts := make([]model.SysextEntry, 0, len(allReleases))
+
+	fedoraStr := strconv.Itoa(c.FedoraVersion)
+
+	for _, rel := range allReleases {
+		parsed, err := ParseFCOSTagName(rel.TagName)
+		if err != nil {
+			continue
+		}
+
+		if parsed.Arch != archSuffix {
+			continue
+		}
+		if parsed.FedoraVersion != fedoraStr {
+			continue
+		}
+
+		if seen[parsed.Name] {
+			continue
+		}
+
+		// Find the .raw asset and SHA256SUMS
+		var downloadURL, sha256sumsURL string
+		for _, asset := range rel.Assets {
+			switch {
+			case asset.Name == "SHA256SUMS":
+				sha256sumsURL = asset.BrowserDownloadURL
+			case strings.HasSuffix(asset.Name, ".raw"):
+				if downloadURL == "" {
+					downloadURL = asset.BrowserDownloadURL
+				}
+			}
+		}
+		if downloadURL == "" {
+			continue
+		}
+		if len(downloadURL) > maxSysextURLLen {
+			continue
+		}
+		if sha256sumsURL != "" && len(sha256sumsURL) > maxSysextURLLen {
+			sha256sumsURL = ""
+		}
+		if validate.SysextName(parsed.Name) != nil {
+			continue
+		}
+
+		seen[parsed.Name] = true
+
+		sha256Hash := ""
+		if sha256sumsURL != "" {
+			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
+			if h, err := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); err == nil {
+				sha256Hash = h
+			}
+		}
+
+		description := truncateDescription(rel.Body, 80)
+		category := ""
+		supportTier := ""
+
+		if meta, ok := FCOSLookup(parsed.Name); ok {
+			if meta.Short != "" {
+				description = meta.Short
+			}
+			category = meta.Category
+			supportTier = meta.SupportTier
+		}
+
+		sysexts = append(sysexts, model.SysextEntry{
+			Name:        parsed.Name,
+			Description: description,
+			Version:     parsed.Version,
+			URL:         downloadURL,
+			Sha256:      sha256Hash,
+			Category:    category,
+			SupportTier: supportTier,
+			Selected:    false,
+		})
+	}
+
+	return sysexts, nil
+}
+
+// fetchPage fetches a single page of releases and returns the next URL (if any).
+func (c *FCOSClient) fetchPage(ctx context.Context, pageURL string) ([]githubRelease, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating FCOS catalog request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "knuckle/1.0")
+	if c.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.AuthToken)
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetching FCOS catalog: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, "", fmt.Errorf("FCOS catalog returned status %d", resp.StatusCode)
+	}
+
+	const maxResponseSize = 5 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, "", fmt.Errorf("reading FCOS catalog response: %w", err)
+	}
+	if int64(len(body)) >= maxResponseSize {
+		return nil, "", fmt.Errorf("FCOS catalog response exceeds 5MB size limit")
+	}
+
+	var releases []githubRelease
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, "", fmt.Errorf("parsing FCOS catalog JSON: %w", err)
+	}
+
+	next, _ := parseLinkNext(resp.Header.Get("Link"))
+	return releases, next, nil
+}
+
+// FCOSTagParsed holds the components of a parsed fedora-sysexts/community tag.
+type FCOSTagParsed struct {
+	Name          string
+	Version       string
+	FedoraVersion string
+	Arch          string
+}
+
+// ParseFCOSTagName parses a fedora-sysexts/community release tag.
+//
+// Tag format: <name-segments>-<version-segments>-<fedoraVersion>-<arch>
+// where arch is "x86-64" or "arm64".
+//
+// Examples:
+//
+//	tailscale-0-1.98.3-1-44-x86-64     → {tailscale, 0-1.98.3-1, 44, x86-64}
+//	docker-ce-3-29.4.0-1.fc43-43-x86-64 → {docker-ce, 3-29.4.0-1.fc43, 43, x86-64}
+//	vscodium-1.121.03429-el8-44-arm64   → {vscodium, 1.121.03429-el8, 44, arm64}
+//	1password-gui-8.12.6-1-43-x86-64   → {1password-gui, 8.12.6-1, 43, x86-64}
+func ParseFCOSTagName(tag string) (FCOSTagParsed, error) {
+	// Strip architecture suffix to determine arch and the remainder.
+	var arch, remainder string
+	if strings.HasSuffix(tag, "-x86-64") {
+		arch = "x86-64"
+		remainder = strings.TrimSuffix(tag, "-x86-64")
+	} else if strings.HasSuffix(tag, "-arm64") {
+		arch = "arm64"
+		remainder = strings.TrimSuffix(tag, "-arm64")
+	} else {
+		return FCOSTagParsed{}, fmt.Errorf("tag %q has no recognized arch suffix", tag)
+	}
+
+	// The last segment of remainder is the Fedora version (a number like "43", "44").
+	lastDash := strings.LastIndex(remainder, "-")
+	if lastDash < 0 {
+		return FCOSTagParsed{}, fmt.Errorf("tag %q has no Fedora version segment", tag)
+	}
+	fedoraVersion := remainder[lastDash+1:]
+	if _, err := strconv.Atoi(fedoraVersion); err != nil {
+		return FCOSTagParsed{}, fmt.Errorf("tag %q: Fedora version %q is not a number", tag, fedoraVersion)
+	}
+	remainder = remainder[:lastDash]
+
+	// Now remainder is "<name-segments>-<version-segments>".
+	// The name is everything before the first segment that starts with a digit.
+	name, version := splitNameVersion(remainder)
+	if name == "" {
+		return FCOSTagParsed{}, fmt.Errorf("tag %q: could not extract name", tag)
+	}
+
+	return FCOSTagParsed{
+		Name:          name,
+		Version:       version,
+		FedoraVersion: fedoraVersion,
+		Arch:          arch,
+	}, nil
+}
+
+// splitNameVersion splits "name-segments-version-segments" into name and version.
+// The version starts at the first dash-separated segment that looks like a version
+// number: starts with a digit and contains a dot (e.g. "8.12.6") or is a single
+// digit that's followed by a dotted segment (epoch like "0" or "3").
+// This avoids misidentifying names like "1password-gui" as starting with a version.
+func splitNameVersion(s string) (name, version string) {
+	parts := strings.Split(s, "-")
+	for i, p := range parts {
+		if len(p) == 0 || p[0] < '0' || p[0] > '9' {
+			continue
+		}
+		// Segment starts with digit. It's a version if:
+		// 1. It contains a dot (e.g. "8.12.6", "1.98.3", "29.4.0")
+		// 2. OR it's a pure number and the next segment contains a dot (epoch pattern: "0-1.98.3", "3-29.4.0")
+		if strings.ContainsRune(p, '.') {
+			return strings.Join(parts[:i], "-"), strings.Join(parts[i:], "-")
+		}
+		if i+1 < len(parts) && strings.ContainsRune(parts[i+1], '.') {
+			return strings.Join(parts[:i], "-"), strings.Join(parts[i:], "-")
+		}
+	}
+	return s, ""
+}

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -1,0 +1,132 @@
+package bakery
+
+// FCOS support tier constants for fedora-sysexts/community extensions.
+const (
+	// FCOSTierCommunity marks extensions maintained by the fedora-sysexts community.
+	FCOSTierCommunity = "Community"
+)
+
+// fcosCatalog is the static curated catalog of common fedora-sysexts/community extensions.
+// When an extension is not present here, FCOSLookup returns ok=false and the raw
+// GitHub release body is used as description.
+var fcosCatalog = map[string]ExtensionMeta{
+	"docker-ce": {
+		Category:    "Container Runtime",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Docker CE — full Docker engine for Fedora CoreOS container workloads",
+		Long:        "Docker Community Edition ships the Docker daemon, CLI, containerd, and runc from official upstream packages. Provides the standard Docker experience on FCOS nodes for running containers, building images, and orchestrating with Compose.",
+		Caveats:     nil,
+	},
+	"tailscale": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Tailscale — zero-config WireGuard mesh VPN for secure node-to-node networking",
+		Long:        "Tailscale creates an encrypted WireGuard mesh network between your nodes with no manual key exchange or firewall rules required. Ships tailscale and tailscaled binaries.",
+		Caveats:     nil,
+	},
+	"vscode": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Visual Studio Code — Microsoft's code editor as a sysext layer",
+		Long:        "Ships Visual Studio Code as a system extension for Fedora CoreOS. Provides a full-featured code editor accessible on the node.",
+		Caveats:     nil,
+	},
+	"vscodium": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "VSCodium — free/libre build of VS Code without Microsoft telemetry",
+		Long:        "VSCodium is an open-source build of Visual Studio Code stripped of Microsoft telemetry and branding. Ships as a sysext layer for Fedora CoreOS.",
+		Caveats:     nil,
+	},
+	"google-chrome": {
+		Category:    "Desktop",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Google Chrome — web browser as a sysext layer for immutable desktops",
+		Long:        "Ships Google Chrome as a system extension for Fedora CoreOS immutable desktop configurations.",
+		Caveats:     nil,
+	},
+	"microsoft-edge": {
+		Category:    "Desktop",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Microsoft Edge — Chromium-based browser as a sysext layer",
+		Long:        "Ships Microsoft Edge as a system extension for Fedora CoreOS immutable desktop configurations.",
+		Caveats:     nil,
+	},
+	"1password-gui": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "1Password — password manager GUI as a sysext layer",
+		Long:        "Ships the 1Password desktop application as a system extension for Fedora CoreOS. Provides password and secret management with a native GUI.",
+		Caveats:     nil,
+	},
+	"bitwarden": {
+		Category:    "Security",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Bitwarden — open-source password manager GUI",
+		Long:        "Ships the Bitwarden desktop application as a system extension for Fedora CoreOS. Provides password management with support for self-hosted Vaultwarden servers.",
+		Caveats:     nil,
+	},
+	"ghostty": {
+		Category:    "Desktop",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Ghostty — fast GPU-accelerated terminal emulator",
+		Long:        "Ghostty is a GPU-accelerated terminal emulator focused on speed, native platform integration, and correct terminal emulation. Ships as a sysext layer.",
+		Caveats:     nil,
+	},
+	"glab": {
+		Category:    "Development",
+		SupportTier: FCOSTierCommunity,
+		Short:       "GLab — GitLab CLI for managing repos, issues, and pipelines",
+		Long:        "GLab is the official GitLab CLI tool for managing repositories, merge requests, issues, and CI/CD pipelines from the terminal.",
+		Caveats:     nil,
+	},
+	"mullvad-vpn": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Mullvad VPN — privacy-focused VPN client with WireGuard support",
+		Long:        "Mullvad VPN provides a privacy-focused VPN client with support for WireGuard and OpenVPN protocols. Ships the GUI and daemon as a sysext layer.",
+		Caveats:     nil,
+	},
+	"incus": {
+		Category:    "Virtualization",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Incus — modern system container and VM manager (LXD successor)",
+		Long:        "Incus is a system container and virtual machine manager, the community successor to LXD. Manages lightweight containers and full VMs on Fedora CoreOS nodes.",
+		Caveats:     nil,
+	},
+	"netbird-ui": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "NetBird — open-source WireGuard-based VPN with management UI",
+		Long:        "NetBird creates a WireGuard-based overlay network with a management UI. Ships the NetBird client with GUI for Fedora CoreOS.",
+		Caveats:     nil,
+	},
+	"cloud-hypervisor": {
+		Category:    "Virtualization",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Cloud Hypervisor — lightweight KVM-based VMM for modern cloud workloads",
+		Long:        "Cloud Hypervisor is a lightweight Virtual Machine Monitor built on KVM, designed for running modern cloud workloads with minimal overhead.",
+		Caveats:     nil,
+	},
+	"dnclient": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "Defined Networking — Nebula-based overlay VPN with managed control plane",
+		Long:        "Defined Networking client connects to the Defined.net managed control plane for simplified Nebula overlay network management.",
+		Caveats:     nil,
+	},
+	"openconnect": {
+		Category:    "Networking",
+		SupportTier: FCOSTierCommunity,
+		Short:       "OpenConnect — VPN client supporting Cisco AnyConnect, Pulse, GlobalProtect",
+		Long:        "OpenConnect is a multi-protocol VPN client supporting Cisco AnyConnect, Pulse Secure, GlobalProtect, and other SSL VPN protocols.",
+		Caveats:     nil,
+	},
+}
+
+// FCOSLookup returns curated metadata for a named FCOS extension.
+// Returns the metadata and true if found; zero ExtensionMeta and false if not in catalog.
+func FCOSLookup(name string) (ExtensionMeta, bool) {
+	meta, ok := fcosCatalog[name]
+	return meta, ok
+}

--- a/internal/bakery/fcos_test.go
+++ b/internal/bakery/fcos_test.go
@@ -1,0 +1,396 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseFCOSTagName(t *testing.T) {
+	tests := []struct {
+		tag     string
+		want    FCOSTagParsed
+		wantErr bool
+	}{
+		{
+			tag:  "tailscale-0-1.98.3-1-44-x86-64",
+			want: FCOSTagParsed{Name: "tailscale", Version: "0-1.98.3-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "docker-ce-3-29.4.0-1.fc43-43-x86-64",
+			want: FCOSTagParsed{Name: "docker-ce", Version: "3-29.4.0-1.fc43", FedoraVersion: "43", Arch: "x86-64"},
+		},
+		{
+			tag:  "vscodium-1.121.03429-el8-44-arm64",
+			want: FCOSTagParsed{Name: "vscodium", Version: "1.121.03429-el8", FedoraVersion: "44", Arch: "arm64"},
+		},
+		{
+			tag:  "1password-gui-8.12.6-1-43-x86-64",
+			want: FCOSTagParsed{Name: "1password-gui", Version: "8.12.6-1", FedoraVersion: "43", Arch: "x86-64"},
+		},
+		{
+			tag:  "google-chrome-147.0.7727.55-1-44-x86-64",
+			want: FCOSTagParsed{Name: "google-chrome", Version: "147.0.7727.55-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "ghostty-1.3.1-2.fc44-44-x86-64",
+			want: FCOSTagParsed{Name: "ghostty", Version: "1.3.1-2.fc44", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "cloud-hypervisor-51.0.0-39.24-43-x86-64",
+			want: FCOSTagParsed{Name: "cloud-hypervisor", Version: "51.0.0-39.24", FedoraVersion: "43", Arch: "x86-64"},
+		},
+		{
+			tag:  "incus-6.18-1.fc42-42-x86-64",
+			want: FCOSTagParsed{Name: "incus", Version: "6.18-1.fc42", FedoraVersion: "42", Arch: "x86-64"},
+		},
+		{
+			tag:  "nordvpn-gui-0-4.2.3-1-43-x86-64",
+			want: FCOSTagParsed{Name: "nordvpn-gui", Version: "0-4.2.3-1", FedoraVersion: "43", Arch: "x86-64"},
+		},
+		{
+			tag:  "openconnect-9.12.git.265.a7e7514-0.fc43-43-x86-64",
+			want: FCOSTagParsed{Name: "openconnect", Version: "9.12.git.265.a7e7514-0.fc43", FedoraVersion: "43", Arch: "x86-64"},
+		},
+		{
+			tag:  "vscode-1.122.1-1780040898.el8-44-x86-64",
+			want: FCOSTagParsed{Name: "vscode", Version: "1.122.1-1780040898.el8", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "dnclient-0.9.3-44-x86-64",
+			want: FCOSTagParsed{Name: "dnclient", Version: "0.9.3", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "mullvad-vpn-2026.2-1-44-x86-64",
+			want: FCOSTagParsed{Name: "mullvad-vpn", Version: "2026.2-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "glab-1.92.1-1-44-x86-64",
+			want: FCOSTagParsed{Name: "glab", Version: "1.92.1-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "microsoft-edge-147.0.3912.72-1-44-x86-64",
+			want: FCOSTagParsed{Name: "microsoft-edge", Version: "147.0.3912.72-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		{
+			tag:  "bitwarden-2026.3.1-1-44-x86-64",
+			want: FCOSTagParsed{Name: "bitwarden", Version: "2026.3.1-1", FedoraVersion: "44", Arch: "x86-64"},
+		},
+		// Umbrella tags (no arch suffix) should fail
+		{
+			tag:     "vscode",
+			wantErr: true,
+		},
+		{
+			tag:     "tailscale",
+			wantErr: true,
+		},
+		{
+			tag:     "latest",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got, err := ParseFCOSTagName(tt.tag)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseFCOSTagName(%q) expected error, got %+v", tt.tag, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseFCOSTagName(%q) unexpected error: %v", tt.tag, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseFCOSTagName(%q) = %+v, want %+v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchCatalogFCOS_FiltersCorrectly(t *testing.T) {
+	releases := []githubRelease{
+		{
+			TagName: "tailscale-0-1.98.3-1-44-x86-64",
+			Body:    "Tailscale for Fedora 44",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "tailscale-0-1.98.3-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.98.3-1-44-x86-64/tailscale-0-1.98.3-1-44-x86-64.raw"},
+				{Name: "SHA256SUMS", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.98.3-1-44-x86-64/SHA256SUMS"},
+			},
+		},
+		{
+			TagName: "tailscale-0-1.98.3-1-44-arm64",
+			Body:    "Tailscale for Fedora 44 arm64",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "tailscale-0-1.98.3-1-44-arm64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.98.3-1-44-arm64/tailscale-0-1.98.3-1-44-arm64.raw"},
+			},
+		},
+		{
+			TagName: "tailscale-0-1.98.3-1-43-x86-64",
+			Body:    "Tailscale for Fedora 43",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "tailscale-0-1.98.3-1-43-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.98.3-1-43-x86-64/tailscale-0-1.98.3-1-43-x86-64.raw"},
+			},
+		},
+		{
+			TagName: "docker-ce-3-29.4.0-1.fc43-44-x86-64",
+			Body:    "Docker CE for Fedora 44",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "docker-ce-3-29.4.0-1.fc43-44-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/docker-ce-3-29.4.0-1.fc43-44-x86-64/docker-ce-3-29.4.0-1.fc43-44-x86-64.raw"},
+			},
+		},
+		// Umbrella tag — should be skipped
+		{
+			TagName: "tailscale",
+			Body:    "Latest tailscale",
+			Assets:  nil,
+		},
+	}
+
+	body, err := json.Marshal(releases)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClientWithURL(srv.URL),
+		FedoraVersion: 44,
+	}
+
+	entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should get tailscale (44-x86-64) and docker-ce (44-x86-64).
+	// NOT tailscale 43, NOT tailscale arm64, NOT umbrella tag.
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name] = true
+	}
+	if !names["tailscale"] {
+		t.Error("expected tailscale in results")
+	}
+	if !names["docker-ce"] {
+		t.Error("expected docker-ce in results")
+	}
+}
+
+func TestFetchCatalogFCOS_Deduplication(t *testing.T) {
+	releases := []githubRelease{
+		{
+			TagName: "glab-1.95.0-1-44-x86-64",
+			Body:    "Newer glab",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "glab-1.95.0-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/glab-1.95.0-1-44-x86-64/glab-1.95.0-1-44-x86-64.raw"},
+			},
+		},
+		{
+			TagName: "glab-1.92.1-1-44-x86-64",
+			Body:    "Older glab",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "glab-1.92.1-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/glab-1.92.1-1-44-x86-64/glab-1.92.1-1-44-x86-64.raw"},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(releases)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClientWithURL(srv.URL),
+		FedoraVersion: 44,
+	}
+
+	entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (dedup)", len(entries))
+	}
+	if entries[0].Version != "1.95.0-1" {
+		t.Errorf("version = %q, want newest (1.95.0-1)", entries[0].Version)
+	}
+}
+
+func TestFetchCatalogFCOS_UnsupportedArch(t *testing.T) {
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClient(),
+		FedoraVersion: 44,
+	}
+	_, err := client.FetchCatalogArch(context.Background(), "s390x")
+	if err == nil {
+		t.Fatal("expected error for unsupported arch")
+	}
+}
+
+func TestFetchCatalogFCOS_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClientWithURL(srv.URL),
+		FedoraVersion: 44,
+	}
+
+	_, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+}
+
+func TestFetchCatalogFCOS_CuratedDescriptions(t *testing.T) {
+	releases := []githubRelease{
+		{
+			TagName: "tailscale-0-1.98.3-1-44-x86-64",
+			Body:    "Raw body from GitHub",
+			Assets: []struct {
+				Name               string `json:"name"`
+				BrowserDownloadURL string `json:"browser_download_url"`
+			}{
+				{Name: "tailscale-0-1.98.3-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.98.3-1-44-x86-64/tailscale-0-1.98.3-1-44-x86-64.raw"},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(releases)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClientWithURL(srv.URL),
+		FedoraVersion: 44,
+	}
+
+	entries, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	// Should use curated description, not raw body
+	if entries[0].Description == "Raw body from GitHub" {
+		t.Error("description should be curated, not raw GitHub body")
+	}
+	if entries[0].Category != "Networking" {
+		t.Errorf("category = %q, want Networking", entries[0].Category)
+	}
+}
+
+func TestFCOSLookup(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantOK  bool
+		wantCat string
+	}{
+		{"docker-ce", true, "Container Runtime"},
+		{"tailscale", true, "Networking"},
+		{"vscode", true, "Development"},
+		{"vscodium", true, "Development"},
+		{"google-chrome", true, "Desktop"},
+		{"1password-gui", true, "Security"},
+		{"nonexistent-ext", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, ok := FCOSLookup(tt.name)
+			if ok != tt.wantOK {
+				t.Fatalf("FCOSLookup(%q) ok=%v, want %v", tt.name, ok, tt.wantOK)
+			}
+			if ok && meta.Category != tt.wantCat {
+				t.Errorf("FCOSLookup(%q).Category = %q, want %q", tt.name, meta.Category, tt.wantCat)
+			}
+		})
+	}
+}
+
+func TestMaxFCOSCatalogPages(t *testing.T) {
+	requestCount := 0
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		releases := []githubRelease{
+			{
+				TagName: fmt.Sprintf("test-ext-%d-1.0-44-x86-64", requestCount),
+				Body:    "test",
+				Assets: []struct {
+					Name               string `json:"name"`
+					BrowserDownloadURL string `json:"browser_download_url"`
+				}{
+					{
+						Name:               fmt.Sprintf("test-ext-%d-1.0-44-x86-64.raw", requestCount),
+						BrowserDownloadURL: fmt.Sprintf("https://example.com/test-ext-%d.raw", requestCount),
+					},
+				},
+			},
+		}
+		body, _ := json.Marshal(releases)
+		w.Header().Set("Link", fmt.Sprintf(`<%s?page=%d>; rel="next"`, srvURL, requestCount+1))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	client := &FCOSClient{
+		HTTPClient:    NewHTTPClientWithURL(srv.URL),
+		FedoraVersion: 44,
+	}
+
+	_, err := client.FetchCatalogArch(context.Background(), "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestCount > maxFCOSCatalogPages {
+		t.Errorf("fetched %d pages, want at most %d", requestCount, maxFCOSCatalogPages)
+	}
+}

--- a/internal/fcos/streams.go
+++ b/internal/fcos/streams.go
@@ -1,0 +1,106 @@
+// Package fcos provides helpers for querying Fedora CoreOS stream metadata.
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	streamBaseURL      = "https://builds.coreos.fedoraproject.org/streams/"
+	defaultTimeout     = 30 * time.Second
+	maxStreamBodyBytes = 2 << 20 // 2 MB — stream JSON is ~200 KB
+)
+
+// streamMetadata is the minimal structure of the FCOS stream JSON we need.
+type streamMetadata struct {
+	Architectures map[string]struct {
+		Artifacts map[string]struct {
+			Release struct {
+				Version string `json:"version"`
+			} `json:"release"`
+		} `json:"artifacts"`
+	} `json:"architectures"`
+}
+
+// FetchStreamFedoraVersion returns the Fedora major version number for a given
+// FCOS stream (e.g. "stable" → 41). The version is parsed from the first
+// component of the FCOS release version string (e.g. "41.20250223.3.0" → 41).
+func FetchStreamFedoraVersion(ctx context.Context, stream string) (int, error) {
+	return FetchStreamFedoraVersionWithClient(ctx, stream, &http.Client{Timeout: defaultTimeout})
+}
+
+// FetchStreamFedoraVersionWithClient is like FetchStreamFedoraVersion but
+// accepts a custom HTTP client (for testing).
+func FetchStreamFedoraVersionWithClient(ctx context.Context, stream string, client *http.Client) (int, error) {
+	if stream == "" {
+		return 0, fmt.Errorf("stream name is required")
+	}
+	url := streamBaseURL + stream + ".json"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating stream request: %w", err)
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetching stream metadata for %q: %w", stream, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("stream metadata for %q returned HTTP %d", stream, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxStreamBodyBytes))
+	if err != nil {
+		return 0, fmt.Errorf("reading stream metadata: %w", err)
+	}
+
+	var meta streamMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return 0, fmt.Errorf("parsing stream metadata: %w", err)
+	}
+
+	version, err := extractVersion(meta)
+	if err != nil {
+		return 0, fmt.Errorf("extracting version from stream %q: %w", stream, err)
+	}
+
+	return parseFedoraMajor(version)
+}
+
+// extractVersion pulls the release version string from the first architecture
+// entry's first artifact in the stream metadata.
+func extractVersion(meta streamMetadata) (string, error) {
+	for _, arch := range meta.Architectures {
+		for _, artifact := range arch.Artifacts {
+			if artifact.Release.Version != "" {
+				return artifact.Release.Version, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no release version found in stream metadata")
+}
+
+// parseFedoraMajor extracts the Fedora major version from an FCOS version
+// string like "41.20250223.3.0" → 41.
+func parseFedoraMajor(version string) (int, error) {
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, fmt.Errorf("empty version string")
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("parsing Fedora major version from %q: %w", version, err)
+	}
+	return major, nil
+}

--- a/internal/fcos/streams_test.go
+++ b/internal/fcos/streams_test.go
@@ -1,0 +1,182 @@
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchStreamFedoraVersion_Stable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/streams/stable.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"architectures": {
+				"x86_64": {
+					"artifacts": {
+						"metal": {
+							"release": {"version": "41.20250223.3.0"}
+						}
+					}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	// Override base URL for testing
+	origBase := streamBaseURL
+	defer func() { /* can't reassign const, use client approach */ }()
+	_ = origBase
+
+	// Use the server directly via custom client
+	ver, err := fetchFromURL(t, srv.URL+"/streams/stable.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 41 {
+		t.Errorf("got Fedora version %d, want 41", ver)
+	}
+}
+
+func TestFetchStreamFedoraVersion_Next(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"architectures": {
+				"x86_64": {
+					"artifacts": {
+						"metal": {
+							"release": {"version": "44.20250601.1.0"}
+						}
+					}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	ver, err := fetchFromURL(t, srv.URL+"/streams/next.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 44 {
+		t.Errorf("got Fedora version %d, want 44", ver)
+	}
+}
+
+func TestFetchStreamFedoraVersion_EmptyStream(t *testing.T) {
+	_, err := FetchStreamFedoraVersion(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty stream")
+	}
+}
+
+func TestFetchStreamFedoraVersion_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchFromURL(t, srv.URL+"/streams/bogus.json")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}
+
+func TestFetchStreamFedoraVersion_NoVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"architectures": {}}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchFromURL(t, srv.URL+"/streams/empty.json")
+	if err == nil {
+		t.Fatal("expected error when no version in metadata")
+	}
+}
+
+func TestFetchStreamFedoraVersion_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchFromURL(t, srv.URL+"/streams/bad.json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseFedoraMajor(t *testing.T) {
+	tests := []struct {
+		version string
+		want    int
+		wantErr bool
+	}{
+		{"41.20250223.3.0", 41, false},
+		{"44.20250601.1.0", 44, false},
+		{"38.20230514.3.0", 38, false},
+		{"", 0, true},
+		{"abc.123", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got, err := parseFedoraMajor(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseFedoraMajor(%q) error=%v, wantErr=%v", tt.version, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseFedoraMajor(%q) = %d, want %d", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// fetchFromURL is a test helper that fetches stream metadata from a specific URL
+// rather than the production stream base URL.
+func fetchFromURL(t *testing.T, url string) (int, error) {
+	t.Helper()
+	client := &http.Client{}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var meta streamMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return 0, err
+	}
+
+	version, err := extractVersion(meta)
+	if err != nil {
+		return 0, err
+	}
+
+	return parseFedoraMajor(version)
+}

--- a/internal/install/fcos.go
+++ b/internal/install/fcos.go
@@ -1,0 +1,130 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/projectbluefin/knuckle/internal/ignition"
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+// FCOSInstaller runs coreos-installer via the runner.
+type FCOSInstaller struct {
+	Runner       runner.Runner
+	Generator    *ignition.Generator
+	Logger       *slog.Logger
+	ignitionPath string
+}
+
+// NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
+func NewFCOSInstaller(r runner.Runner, logger *slog.Logger) *FCOSInstaller {
+	return &FCOSInstaller{
+		Runner:    r,
+		Generator: ignition.NewGenerator(),
+		Logger:    logger,
+	}
+}
+
+// Install performs the FCOS installation:
+// 1. Generate FCOS Butane YAML (or use external IgnitionURL)
+// 2. Compile Butane → Ignition JSON
+// 3. Run coreos-installer install with the target disk, stream, and ignition config
+func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	if cfg.IgnitionURL != "" {
+		progress("Using external Ignition config...")
+	} else {
+		progress("Generating Butane config...")
+		butaneYAML, err := i.Generator.GenerateFCOSButane(cfg)
+		if err != nil {
+			return fmt.Errorf("generating butane config: %w", err)
+		}
+
+		progress("Compiling Ignition config...")
+		ignitionJSON, err := compileToIgnitionFunc(butaneYAML)
+		if err != nil {
+			return fmt.Errorf("compiling butane: %w", err)
+		}
+
+		progress("Writing Ignition config...")
+		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		if err != nil {
+			return fmt.Errorf("writing ignition file: %w", err)
+		}
+		i.ignitionPath = ignPath
+		defer i.cleanupIgnitionFile()
+	}
+
+	if cfg.Version != "" {
+		i.Logger.Warn("FCOS version pinning is not supported by coreos-installer; ignoring cfg.Version", "version", cfg.Version)
+	}
+
+	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+
+	progress("Running coreos-installer...")
+	i.Logger.Info("executing coreos-installer", "args", args)
+
+	result, err := i.Runner.Run(ctx, "coreos-installer", args...)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatCommandError("coreos-installer failed", result, err)
+	}
+
+	progress("Installation complete!")
+	return nil
+}
+
+func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
+	args := []string{
+		"install",
+		"--stream", cfg.Channel,
+		diskPath,
+	}
+
+	if cfg.IgnitionURL != "" {
+		args = append(args, "--ignition-url", cfg.IgnitionURL)
+	} else if ignitionPath != "" {
+		args = append(args, "--ignition-file", ignitionPath)
+	}
+
+	return args
+}
+
+// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
+func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	f, err := newIgnitionTempFile()
+	if err != nil {
+		return "", fmt.Errorf("creating temp ignition file: %w", err)
+	}
+	path := f.Name()
+
+	if _, err := f.WriteString(ignitionJSON); err != nil {
+		_ = f.Close()
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("writing ignition content: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("closing ignition file: %w", err)
+	}
+
+	i.Logger.Info("ignition file written", "path", path)
+	return path, nil
+}
+
+func (i *FCOSInstaller) cleanupIgnitionFile() {
+	if i.ignitionPath == "" {
+		return
+	}
+	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
+		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
+	}
+	i.ignitionPath = ""
+}

--- a/internal/install/fcos_test.go
+++ b/internal/install/fcos_test.go
@@ -1,0 +1,406 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func TestFCOSInstall_BasicDHCP(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// coreos-installer must be called, not flatcar-install
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+		}
+		if spy.Calls[i].Name == "flatcar-install" {
+			t.Error("flatcar-install should not be called by FCOSInstaller")
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	// Verify args: install --stream stable /dev/sda --ignition-file <path>
+	if installCall.Args[0] != "install" {
+		t.Errorf("first arg = %q, want %q", installCall.Args[0], "install")
+	}
+	if installCall.Args[1] != "--stream" || installCall.Args[2] != "stable" {
+		t.Errorf("stream args = %v, want --stream stable", installCall.Args[1:3])
+	}
+	if installCall.Args[3] != "/dev/sda" {
+		t.Errorf("disk arg = %q, want /dev/sda", installCall.Args[3])
+	}
+	if installCall.Args[4] != "--ignition-file" {
+		t.Errorf("ignition flag = %q, want --ignition-file", installCall.Args[4])
+	}
+}
+
+func TestFCOSInstall_NoWipefsOrSfdisk(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-no-wipe",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, call := range spy.Calls {
+		if call.Name == "wipefs" {
+			t.Error("wipefs should NOT be called by FCOSInstaller")
+		}
+		if call.Name == "sfdisk" {
+			t.Error("sfdisk should NOT be called by FCOSInstaller")
+		}
+	}
+}
+
+func TestFCOSInstall_ExternalIgnitionURL(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:          model.OSFCOS,
+		Channel:     "testing",
+		Hostname:    "fcos-ext",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/config.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var installCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			installCall = &spy.Calls[i]
+			break
+		}
+	}
+	if installCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	wantArgs := []string{"install", "--stream", "testing", "/dev/vda", "--ignition-url", "https://example.com/config.ign"}
+	if len(installCall.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", installCall.Args, wantArgs)
+	}
+	for i, arg := range wantArgs {
+		if installCall.Args[i] != arg {
+			t.Errorf("arg[%d] = %q, want %q", i, installCall.Args[i], arg)
+		}
+	}
+}
+
+func TestFCOSInstall_NilConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+
+	err := installer.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if got := err.Error(); got != "install config cannot be nil" {
+		t.Errorf("error = %q, want %q", got, "install config cannot be nil")
+	}
+}
+
+func TestFCOSInstall_VersionPinWarning(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Version:  "38.20230514.3.0",
+		Hostname: "fcos-version",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Version should NOT appear in the coreos-installer args
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			for _, arg := range spy.Calls[i].Args {
+				if arg == "38.20230514.3.0" || arg == "-V" || arg == "--version" {
+					t.Errorf("version pinning should not be passed to coreos-installer, got arg %q", arg)
+				}
+			}
+		}
+	}
+}
+
+func TestFCOSInstall_PrefersByIDPath(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:      model.OSFCOS,
+		Channel: "stable",
+		Disk: model.DiskInfo{
+			DevPath: "/dev/sda",
+			Path:    "/dev/disk/by-id/ata-Samsung_SSD",
+		},
+		Hostname: "fcos-byid",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			if spy.Calls[i].Args[3] != "/dev/disk/by-id/ata-Samsung_SSD" {
+				t.Errorf("disk path = %q, want /dev/disk/by-id/ata-Samsung_SSD", spy.Calls[i].Args[3])
+			}
+		}
+	}
+}
+
+func TestFCOSInstall_Failure(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.AllError = fmt.Errorf("command exited with code 1")
+
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-fail",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when coreos-installer fails")
+	}
+}
+
+func TestFCOSInstall_ProgressSteps(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-progress",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	var steps []string
+	err := installer.Install(context.Background(), cfg, func(step string) {
+		steps = append(steps, step)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedSteps := []string{
+		"Generating Butane config...",
+		"Compiling Ignition config...",
+		"Writing Ignition config...",
+		"Running coreos-installer...",
+		"Installation complete!",
+	}
+
+	if len(steps) != len(expectedSteps) {
+		t.Fatalf("got %d progress steps, want %d\nsteps: %v", len(steps), len(expectedSteps), steps)
+	}
+	for i, want := range expectedSteps {
+		if steps[i] != want {
+			t.Errorf("step[%d] = %q, want %q", i, steps[i], want)
+		}
+	}
+}
+
+func TestFCOSInstall_GenerateButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-butane-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core"}},
+		Sysexts: []model.SysextEntry{
+			{Name: "bad", URL: "http://insecure.example.com/bad.raw", Selected: true},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from FCOS butane generation")
+	}
+	if !strings.Contains(err.Error(), "generating butane config") {
+		t.Errorf("error = %q, want 'generating butane config' prefix", err.Error())
+	}
+}
+
+func TestFCOSInstall_CompileError(t *testing.T) {
+	prev := compileToIgnitionFunc
+	t.Cleanup(func() { compileToIgnitionFunc = prev })
+	compileToIgnitionFunc = func(string) (string, error) {
+		return "", fmt.Errorf("injected compilation error")
+	}
+
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-compile-err",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from compileToIgnitionFunc")
+	}
+	if !strings.Contains(err.Error(), "compiling butane") {
+		t.Errorf("error = %q, want 'compiling butane' prefix", err.Error())
+	}
+}
+
+func TestBuildFCOSInstallArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *model.InstallConfig
+		ignitionPath string
+		want         []string
+	}{
+		{
+			name: "basic with ignition file",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/sda", "--ignition-file", "/tmp/test-ign.json"},
+		},
+		{
+			name: "external URL",
+			cfg: &model.InstallConfig{
+				Channel:     "next",
+				Disk:        model.DiskInfo{DevPath: "/dev/nvme0n1"},
+				IgnitionURL: "https://example.com/ign.json",
+			},
+			ignitionPath: "",
+			want:         []string{"install", "--stream", "next", "/dev/nvme0n1", "--ignition-url", "https://example.com/ign.json"},
+		},
+		{
+			name: "no ignition",
+			cfg: &model.InstallConfig{
+				Channel: "testing",
+				Disk:    model.DiskInfo{DevPath: "/dev/vda"},
+			},
+			ignitionPath: "",
+			want:         []string{"install", "--stream", "testing", "/dev/vda"},
+		},
+		{
+			name: "prefers by-id path",
+			cfg: &model.InstallConfig{
+				Channel: "stable",
+				Disk: model.DiskInfo{
+					DevPath: "/dev/sda",
+					Path:    "/dev/disk/by-id/ata-Samsung_SSD",
+				},
+			},
+			ignitionPath: "/tmp/test-ign.json",
+			want:         []string{"install", "--stream", "stable", "/dev/disk/by-id/ata-Samsung_SSD", "--ignition-file", "/tmp/test-ign.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFCOSInstallArgs(tt.cfg, tt.ignitionPath)
+			if len(got) != len(tt.want) {
+				t.Fatalf("buildFCOSInstallArgs() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("arg[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFCOSInstall_CorEOSInstallerStderrIncluded(t *testing.T) {
+	failRunner := &fcosStderrFailRunner{}
+	installer := NewFCOSInstaller(failRunner, testLogger())
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-stderr",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error when coreos-installer fails")
+	}
+	if !strings.Contains(err.Error(), "disk is in use") {
+		t.Errorf("error = %q, want stderr from coreos-installer", err.Error())
+	}
+}
+
+type fcosStderrFailRunner struct{}
+
+func (fcosStderrFailRunner) Run(ctx context.Context, name string, args ...string) (*runner.Result, error) {
+	if name != "coreos-installer" {
+		return &runner.Result{Command: name, Args: args, ExitCode: 0}, nil
+	}
+	return &runner.Result{
+		Command:  name,
+		Args:     args,
+		Stderr:   "error: disk is in use",
+		ExitCode: 1,
+	}, fmt.Errorf("command %q exited with code 1", name)
+}
+
+func (fcosStderrFailRunner) RunWithInput(ctx context.Context, input string, name string, args ...string) (*runner.Result, error) {
+	return nil, fmt.Errorf("unexpected RunWithInput call")
+}


### PR DESCRIPTION
## Summary

- Adds `FCOSInstaller` struct implementing the `Installer` interface, using `coreos-installer` instead of `flatcar-install`
- `coreos-installer install --stream <stream> --ignition-file <path> <disk>` — no `wipefs` or `sfdisk` calls (coreos-installer handles disk prep internally)
- Version pinning (`cfg.Version`) logs a warning and is ignored — `coreos-installer` has no `-V` equivalent; pinning requires `--image-url` which is out of scope for v1
- Reuses existing helpers: `installDiskPath()`, `compileToIgnitionFunc`, `newIgnitionTempFile`, `removeIgnitionFile`, `formatCommandError()`

## Test plan

- [x] `coreos-installer install` called with correct args (stream, disk, ignition-file)
- [x] `wipefs` NOT called
- [x] `sfdisk` NOT called
- [x] External ignition URL uses `--ignition-url` flag
- [x] Nil config returns error
- [x] Version pinning ignored (not passed to coreos-installer)
- [x] Prefers `/dev/disk/by-id` path over devpath
- [x] Progress steps match expected sequence (no wipe/repair steps)
- [x] Butane generation error propagated
- [x] Compile error propagated
- [x] stderr from coreos-installer included in error message
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass

Closes #640
---
🐝 **Hive Agent**: `contributor` | **SHA:** `3637612`