### PR TITLE
feat(bakery): FCOS sysext catalog client for fedora-sysexts/community

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -113,7 +113,10 @@ func main() {
 	} else {
 		realRunner := runner.NewRealRunner(logger)
 		prober = probe.NewSystemProber(realRunner)
-		bakeryClient = bakery.NewHTTPClient()
+		bakeryClient = &bakery.DispatchingClient{
+			Flatcar: bakery.NewHTTPClient(),
+			FCOS:    bakery.NewFCOSHTTPClient(),
+		}
 		installer = &install.DispatchingInstaller{
 			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
 			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
@@ -146,6 +149,12 @@ func main() {
 		// Fetch sysext catalog (non-fatal if it fails)
 		if err := w.FetchSysexts(ctx); err != nil {
 			logger.Warn("sysext catalog fetch failed", "error", err)
+		}
+
+		// Fetch FCOS stream info when OS is FCOS (non-fatal if it fails).
+		// FetchSysexts also resolves this lazily, so this is a best-effort pre-fetch.
+		if err := w.FetchFCOSStream(ctx); err != nil {
+			logger.Warn("FCOS stream info fetch failed", "error", err)
 		}
 
 		// Fetch channel version info (non-fatal if it fails)

--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -146,15 +146,15 @@ func main() {
 			logger.Warn("hardware probe failed", "error", err)
 		}
 
+		// Fetch FCOS stream info when OS is FCOS (non-fatal if it fails).
+		// Must run before FetchSysexts so FCOSFedoraVersion is populated for catalog dispatch.
+		if err := w.FetchFCOSStream(ctx); err != nil {
+			logger.Warn("FCOS stream info fetch failed", "error", err)
+		}
+
 		// Fetch sysext catalog (non-fatal if it fails)
 		if err := w.FetchSysexts(ctx); err != nil {
 			logger.Warn("sysext catalog fetch failed", "error", err)
-		}
-
-		// Fetch FCOS stream info when OS is FCOS (non-fatal if it fails).
-		// FetchSysexts also resolves this lazily, so this is a best-effort pre-fetch.
-		if err := w.FetchFCOSStream(ctx); err != nil {
-			logger.Warn("FCOS stream info fetch failed", "error", err)
 		}
 
 		// Fetch channel version info (non-fatal if it fails)

--- a/internal/bakery/bakery.go
+++ b/internal/bakery/bakery.go
@@ -355,8 +355,9 @@ func truncateDescription(s string, maxLen int) string {
 
 // MockClient is a test double that returns preconfigured results
 type MockClient struct {
-	Entries []model.SysextEntry
-	Err     error
+	Entries           []model.SysextEntry
+	Err               error
+	LastFedoraVersion int // records the fedoraVersion arg passed to FetchCatalogFCOS
 }
 
 func (m *MockClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
@@ -389,5 +390,6 @@ func (m *MockClient) FetchCatalogArch(ctx context.Context, arch string) ([]model
 
 // FetchCatalogFCOS implements FCOSCatalogClient; delegates to FetchCatalogArch and ignores fedoraVersion.
 func (m *MockClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	m.LastFedoraVersion = fedoraVersion
 	return m.FetchCatalogArch(ctx, arch)
 }

--- a/internal/bakery/bakery.go
+++ b/internal/bakery/bakery.go
@@ -386,3 +386,8 @@ func (m *MockClient) FetchCatalogArch(ctx context.Context, arch string) ([]model
 	}
 	return filtered, nil
 }
+
+// FetchCatalogFCOS implements FCOSCatalogClient; delegates to FetchCatalogArch and ignores fedoraVersion.
+func (m *MockClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	return m.FetchCatalogArch(ctx, arch)
+}

--- a/internal/bakery/dispatch.go
+++ b/internal/bakery/dispatch.go
@@ -7,13 +7,21 @@ import (
 	"github.com/projectbluefin/knuckle/internal/model"
 )
 
+// FCOSCatalogClient extends Client with FCOS-specific Fedora-version filtering.
+// FetchCatalogFCOS filters assets by fedoraVersion, which is obtained from the
+// FCOS stream metadata (see fcos.FetchStreamFedoraVersion).
+type FCOSCatalogClient interface {
+	Client
+	FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error)
+}
+
 // DispatchingClient delegates to an OS-specific bakery Client based on
 // the os parameter passed to FetchCatalogForOS. The wizard calls this
 // method with the current cfg.OS at StepSysext time, when the user's
 // OS choice is known.
 type DispatchingClient struct {
 	Flatcar Client
-	FCOS    Client
+	FCOS    FCOSCatalogClient
 }
 
 func (d *DispatchingClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
@@ -25,14 +33,16 @@ func (d *DispatchingClient) FetchCatalogArch(ctx context.Context, arch string) (
 }
 
 // FetchCatalogForOS fetches the sysext catalog for the given OS and architecture.
-// FCOS may use a different catalog source or filtering in the future.
-func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os string) ([]model.SysextEntry, error) {
+// For FCOS, fedoraVersion is required to filter assets by Fedora major version;
+// obtain it via fcos.FetchStreamFedoraVersion before calling this method.
+// For Flatcar, fedoraVersion is unused.
+func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os string, fedoraVersion int) ([]model.SysextEntry, error) {
 	switch os {
 	case model.OSFCOS:
 		if d.FCOS == nil {
 			return nil, fmt.Errorf("fcos bakery client not configured")
 		}
-		return d.FCOS.FetchCatalogArch(ctx, arch)
+		return d.FCOS.FetchCatalogFCOS(ctx, arch, fedoraVersion)
 	case model.OSFlatcar, "":
 		return d.Flatcar.FetchCatalogArch(ctx, arch)
 	default:

--- a/internal/bakery/dispatch.go
+++ b/internal/bakery/dispatch.go
@@ -42,6 +42,9 @@ func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os stri
 		if d.FCOS == nil {
 			return nil, fmt.Errorf("fcos bakery client not configured")
 		}
+		if fedoraVersion <= 0 {
+			return nil, fmt.Errorf("invalid FCOS Fedora version %d: stream version must be resolved before fetching the FCOS catalog", fedoraVersion)
+		}
 		return d.FCOS.FetchCatalogFCOS(ctx, arch, fedoraVersion)
 	case model.OSFlatcar, "":
 		return d.Flatcar.FetchCatalogArch(ctx, arch)

--- a/internal/bakery/dispatch_test.go
+++ b/internal/bakery/dispatch_test.go
@@ -14,7 +14,7 @@ func TestDispatchingClient_FlatcarDefault(t *testing.T) {
 	fcos := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "podman"}}}
 	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: fcos}
 
-	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar)
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestDispatchingClient_EmptyOSDefaultsToFlatcar(t *testing.T) {
 	flatcar := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "docker"}}}
 	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: &bakery.MockClient{}}
 
-	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", "")
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", "", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestDispatchingClient_FCOS(t *testing.T) {
 	fcos := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "podman"}}}
 	d := &bakery.DispatchingClient{Flatcar: flatcar, FCOS: fcos}
 
-	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS)
+	entries, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS, 44)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestDispatchingClient_UnsupportedOS(t *testing.T) {
 		Flatcar: &bakery.MockClient{},
 		FCOS:    &bakery.MockClient{},
 	}
-	_, err := d.FetchCatalogForOS(context.Background(), "amd64", "nixos")
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", "nixos", 0)
 	if err == nil {
 		t.Fatal("expected error for unsupported OS")
 	}
@@ -63,7 +63,7 @@ func TestDispatchingClient_UnsupportedOS(t *testing.T) {
 
 func TestDispatchingClient_NilFCOS(t *testing.T) {
 	d := &bakery.DispatchingClient{Flatcar: &bakery.MockClient{}}
-	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS)
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS, 44)
 	if err == nil {
 		t.Fatal("expected error when FCOS client is nil")
 	}
@@ -73,7 +73,7 @@ func TestDispatchingClient_PropagatesError(t *testing.T) {
 	flatcar := &bakery.MockClient{Err: fmt.Errorf("network error")}
 	d := &bakery.DispatchingClient{Flatcar: flatcar}
 
-	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar)
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFlatcar, 0)
 	if err == nil || err.Error() != "network error" {
 		t.Fatalf("expected 'network error', got: %v", err)
 	}

--- a/internal/bakery/dispatch_test.go
+++ b/internal/bakery/dispatch_test.go
@@ -106,3 +106,13 @@ func TestDispatchingClient_FetchCatalogArchDelegatesToFlatcar(t *testing.T) {
 }
 
 var _ bakery.Client = (*bakery.DispatchingClient)(nil)
+
+func TestDispatchingClient_FCOS_ZeroFedoraVersion(t *testing.T) {
+	fcos := &bakery.MockClient{Entries: []model.SysextEntry{{Name: "podman"}}}
+	d := &bakery.DispatchingClient{FCOS: fcos}
+
+	_, err := d.FetchCatalogForOS(context.Background(), "amd64", model.OSFCOS, 0)
+	if err == nil {
+		t.Fatal("expected error when fedoraVersion is 0")
+	}
+}

--- a/internal/bakery/fcos.go
+++ b/internal/bakery/fcos.go
@@ -235,13 +235,17 @@ func (c *HTTPClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVe
 
 		seen[name] = true
 
-		// Fetch SHA256 hash (best-effort — soft fail on error).
+		// Fetch SHA256 hash — hard-fail if present but unresolvable (avoid catalog entry with empty hash).
 		sha256Hash := ""
 		if sha256sumsURL != "" {
 			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
-			if h, hashErr := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); hashErr == nil {
-				sha256Hash = h
+			h, hashErr := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename)
+			if hashErr != nil {
+				// SHA256SUMS asset is present but could not be fetched/parsed; skip this entry
+				// rather than producing one with an empty hash that would pass integrity checks.
+				continue
 			}
+			sha256Hash = h
 		}
 
 		description := truncateDescription(rel.Body, 80)

--- a/internal/bakery/fcos.go
+++ b/internal/bakery/fcos.go
@@ -1,0 +1,271 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
+)
+
+const (
+	// FCOSCatalogURL is the GitHub Releases API for the fedora-sysexts/community catalog.
+	FCOSCatalogURL = "https://api.github.com/repos/fedora-sysexts/community/releases?per_page=100"
+
+	// maxFCOSCatalogPages caps pagination for the FCOS sysext catalog.
+	// fedora-sysexts/community has 1,583+ releases (as of 2026); at 100 per page that is
+	// ~16 pages. A cap of 20 provides headroom for future growth.
+	// If the cap is reached while a next page still exists, partial results are returned
+	// and a slog warning is emitted (soft failure — partial catalog > no catalog).
+	maxFCOSCatalogPages = 20
+)
+
+// NewFCOSHTTPClient creates a bakery client targeting the fedora-sysexts/community catalog.
+func NewFCOSHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		CatalogURL: FCOSCatalogURL,
+		HTTP: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		AuthToken: githubTokenFromEnv(),
+	}
+}
+
+// ParseFCOSTagName parses a fedora-sysexts/community release tag into its components.
+//
+// Tag format: <name>-<version>-<fedoraVersion>-<arch>
+//   - arch:          "x86-64" or "arm64"
+//   - fedoraVersion: a pure integer (e.g. 43, 44)
+//   - version:       may contain hyphens, digits, letters, and dots (RPM version/release)
+//   - name:          alphanumeric with hyphens (e.g. "docker-ce", "1password-gui")
+//
+// The name/version split uses a left-to-right scan for the first "-<digit>" boundary
+// after at least one character. This correctly handles names beginning with digits
+// ("1password-gui") and names containing hyphens ("docker-ce", "cloud-hypervisor").
+//
+// Floating tags (e.g. "tailscale", "vscode", "latest") that carry no arch suffix are
+// rejected — callers should skip those via the non-nil error return.
+func ParseFCOSTagName(tag string) (name, version, fedoraVersion, arch string, err error) {
+	// Step 1: identify and strip the arch suffix.
+	// Note: "x86-64" contains a hyphen, so we must match it as a whole suffix string
+	// rather than splitting on the last hyphen.
+	var archSuffix string
+	switch {
+	case strings.HasSuffix(tag, "-arm64"):
+		arch = "arm64"
+		archSuffix = "-arm64"
+	case strings.HasSuffix(tag, "-x86-64"):
+		arch = "x86-64"
+		archSuffix = "-x86-64"
+	default:
+		return "", "", "", "", fmt.Errorf("no recognized arch suffix in tag %q", tag)
+	}
+	remaining := tag[:len(tag)-len(archSuffix)]
+
+	// Step 2: strip fedoraVersion — the last hyphen-delimited segment (pure integer).
+	lastDash := strings.LastIndex(remaining, "-")
+	if lastDash < 0 {
+		return "", "", "", "", fmt.Errorf("no fedora version segment in tag %q", tag)
+	}
+	fedoraVersionStr := remaining[lastDash+1:]
+	fver, parseErr := strconv.Atoi(fedoraVersionStr)
+	if parseErr != nil || fver <= 0 {
+		return "", "", "", "", fmt.Errorf("invalid fedora version %q in tag %q", fedoraVersionStr, tag)
+	}
+	fedoraVersion = fedoraVersionStr
+	remaining = remaining[:lastDash]
+
+	// Step 3: split name from version at the first "-<digit>" boundary (left-to-right).
+	// Names must have at least one character before the split point.
+	splitIdx := -1
+	for i := 1; i < len(remaining); i++ {
+		if remaining[i-1] == '-' && unicode.IsDigit(rune(remaining[i])) {
+			splitIdx = i - 1
+			break
+		}
+	}
+	if splitIdx < 0 {
+		return "", "", "", "", fmt.Errorf("cannot split name/version in tag %q", tag)
+	}
+
+	name = remaining[:splitIdx]
+	version = remaining[splitIdx+1:]
+	if name == "" || version == "" {
+		return "", "", "", "", fmt.Errorf("empty name or version in tag %q", tag)
+	}
+	return name, version, fedoraVersion, arch, nil
+}
+
+// FetchCatalogFCOS fetches sysexts from fedora-sysexts/community for the given architecture
+// and Fedora major version. fedoraVersion is an integer (e.g. 44) obtained from
+// fcos.FetchStreamFedoraVersion. Only assets that match both arch and fedoraVersion are included.
+//
+// The catalog is paginated; up to maxFCOSCatalogPages pages are fetched. If the cap is reached
+// while more pages exist, partial results are returned alongside a slog warning.
+//
+// Asset URLs are served from github.com/fedora-sysexts/community/releases/download/…
+// (not from the extensions.fcos.fr CDN). This was confirmed against the live API on 2026-05.
+func (c *HTTPClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	// Map Go arch identifier to the suffix used in fedora-sysexts/community asset names.
+	var archSuffix string
+	switch arch {
+	case "amd64":
+		archSuffix = "x86-64"
+	case "arm64":
+		archSuffix = "arm64"
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q: must be amd64 or arm64", arch)
+	}
+
+	// Asset filename ends with "-<fedoraVersion>-<archSuffix>.raw".
+	rawSuffix := fmt.Sprintf("-%d-%s.raw", fedoraVersion, archSuffix)
+
+	const maxResponseSize = 5 << 20
+	var allReleases []githubRelease
+	nextURL := c.CatalogURL
+	truncated := false
+
+	for page := 0; page < maxFCOSCatalogPages && nextURL != ""; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating FCOS catalog request (page %d): %w", page+1, err)
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "knuckle/1.0")
+		if c.AuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+c.AuthToken)
+		}
+
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching FCOS catalog (page %d): %w", page+1, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("FCOS catalog returned HTTP %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading FCOS catalog response (page %d): %w", page+1, err)
+		}
+		if int64(len(body)) >= maxResponseSize {
+			return nil, fmt.Errorf("FCOS catalog response page %d exceeds 5MiB size limit", page+1)
+		}
+
+		var releases []githubRelease
+		if err := json.Unmarshal(body, &releases); err != nil {
+			return nil, fmt.Errorf("parsing FCOS catalog JSON (page %d): %w", page+1, err)
+		}
+		if len(releases) == 0 {
+			break
+		}
+		allReleases = append(allReleases, releases...)
+
+		nextURL, _ = parseLinkNext(resp.Header.Get("Link"))
+		if page+1 == maxFCOSCatalogPages && nextURL != "" {
+			truncated = true
+		}
+	}
+
+	if truncated {
+		slog.Warn("FCOS catalog pagination cap reached; sysext list may be incomplete",
+			"max_pages", maxFCOSCatalogPages)
+	}
+
+	// Filter by arch and fedoraVersion, then deduplicate by name (API returns newest first).
+	seen := make(map[string]bool)
+	sysexts := make([]model.SysextEntry, 0)
+
+	for _, rel := range allReleases {
+		name, version, relFedVStr, relArch, parseErr := ParseFCOSTagName(rel.TagName)
+		if parseErr != nil {
+			continue // floating tag or unparseable — skip
+		}
+
+		// Filter by arch.
+		if relArch != archSuffix {
+			continue
+		}
+
+		// Filter by Fedora version.
+		relFedV, _ := strconv.Atoi(relFedVStr)
+		if relFedV != fedoraVersion {
+			continue
+		}
+
+		// Deduplicate by name — keep first (newest) since API returns newest-first.
+		if seen[name] {
+			continue
+		}
+
+		// Find the .raw asset and SHA256SUMS for this release.
+		var downloadURL, sha256sumsURL string
+		for _, asset := range rel.Assets {
+			switch {
+			case asset.Name == "SHA256SUMS":
+				sha256sumsURL = asset.BrowserDownloadURL
+			case strings.HasSuffix(asset.Name, rawSuffix):
+				if downloadURL == "" {
+					downloadURL = asset.BrowserDownloadURL
+				}
+			}
+		}
+		if downloadURL == "" {
+			continue
+		}
+		if len(downloadURL) > maxSysextURLLen {
+			continue
+		}
+		if sha256sumsURL != "" && len(sha256sumsURL) > maxSysextURLLen {
+			sha256sumsURL = ""
+		}
+		if validate.SysextName(name) != nil {
+			continue
+		}
+
+		seen[name] = true
+
+		// Fetch SHA256 hash (best-effort — soft fail on error).
+		sha256Hash := ""
+		if sha256sumsURL != "" {
+			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
+			if h, hashErr := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); hashErr == nil {
+				sha256Hash = h
+			}
+		}
+
+		description := truncateDescription(rel.Body, 80)
+		category := ""
+		supportTier := ""
+
+		if meta, ok := FCOSLookup(name); ok {
+			if meta.Short != "" {
+				description = meta.Short
+			}
+			category = meta.Category
+			supportTier = meta.SupportTier
+		}
+
+		sysexts = append(sysexts, model.SysextEntry{
+			Name:        name,
+			Description: description,
+			Version:     version,
+			URL:         downloadURL,
+			Sha256:      sha256Hash,
+			Category:    category,
+			SupportTier: supportTier,
+		})
+	}
+
+	return sysexts, nil
+}

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -59,6 +59,20 @@ var fcosCatalog = map[string]ExtensionMeta{
 		Long:        "1Password is a password manager and secure credential vault. Ships the 1password GUI application for FCOS desktop or graphical deployments.",
 		Caveats:     nil,
 	},
+	"1password-cli": {
+		Category:    "Security",
+		SupportTier: TierFCOSCommunity,
+		Short:       "1Password CLI — terminal-based 1Password credential access",
+		Long:        "The 1Password CLI (op) provides terminal access to your 1Password vaults and supports secret injection into shell environments. Useful for scripted FCOS workflows that need credential retrieval.",
+		Caveats:     nil,
+	},
+	"kubernetes": {
+		Category:    "Container Runtime",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Kubernetes — container orchestration tools (kubectl, kubeadm, kubelet)",
+		Long:        "Ships the core Kubernetes binaries — kubectl, kubeadm, and kubelet — for FCOS nodes. Enables FCOS hosts to join or bootstrap Kubernetes clusters. Pair with Ignition provisioning for unattended node setup.",
+		Caveats:     []string{"Requires additional CNI configuration before cluster bring-up. Pin the version to match your cluster control-plane."},
+	},
 	"bitwarden": {
 		Category:    "Security",
 		SupportTier: TierFCOSCommunity,

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -1,0 +1,76 @@
+package bakery
+
+// FCOS community sysext support tier constants.
+const (
+	// TierFCOSCommunity marks extensions from the fedora-sysexts/community catalog.
+	TierFCOSCommunity = "FCOS Community"
+)
+
+// fcosCatalog is the curated metadata catalog for fedora-sysexts/community extensions.
+// When the community catalog contains an extension not listed here, FCOSLookup returns
+// ok=false and the caller falls back to the raw GitHub release body as description.
+var fcosCatalog = map[string]ExtensionMeta{
+	"tailscale": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Tailscale — zero-config WireGuard mesh VPN for FCOS nodes",
+		Long:        "Tailscale creates an encrypted WireGuard mesh network between your nodes with no manual key exchange or firewall rules. Ships tailscale and tailscaled binaries with a systemd service unit. Authenticate with tailscale up after provisioning.",
+		Caveats:     nil,
+	},
+	"docker-ce": {
+		Category:    "Container Runtime",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Docker CE — container runtime and CLI for FCOS",
+		Long:        "Docker CE ships the Docker daemon, CLI, and containerd for Fedora CoreOS. Provides the familiar docker build/run/compose workflow. Compatible with Podman-based FCOS deployments as an alternative container runtime.",
+		Caveats:     []string{"Conflicts with the Podman socket if both are running; disable one before starting the other."},
+	},
+	"vscode": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Visual Studio Code — Microsoft's editor with extensions support",
+		Long:        "Visual Studio Code is a lightweight but powerful source code editor from Microsoft. Ships the code binary and supporting files for FCOS. Useful for development workflows directly on CoreOS nodes.",
+		Caveats:     nil,
+	},
+	"vscodium": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "VSCodium — community-built VS Code without Microsoft telemetry",
+		Long:        "VSCodium is a community-maintained binary distribution of VS Code compiled without Microsoft branding or telemetry. Ships the codium binary and supporting files for FCOS.",
+		Caveats:     nil,
+	},
+	"glab": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "glab — GitLab CLI for managing MRs, issues, and pipelines",
+		Long:        "glab is the official GitLab CLI tool. Manage merge requests, issues, CI/CD pipelines, and repositories directly from the terminal on FCOS.",
+		Caveats:     nil,
+	},
+	"cilium-cli": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Cilium CLI — install and manage Cilium CNI in Kubernetes clusters",
+		Long:        "The Cilium CLI is used to install, configure, and troubleshoot Cilium, a powerful eBPF-based networking and security plugin for Kubernetes. Useful for bootstrapping Cilium on FCOS-based Kubernetes nodes.",
+		Caveats:     nil,
+	},
+	"1password-gui": {
+		Category:    "Security",
+		SupportTier: TierFCOSCommunity,
+		Short:       "1Password GUI — desktop 1Password client for credential management",
+		Long:        "1Password is a password manager and secure credential vault. Ships the 1password GUI application for FCOS desktop or graphical deployments.",
+		Caveats:     nil,
+	},
+	"bitwarden": {
+		Category:    "Security",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Bitwarden — open-source password manager desktop client",
+		Long:        "Bitwarden is a free and open-source password manager. Ships the Bitwarden desktop application for FCOS graphical deployments. Stores credentials in your self-hosted or cloud Bitwarden vault.",
+		Caveats:     nil,
+	},
+}
+
+// FCOSLookup returns the curated ExtensionMeta for an FCOS community sysext by name.
+// Returns (ExtensionMeta{}, false) when the extension is not in the curated catalog.
+func FCOSLookup(name string) (ExtensionMeta, bool) {
+	meta, ok := fcosCatalog[name]
+	return meta, ok
+}

--- a/internal/bakery/fcos_test.go
+++ b/internal/bakery/fcos_test.go
@@ -1,0 +1,323 @@
+package bakery_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+)
+
+// --- ParseFCOSTagName tests ---
+
+func TestParseFCOSTagName(t *testing.T) {
+	tests := []struct {
+		tag             string
+		wantName        string
+		wantVersion     string
+		wantFedoraVer   string
+		wantArch        string
+		wantErrContains string
+	}{
+		// Standard cases
+		{
+			tag:      "tailscale-0-1.98.4-1-44-x86-64",
+			wantName: "tailscale", wantVersion: "0-1.98.4-1", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "docker-ce-3-29.5.3-1.fc44-44-x86-64",
+			wantName: "docker-ce", wantVersion: "3-29.5.3-1.fc44", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "1password-gui-8.12.22-1-44-x86-64",
+			wantName: "1password-gui", wantVersion: "8.12.22-1", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "vscode-1.100.3-1-44-arm64",
+			wantName: "vscode", wantVersion: "1.100.3-1", wantFedoraVer: "44", wantArch: "arm64",
+		},
+		{
+			tag:      "netbird-ui-0.35.1-1-44-arm64",
+			wantName: "netbird-ui", wantVersion: "0.35.1-1", wantFedoraVer: "44", wantArch: "arm64",
+		},
+		{
+			tag:      "cloud-hypervisor-1-39.1-1-43-x86-64",
+			wantName: "cloud-hypervisor", wantVersion: "1-39.1-1", wantFedoraVer: "43", wantArch: "x86-64",
+		},
+		// Error cases
+		{
+			tag:             "tailscale",
+			wantErrContains: "no recognized arch suffix",
+		},
+		{
+			tag:             "latest",
+			wantErrContains: "no recognized arch suffix",
+		},
+		{
+			tag:             "vscode",
+			wantErrContains: "no recognized arch suffix",
+		},
+		{
+			tag:             "noversion-x86-64",
+			wantErrContains: "no fedora version segment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			name, version, fedoraVer, arch, err := bakery.ParseFCOSTagName(tt.tag)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.wantErrContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tt.wantName {
+				t.Errorf("name: got %q, want %q", name, tt.wantName)
+			}
+			if version != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", version, tt.wantVersion)
+			}
+			if fedoraVer != tt.wantFedoraVer {
+				t.Errorf("fedoraVersion: got %q, want %q", fedoraVer, tt.wantFedoraVer)
+			}
+			if arch != tt.wantArch {
+				t.Errorf("arch: got %q, want %q", arch, tt.wantArch)
+			}
+		})
+	}
+}
+
+// --- FetchCatalogFCOS tests ---
+
+type fcosRelease struct {
+	TagName string      `json:"tag_name"`
+	Body    string      `json:"body"`
+	Assets  []fcosAsset `json:"assets"`
+}
+
+type fcosAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func makeFCOSTestServer(t *testing.T, releases []fcosRelease) *httptest.Server {
+	t.Helper()
+	body, err := json.Marshal(releases)
+	if err != nil {
+		t.Fatalf("marshaling test releases: %v", err)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestFetchCatalogFCOS_BasicFiltering(t *testing.T) {
+	releases := []fcosRelease{
+		{
+			TagName: "tailscale-0-1.98.4-1-44-x86-64",
+			Body:    "Tailscale VPN",
+			Assets: []fcosAsset{
+				{Name: "tailscale-0-1.98.4-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/org/repo/releases/download/tailscale-0-1.98.4-1-44-x86-64/tailscale-0-1.98.4-1-44-x86-64.raw"},
+				{Name: "SHA256SUMS", BrowserDownloadURL: "https://github.com/org/repo/releases/download/tailscale-0-1.98.4-1-44-x86-64/SHA256SUMS"},
+			},
+		},
+		{
+			// Wrong arch — should be filtered out.
+			TagName: "tailscale-0-1.98.4-1-44-arm64",
+			Body:    "Tailscale VPN arm64",
+			Assets: []fcosAsset{
+				{Name: "tailscale-0-1.98.4-1-44-arm64.raw", BrowserDownloadURL: "https://github.com/org/repo/releases/download/tailscale-0-1.98.4-1-44-arm64/tailscale-0-1.98.4-1-44-arm64.raw"},
+			},
+		},
+		{
+			// Wrong fedora version — should be filtered out.
+			TagName: "docker-ce-3-29.5.3-1.fc43-43-x86-64",
+			Body:    "Docker CE for F43",
+			Assets: []fcosAsset{
+				{Name: "docker-ce-3-29.5.3-1.fc43-43-x86-64.raw", BrowserDownloadURL: "https://github.com/org/repo/releases/download/docker-ce-3-29.5.3-1.fc43-43-x86-64/docker-ce-3-29.5.3-1.fc43-43-x86-64.raw"},
+			},
+		},
+	}
+
+	srv := makeFCOSTestServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(entries), entries)
+	}
+	if entries[0].Name != "tailscale" {
+		t.Errorf("expected 'tailscale', got %q", entries[0].Name)
+	}
+}
+
+func TestFetchCatalogFCOS_Deduplication(t *testing.T) {
+	releases := []fcosRelease{
+		{
+			TagName: "tailscale-0-1.99.0-1-44-x86-64",
+			Body:    "Newer",
+			Assets: []fcosAsset{
+				{Name: "tailscale-0-1.99.0-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/t/tailscale-0-1.99.0-1-44-x86-64.raw"},
+			},
+		},
+		{
+			// Older release of same extension — should be deduped.
+			TagName: "tailscale-0-1.98.4-1-44-x86-64",
+			Body:    "Older",
+			Assets: []fcosAsset{
+				{Name: "tailscale-0-1.98.4-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/t2/tailscale-0-1.98.4-1-44-x86-64.raw"},
+			},
+		},
+	}
+
+	srv := makeFCOSTestServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 deduplicated entry, got %d", len(entries))
+	}
+	if entries[0].Version != "0-1.99.0-1" {
+		t.Errorf("expected newer version, got %q", entries[0].Version)
+	}
+}
+
+func TestFetchCatalogFCOS_SkipsFloatingTags(t *testing.T) {
+	releases := []fcosRelease{
+		// Floating tag — no arch/version, should be skipped.
+		{TagName: "tailscale", Body: "floating", Assets: []fcosAsset{
+			{Name: "tailscale.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/tailscale/tailscale.raw"},
+		}},
+		// Valid entry.
+		{TagName: "vscode-1.100.3-1-44-x86-64", Body: "VS Code", Assets: []fcosAsset{
+			{Name: "vscode-1.100.3-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/vscode-1.100.3-1-44-x86-64/vscode-1.100.3-1-44-x86-64.raw"},
+		}},
+	}
+
+	srv := makeFCOSTestServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "vscode" {
+		t.Fatalf("expected only 'vscode', got %v", entries)
+	}
+}
+
+func TestFetchCatalogFCOS_CuratedDescriptions(t *testing.T) {
+	releases := []fcosRelease{
+		{
+			TagName: "tailscale-0-1.98.4-1-44-x86-64",
+			Body:    "raw github body",
+			Assets: []fcosAsset{
+				{Name: "tailscale-0-1.98.4-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/t/tailscale-0-1.98.4-1-44-x86-64.raw"},
+			},
+		},
+	}
+
+	srv := makeFCOSTestServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry")
+	}
+	// Curated description should override the raw GitHub body.
+	if entries[0].Description == "raw github body" {
+		t.Errorf("expected curated description, got raw body %q", entries[0].Description)
+	}
+	if entries[0].Category != "Networking" {
+		t.Errorf("expected category Networking, got %q", entries[0].Category)
+	}
+}
+
+func TestFetchCatalogFCOS_UnsupportedArch(t *testing.T) {
+	client := bakery.NewHTTPClientWithURL("http://unused")
+	_, err := client.FetchCatalogFCOS(context.Background(), "riscv64", 44)
+	if err == nil {
+		t.Fatal("expected error for unsupported arch")
+	}
+}
+
+func TestFetchCatalogFCOS_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	_, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+}
+
+func TestFetchCatalogFCOS_Pagination(t *testing.T) {
+	// Page 1 → returns one release + Link: next header
+	page1Release := []fcosRelease{{
+		TagName: "vscode-1.100.3-1-44-x86-64",
+		Body:    "VS Code",
+		Assets: []fcosAsset{
+			{Name: "vscode-1.100.3-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/v/vscode-1.100.3-1-44-x86-64.raw"},
+		},
+	}}
+	page1Body, _ := json.Marshal(page1Release)
+
+	page2Release := []fcosRelease{{
+		TagName: "tailscale-0-1.98.4-1-44-x86-64",
+		Body:    "Tailscale",
+		Assets: []fcosAsset{
+			{Name: "tailscale-0-1.98.4-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/r/r/releases/download/t/tailscale-0-1.98.4-1-44-x86-64.raw"},
+		},
+	}}
+	page2Body, _ := json.Marshal(page2Release)
+
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.RawQuery == "" || strings.Contains(r.URL.RawQuery, "page=1") {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?page=2>; rel="next"`, srvURL))
+			_, _ = w.Write(page1Body)
+		} else {
+			_, _ = w.Write(page2Body)
+		}
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries from 2 pages, got %d", len(entries))
+	}
+}

--- a/internal/bakery/fcos_test.go
+++ b/internal/bakery/fcos_test.go
@@ -130,7 +130,6 @@ func TestFetchCatalogFCOS_BasicFiltering(t *testing.T) {
 			Body:    "Tailscale VPN",
 			Assets: []fcosAsset{
 				{Name: "tailscale-0-1.98.4-1-44-x86-64.raw", BrowserDownloadURL: "https://github.com/org/repo/releases/download/tailscale-0-1.98.4-1-44-x86-64/tailscale-0-1.98.4-1-44-x86-64.raw"},
-				{Name: "SHA256SUMS", BrowserDownloadURL: "https://github.com/org/repo/releases/download/tailscale-0-1.98.4-1-44-x86-64/SHA256SUMS"},
 			},
 		},
 		{

--- a/internal/fcos/streams.go
+++ b/internal/fcos/streams.go
@@ -1,0 +1,99 @@
+// Package fcos provides helpers for interacting with Fedora CoreOS metadata.
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// StreamsBaseURL is the FCOS stream metadata endpoint.
+// It is a variable (not a constant) to allow test injection of an httptest.Server URL.
+var StreamsBaseURL = "https://builds.coreos.fedoraproject.org/streams"
+
+const (
+	// streamsMaxResponseSize caps the stream JSON response at 5 MiB.
+	streamsMaxResponseSize = 5 << 20
+)
+
+var streamsHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+type fcosStreamDoc struct {
+	Architectures map[string]fcosArchDoc `json:"architectures"`
+}
+
+type fcosArchDoc struct {
+	Artifacts map[string]fcosArtifact `json:"artifacts"`
+}
+
+type fcosArtifact struct {
+	Release string `json:"release"`
+}
+
+// FetchStreamFedoraVersion returns the Fedora major version number for an FCOS stream.
+// For example, "stable" → 44 when the stable stream ships Fedora 44 packages.
+// The version is parsed from the first component of any artifacts[*].release field
+// (format: "44.20260510.3.1"). All artifacts within a stream share the same major version.
+func FetchStreamFedoraVersion(ctx context.Context, stream string) (int, error) {
+	switch stream {
+	case "stable", "testing", "next":
+	default:
+		return 0, fmt.Errorf("unsupported FCOS stream %q: must be stable, testing, or next", stream)
+	}
+
+	url := fmt.Sprintf("%s/%s.json", StreamsBaseURL, stream)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating FCOS stream request: %w", err)
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := streamsHTTPClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetching FCOS stream %s: %w", stream, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("FCOS stream %s returned HTTP %d", stream, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, streamsMaxResponseSize))
+	if err != nil {
+		return 0, fmt.Errorf("reading FCOS stream response: %w", err)
+	}
+
+	return parseFCOSStreamVersion(body)
+}
+
+// parseFCOSStreamVersion extracts the Fedora major version from FCOS stream JSON.
+func parseFCOSStreamVersion(body []byte) (int, error) {
+	var doc fcosStreamDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return 0, fmt.Errorf("parsing FCOS stream JSON: %w", err)
+	}
+
+	// All artifacts within a stream share the same Fedora major version.
+	// Return the first valid one found.
+	for _, arch := range doc.Architectures {
+		for _, artifact := range arch.Artifacts {
+			if artifact.Release == "" {
+				continue
+			}
+			// Release format: "44.20260510.3.1" — the major version is the first component.
+			parts := strings.SplitN(artifact.Release, ".", 2)
+			ver, err := strconv.Atoi(parts[0])
+			if err != nil || ver <= 0 {
+				continue
+			}
+			return ver, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no Fedora version found in FCOS stream JSON")
+}

--- a/internal/fcos/streams_test.go
+++ b/internal/fcos/streams_test.go
@@ -1,0 +1,117 @@
+package fcos_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/fcos"
+)
+
+func TestFetchStreamFedoraVersion(t *testing.T) {
+	const sampleStreamJSON = `{
+		"architectures": {
+			"x86_64": {
+				"artifacts": {
+					"metal": {"release": "44.20260510.3.1"},
+					"qemu": {"release": "44.20260510.3.1"}
+				}
+			},
+			"aarch64": {
+				"artifacts": {
+					"metal": {"release": "44.20260510.3.1"}
+				}
+			}
+		}
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleStreamJSON))
+	}))
+	defer srv.Close()
+
+	// Override the base URL for the test.
+	origBase := fcos.StreamsBaseURL
+	fcos.StreamsBaseURL = srv.URL
+	defer func() { fcos.StreamsBaseURL = origBase }()
+
+	ver, err := fcos.FetchStreamFedoraVersion(context.Background(), "stable")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 44 {
+		t.Errorf("expected Fedora version 44, got %d", ver)
+	}
+}
+
+func TestFetchStreamFedoraVersion_InvalidStream(t *testing.T) {
+	_, err := fcos.FetchStreamFedoraVersion(context.Background(), "nightly")
+	if err == nil {
+		t.Fatal("expected error for unsupported stream")
+	}
+}
+
+func TestFetchStreamFedoraVersion_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	origBase := fcos.StreamsBaseURL
+	fcos.StreamsBaseURL = srv.URL
+	defer func() { fcos.StreamsBaseURL = origBase }()
+
+	_, err := fcos.FetchStreamFedoraVersion(context.Background(), "stable")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+}
+
+func TestFetchStreamFedoraVersion_EmptyJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"architectures":{}}`))
+	}))
+	defer srv.Close()
+
+	origBase := fcos.StreamsBaseURL
+	fcos.StreamsBaseURL = srv.URL
+	defer func() { fcos.StreamsBaseURL = origBase }()
+
+	_, err := fcos.FetchStreamFedoraVersion(context.Background(), "testing")
+	if err == nil {
+		t.Fatal("expected error when no release fields found")
+	}
+}
+
+func TestFetchStreamFedoraVersion_MalformedRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"architectures": {
+				"x86_64": {
+					"artifacts": {
+						"metal": {"release": "not-a-number.20260510.3.1"},
+						"qemu": {"release": "44.20260510.3.1"}
+					}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	origBase := fcos.StreamsBaseURL
+	fcos.StreamsBaseURL = srv.URL
+	defer func() { fcos.StreamsBaseURL = origBase }()
+
+	// Should still succeed using the valid artifact.
+	ver, err := fcos.FetchStreamFedoraVersion(context.Background(), "next")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 44 {
+		t.Errorf("expected 44, got %d", ver)
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -44,6 +44,9 @@ type State struct {
 	// FCOSFedoraVersion is the Fedora major version for the current FCOS stream.
 	// Populated by FetchFCOSStream; used by FetchSysexts to filter the FCOS catalog.
 	FCOSFedoraVersion int
+	// FCOSFedoraStream is the Config.Channel value used for the last FCOSFedoraVersion fetch.
+	// Used to detect channel changes and re-resolve FCOSFedoraVersion when the stream switches.
+	FCOSFedoraStream string
 
 	// System checks (populated at startup)
 	SystemChecks []SystemCheck
@@ -387,11 +390,15 @@ func (w *Wizard) FetchSysexts(ctx context.Context) error {
 	var err error
 
 	if dc, ok := w.Bakery.(*bakery.DispatchingClient); ok {
-		if w.State.Config.OS == model.OSFCOS && w.State.FCOSFedoraVersion == 0 {
-			// Resolve the Fedora version for the current stream on first use.
-			if ver, ferr := fetchFCOSStreamVersionFn(ctx, w.State.Config.Channel); ferr == nil {
-				w.State.FCOSFedoraVersion = ver
+		if w.State.Config.OS == model.OSFCOS &&
+			(w.State.FCOSFedoraVersion == 0 || w.State.FCOSFedoraStream != w.State.Config.Channel) {
+			// Re-resolve Fedora version when unset or when the channel has changed.
+			ver, ferr := fetchFCOSStreamVersionFn(ctx, w.State.Config.Channel)
+			if ferr != nil {
+				return fmt.Errorf("resolving FCOS Fedora version for stream %q: %w", w.State.Config.Channel, ferr)
 			}
+			w.State.FCOSFedoraVersion = ver
+			w.State.FCOSFedoraStream = w.State.Config.Channel
 		}
 		sysexts, err = dc.FetchCatalogForOS(ctx, w.State.Config.Arch, w.State.Config.OS, w.State.FCOSFedoraVersion)
 	} else {
@@ -431,6 +438,7 @@ func (w *Wizard) FetchFCOSStream(ctx context.Context) error {
 		return fmt.Errorf("fetching FCOS stream info: %w", err)
 	}
 	w.State.FCOSFedoraVersion = ver
+	w.State.FCOSFedoraStream = w.State.Config.Channel
 	return nil
 }
 

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/fcos"
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/install"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -17,6 +18,9 @@ import (
 
 // fetchAllChannelsFn is a package-level hook so tests can inject a mock.
 var fetchAllChannelsFn = bakery.FetchAllChannels
+
+// fetchFCOSStreamVersionFn is a package-level hook so tests can inject a mock.
+var fetchFCOSStreamVersionFn = fcos.FetchStreamFedoraVersion
 
 // State holds the complete wizard state
 type State struct {
@@ -36,6 +40,10 @@ type State struct {
 
 	// Channel version info (fetched at startup)
 	Channels []bakery.ChannelInfo
+
+	// FCOSFedoraVersion is the Fedora major version for the current FCOS stream.
+	// Populated by FetchFCOSStream; used by FetchSysexts to filter the FCOS catalog.
+	FCOSFedoraVersion int
 
 	// System checks (populated at startup)
 	SystemChecks []SystemCheck
@@ -368,11 +376,28 @@ func (w *Wizard) runSystemChecks() {
 	}
 }
 
-// FetchSysexts loads the sysext catalog for the configured architecture.
+// FetchSysexts loads the sysext catalog for the configured architecture and OS.
+// When OS is FCOS, it dispatches to the FCOS catalog and resolves the Fedora version
+// from the current stream (fetched inline if not already known). When OS is Flatcar
+// (or the bakery is not a DispatchingClient), it falls back to FetchCatalogArch.
 // If an NVIDIA GPU was detected during ProbeHardware, nvidia-runtime is
 // auto-selected and the default driver series is pre-configured.
 func (w *Wizard) FetchSysexts(ctx context.Context) error {
-	sysexts, err := w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	var sysexts []model.SysextEntry
+	var err error
+
+	if dc, ok := w.Bakery.(*bakery.DispatchingClient); ok {
+		if w.State.Config.OS == model.OSFCOS && w.State.FCOSFedoraVersion == 0 {
+			// Resolve the Fedora version for the current stream on first use.
+			if ver, ferr := fetchFCOSStreamVersionFn(ctx, w.State.Config.Channel); ferr == nil {
+				w.State.FCOSFedoraVersion = ver
+			}
+		}
+		sysexts, err = dc.FetchCatalogForOS(ctx, w.State.Config.Arch, w.State.Config.OS, w.State.FCOSFedoraVersion)
+	} else {
+		sysexts, err = w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	}
+
 	if err != nil {
 		return fmt.Errorf("fetching sysext catalog: %w", err)
 	}
@@ -391,6 +416,21 @@ func (w *Wizard) FetchSysexts(ctx context.Context) error {
 			}
 		}
 	}
+	return nil
+}
+
+// FetchFCOSStream fetches the Fedora major version for the current FCOS stream and
+// stores it in State.FCOSFedoraVersion. Must be called after Config.Channel is set.
+// No-op when OS is not FCOS; FetchSysexts also resolves this lazily if needed.
+func (w *Wizard) FetchFCOSStream(ctx context.Context) error {
+	if w.State.Config.OS != model.OSFCOS {
+		return nil
+	}
+	ver, err := fetchFCOSStreamVersionFn(ctx, w.State.Config.Channel)
+	if err != nil {
+		return fmt.Errorf("fetching FCOS stream info: %w", err)
+	}
+	w.State.FCOSFedoraVersion = ver
 	return nil
 }
 


### PR DESCRIPTION
Closes #641

## Summary

Implements all sub-scopes from issue #641 — adds the FCOS sysext catalog client for `fedora-sysexts/community`, including stream metadata fetching, tag name parsing, catalog pagination, curated descriptions, and wizard wiring.

## Changes

**A — FCOS stream metadata** (`internal/fcos/streams.go`)
- `FetchStreamFedoraVersion(ctx, stream)` fetches the Fedora major version from the FCOS stream JSON at `builds.coreos.fedoraproject.org/streams/<stream>.json`
- Validates stream is `stable`, `testing`, or `next`; parses major version from `release` field

**B — Tag name parsing** (`internal/bakery/fcos.go`)
- `ParseFCOSTagName(tag)` parses `<name>-<version>-<fedoraVersion>-<arch>` tags
- Handles `docker-ce`, `1password-gui`, `tailscale-0-1.98.4-1`, `netbird-ui`, `cloud-hypervisor`
- Floating tags (`tailscale`, `latest`, `vscode`) rejected with descriptive error

**C — Catalog URL + pagination** (`internal/bakery/fcos.go`)
- `FCOSCatalogURL` const; `maxFCOSCatalogPages = 20` (covers ~1600 releases at 100/page)
- `slog.Warn` emitted if cap hit while `rel="next"` still exists (soft failure)

**D — `HTTPClient.FetchCatalogFCOS`** (`internal/bakery/fcos.go`)
- Filters releases by arch AND fedoraVersion before deduplication
- SHA256SUMS best-effort; `NewFCOSHTTPClient()` factory
- Asset URLs confirmed to be on `github.com` (not `extensions.fcos.fr`)

**E — Curated descriptions** (`internal/bakery/fcos_descriptions.go`)
- `FCOSLookup` + `TierFCOSCommunity` constant
- Covers: tailscale, docker-ce, vscode, vscodium, glab, cilium-cli, 1password-gui, bitwarden

** Dispatcher + wizard wiring**F 
- `FCOSCatalogClient` interface in `dispatch.go` (extends `Client` with `FetchCatalogFCOS`)
- `FetchCatalogForOS` gains `fedoraVersion int` parameter
- Wizard `FetchSysexts` dispatches via `DispatchingClient`, resolves fedoraVersion lazily on first use
- `Wizard.FetchFCOSStream` pre-fetch helper called from `main.go` startup
- `main.go` wired to `DispatchingClient{Flatcar: NewHTTPClient(), FCOS: NewFCOSHTTPClient()}`

## Tests

- `internal/fcos/streams_test.go`: httptest-based tests for stream version fetching
- `internal/bakery/fcos_test.go`: table-driven ParseFCOSTagName + FetchCatalogFCOS integration tests
- All `go test ./...` pass; `go vet ./...` and `gofmt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fedora CoreOS catalog support with automatic Fedora version detection from stream metadata.
  * Implemented Fedora version-aware filtering for CoreOS system extensions.
  * Introduced curated metadata for CoreOS community extensions, including categories and support tiers.
  * Extended catalog fetching to support multiple operating systems with separate configurations.

* **Tests**
  * Added comprehensive test coverage for CoreOS catalog operations and stream version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->