### PR TITLE
feat(headless): add os field, FCOS stream validation, NvidiaDriverVersion guard

### DIFF
--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -1,7 +1,8 @@
 # Headless Mode — JSON Config Schema
 
 Knuckle's headless mode (`--headless --config <file.json>`) performs a fully
-automated, non-interactive Flatcar install driven by a JSON configuration file.
+automated, non-interactive install driven by a JSON configuration file.
+Both Flatcar Linux and Fedora CoreOS (FCOS) are supported via the `os` field.
 This document is the authoritative reference for every field in that file.
 
 ## Quick-start examples
@@ -69,6 +70,29 @@ This document is the authoritative reference for every field in that file.
 }
 ```
 
+### Fedora CoreOS (FCOS) install
+
+```json
+{
+  "os": "fcos",
+  "channel": "stable",
+  "hostname": "fcos-node-1",
+  "disk": "/dev/disk/by-id/...",
+  "network": { "mode": "dhcp" },
+  "users": [
+    {
+      "username": "core",
+      "ssh_keys": ["ssh-ed25519 AAAA... you@host"]
+    }
+  ]
+}
+```
+
+> **FCOS limitations** (compared to Flatcar):
+> - `version` — version pinning is not supported by `coreos-installer`; the field is silently ignored.
+> - `nvidia_driver_version` — not supported; rejected with an error if set.
+> - `update_strategy` — `etcd-lock` is not available; use `reboot` (maps to zincati `immediate`) or `off` (disables zincati automatic updates). Defaults to `reboot`.
+
 ---
 
 ## Full field reference
@@ -77,17 +101,18 @@ This document is the authoritative reference for every field in that file.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `os` | string | no | `"flatcar"` | Target OS. One of `flatcar` (default) or `fcos`. Omit for Flatcar (backward compatible). |
+| `channel` | string | no | `"stable"` | Release channel. Flatcar: one of `stable`, `beta`, `alpha`, `lts`, `edge`. FCOS: one of `stable`, `testing`, `next`. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. **Not supported for FCOS** — `coreos-installer` has no equivalent version-pinning flag for stream-based installs; this field is silently ignored when `os` is `fcos`. |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |
 | `users` | array | yes* | — | One or more user accounts. `*` Not required when `ignition_url` is set. |
-| `update_strategy` | string | no | `"reboot"` | Flatcar update strategy. One of `reboot`, `off`, `etcd-lock`. |
+| `update_strategy` | string | no | `"reboot"` | OS update strategy. Flatcar: one of `reboot`, `off`, `etcd-lock`. FCOS: one of `reboot` (maps to zincati `immediate`) or `off` (disables zincati automatic updates). `etcd-lock` is not supported for FCOS. |
 | `arch` | string | no | `"amd64"` | CPU architecture. One of `amd64`, `arm64`. `arm64` is not available on the `lts` channel. |
 | `timezone` | string | no | `"UTC"` | System timezone (IANA format, e.g. `"America/New_York"`). |
 | `sysexts` | string[] | no | `[]` | List of system extension names from the bakery catalog (e.g. `["docker", "kubernetes"]`). |
-| `nvidia_driver_version` | string | no | _(none)_ | NVIDIA kernel driver series. One of `570-open` (default/recommended), `550-open`, `535-open`, `460`. Omit to skip NVIDIA setup. |
+| `nvidia_driver_version` | string | no | _(none)_ | **Flatcar only.** NVIDIA kernel driver series. One of `570-open` (default/recommended), `550-open`, `535-open`, `460`. Omit to skip NVIDIA setup. Rejected with an error if set for FCOS. |
 | `tailscale` | object | no | — | See [Tailscale](#tailscale). Omit or leave `auth_key` blank to skip. |
 | `swap` | object | no | _(enabled, 4 GiB)_ | See [Swap](#swap). Omit for the default (4 GiB enabled). |
 | `ignition_url` | string | no | — | URL of an external Ignition config. When set, knuckle downloads this config instead of generating one — only `disk` is then required. Must be HTTPS. |

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -181,10 +181,20 @@ func (c *Config) ToInstallConfig() *model.InstallConfig {
 	}
 
 	// Update strategy
-	if c.UpdateStrategy != "" {
-		cfg.UpdateStrategy.RebootStrategy = c.UpdateStrategy
+	if c.OS == model.OSFCOS {
+		// Map headless update_strategy to FCOS zincati strategy
+		switch c.UpdateStrategy {
+		case "off":
+			cfg.UpdateStrategy.FCOSUpdateStrategy = model.FCOSStrategyDisabled
+		default: // "reboot", "" → immediate (coreos-installer default)
+			cfg.UpdateStrategy.FCOSUpdateStrategy = model.FCOSStrategyImmediate
+		}
 	} else {
-		cfg.UpdateStrategy.RebootStrategy = "reboot"
+		if c.UpdateStrategy != "" {
+			cfg.UpdateStrategy.RebootStrategy = c.UpdateStrategy
+		} else {
+			cfg.UpdateStrategy.RebootStrategy = "reboot"
+		}
 	}
 
 	return cfg
@@ -246,9 +256,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Version
-	if err := validate.FlatcarVersion(c.Version); err != nil {
-		return fmt.Errorf("version: %w", err)
+	// Version (Flatcar-only; FCOS version pinning is not supported by coreos-installer)
+	if c.OS != model.OSFCOS {
+		if err := validate.FlatcarVersion(c.Version); err != nil {
+			return fmt.Errorf("version: %w", err)
+		}
 	}
 
 	// Hostname
@@ -349,6 +361,10 @@ func (c *Config) Validate() error {
 	if !validStrategies[c.UpdateStrategy] {
 		return fmt.Errorf("update_strategy: must be reboot, off, or etcd-lock (got %q)", c.UpdateStrategy)
 	}
+	// etcd-lock is Flatcar-only (zincati, used by FCOS, has no equivalent)
+	if c.OS == model.OSFCOS && c.UpdateStrategy == "etcd-lock" {
+		return fmt.Errorf("update_strategy: etcd-lock is not supported for FCOS (use reboot or off)")
+	}
 
 	// Swap size must be within [0, MaxSwapSizeMB]
 	if c.Swap != nil {
@@ -378,6 +394,11 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("tailscale routes: %w", err)
 			}
 		}
+	}
+
+	// NVIDIA driver version is Flatcar-only (FCOS uses out-of-tree modules or layering)
+	if c.OS == model.OSFCOS && c.NvidiaDriverVersion != "" {
+		return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
 	}
 
 	// NVIDIA driver version must be a known series

--- a/internal/headless/headless_validation_coverage_test.go
+++ b/internal/headless/headless_validation_coverage_test.go
@@ -295,3 +295,108 @@ func TestToInstallConfig_OSPropagation(t *testing.T) {
 		})
 	}
 }
+
+// fcosBase returns a minimal valid FCOS headless Config for use in test helpers.
+func fcosBase() *Config {
+	return &Config{
+		OS:       "fcos",
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Network:  NetworkConfig{Mode: "dhcp"},
+		Users:    []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:     "/dev/vdb",
+	}
+}
+
+func TestValidate_FCOSVersionPassthrough(t *testing.T) {
+	// FCOS version strings do not match the Flatcar semver regex (MAJOR.MINOR.PATCH).
+	// Validate() must not call FlatcarVersion for FCOS — it should accept any non-empty
+	// version string without error (the FCOSInstaller will warn and ignore it).
+	cfg := fcosBase()
+	cfg.Version = "38.20230514.3.0"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("FCOS with version string should pass Validate(), got: %v", err)
+	}
+}
+
+func TestValidate_FCOSNvidiaRejected(t *testing.T) {
+	cfg := fcosBase()
+	cfg.NvidiaDriverVersion = "570-open"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for nvidia_driver_version on FCOS, got nil")
+	}
+	if !strings.Contains(err.Error(), "nvidia_driver_version") {
+		t.Errorf("expected nvidia_driver_version error, got: %v", err)
+	}
+}
+
+func TestValidate_FCOSEtcdLockRejected(t *testing.T) {
+	cfg := fcosBase()
+	cfg.UpdateStrategy = "etcd-lock"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for etcd-lock on FCOS, got nil")
+	}
+	if !strings.Contains(err.Error(), "etcd-lock") {
+		t.Errorf("expected etcd-lock error, got: %v", err)
+	}
+}
+
+func TestValidate_FCOSUpdateStrategyOffOK(t *testing.T) {
+	cfg := fcosBase()
+	cfg.UpdateStrategy = "off"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("FCOS update_strategy=off should pass Validate(), got: %v", err)
+	}
+}
+
+func TestValidate_FCOSUpdateStrategyRebootOK(t *testing.T) {
+	cfg := fcosBase()
+	cfg.UpdateStrategy = "reboot"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("FCOS update_strategy=reboot should pass Validate(), got: %v", err)
+	}
+}
+
+func TestToInstallConfig_FCOSUpdateStrategyMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		updateStrategy string
+		wantFCOS       string
+		wantFlatcar    string
+	}{
+		{"fcos reboot → immediate", "reboot", model.FCOSStrategyImmediate, ""},
+		{"fcos empty → immediate", "", model.FCOSStrategyImmediate, ""},
+		{"fcos off → disabled", "off", model.FCOSStrategyDisabled, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := fcosBase()
+			cfg.UpdateStrategy = tt.updateStrategy
+			ic := cfg.ToInstallConfig()
+			if ic.UpdateStrategy.FCOSUpdateStrategy != tt.wantFCOS {
+				t.Errorf("FCOSUpdateStrategy = %q, want %q", ic.UpdateStrategy.FCOSUpdateStrategy, tt.wantFCOS)
+			}
+		})
+	}
+}
+
+func TestToInstallConfig_FlatcarUpdateStrategyUnchanged(t *testing.T) {
+	cfg := &Config{
+		OS:             "flatcar",
+		Channel:        "stable",
+		Hostname:       "node",
+		Network:        NetworkConfig{Mode: "dhcp"},
+		Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+		Disk:           "/dev/vdb",
+		UpdateStrategy: "etcd-lock",
+	}
+	ic := cfg.ToInstallConfig()
+	if ic.UpdateStrategy.RebootStrategy != "etcd-lock" {
+		t.Errorf("Flatcar RebootStrategy = %q, want etcd-lock", ic.UpdateStrategy.RebootStrategy)
+	}
+	if ic.UpdateStrategy.FCOSUpdateStrategy != "" {
+		t.Errorf("Flatcar FCOSUpdateStrategy should be empty, got %q", ic.UpdateStrategy.FCOSUpdateStrategy)
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -244,6 +244,11 @@ func GroupName(name string) error {
 
 // CheckConsistency validates the overall config for conflicting settings.
 func CheckConsistency(cfg *model.InstallConfig) error {
+	// NVIDIA driver version is Flatcar-only regardless of ignition_url mode
+	if cfg.OS == model.OSFCOS && cfg.NvidiaDriverVersion != "" {
+		return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
+	}
+
 	// External Ignition URL mode: only disk is required, skip auth/network checks
 	if cfg.IgnitionURL != "" {
 		if cfg.Disk.DevPath == "" {

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -620,6 +620,33 @@ func TestCheckConsistency(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name: "FCOS nvidia driver version rejected",
+			modify: func(cfg *model.InstallConfig) {
+				cfg.OS = model.OSFCOS
+				cfg.NvidiaDriverVersion = "570-open"
+			},
+			wantErr: "nvidia_driver_version: not supported on FCOS",
+		},
+		{
+			name: "FCOS nvidia driver version empty is OK",
+			modify: func(cfg *model.InstallConfig) {
+				cfg.OS = model.OSFCOS
+			},
+			wantErr: "",
+		},
+		{
+			name: "FCOS nvidia driver version rejected even with ignition_url",
+			modify: func(cfg *model.InstallConfig) {
+				cfg.OS = model.OSFCOS
+				cfg.IgnitionURL = "https://example.com/fcos.ign"
+				cfg.NvidiaDriverVersion = "570-open"
+				cfg.SSHKeys = nil
+				cfg.Users = nil
+				cfg.Channel = ""
+			},
+			wantErr: "nvidia_driver_version: not supported on FCOS",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #642

Full FCOS support in the headless install path.

- `Validate()`: skip FlatcarVersion for FCOS, reject nvidia_driver_version for FCOS, reject etcd-lock for FCOS
- `ToInstallConfig()`: map update_strategy → FCOSUpdateStrategy (reboot/empty→immediate, off→disabled)
- `CheckConsistency()`: reject NvidiaDriverVersion for FCOS
- `docs/HEADLESS-CONFIG.md`: add os field, FCOS example, FCOS limitations
- 10 new tests (7 headless, 3 validate)

All 18 packages pass `go test ./...`