### PR TITLE
feat(install): FCOSInstaller using coreos-installer

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -116,7 +116,7 @@ func main() {
 		bakeryClient = bakery.NewHTTPClient()
 		installer = &install.DispatchingInstaller{
 			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
-			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+			FCOS:    install.NewFCOSInstaller(cmdRunner, logger),
 		}
 	}
 
@@ -214,7 +214,7 @@ func runHeadlessWithRunner(configPath string, dryRun bool, logFile string, cmdRu
 
 	installer := &install.DispatchingInstaller{
 		Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
-		// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+		FCOS:    install.NewFCOSInstaller(cmdRunner, logger),
 	}
 
 	// Run headless install with a 30-minute wall-clock timeout.

--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -78,7 +78,7 @@ This document is the authoritative reference for every field in that file.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. **Not supported for FCOS** — `coreos-installer` uses the stream's latest image; setting `version` for an FCOS install logs a warning and is ignored. |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -1,0 +1,120 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/projectbluefin/knuckle/internal/ignition"
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+// FCOSInstaller runs coreos-installer via the runner.
+// Unlike FlatcarInstaller, coreos-installer handles disk preparation internally —
+// no wipefs or sfdisk calls are needed.
+type FCOSInstaller struct {
+	Runner       runner.Runner
+	Generator    *ignition.Generator
+	Logger       *slog.Logger
+	ignitionPath string // dynamically set temp file path
+}
+
+// NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
+func NewFCOSInstaller(r runner.Runner, logger *slog.Logger) *FCOSInstaller {
+	return &FCOSInstaller{
+		Runner:    r,
+		Generator: ignition.NewGenerator(),
+		Logger:    logger,
+	}
+}
+
+// Install performs the FCOS installation:
+// 1. Generate FCOS Butane → compile Ignition (uses GenerateFCOSButane)
+// 2. Write ignition to secure temp file
+// 3. Run: coreos-installer install --stream <stream> --ignition-file <path> <disk>
+func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	if cfg.Version != "" {
+		i.Logger.Warn("FCOS version pinning via cfg.Version is not supported; coreos-installer uses stream default",
+			"version", cfg.Version)
+	}
+
+	if cfg.IgnitionURL != "" {
+		// External ignition URL mode — pass directly to coreos-installer
+		progress("Using external Ignition config...")
+	} else {
+		progress("Generating Butane config...")
+		butaneYAML, err := i.Generator.GenerateFCOSButane(cfg)
+		if err != nil {
+			return fmt.Errorf("generating butane config: %w", err)
+		}
+
+		progress("Compiling Ignition config...")
+		ignitionJSON, err := compileToIgnitionFunc(butaneYAML)
+		if err != nil {
+			return fmt.Errorf("compiling butane: %w", err)
+		}
+
+		progress("Writing Ignition config...")
+		ignPath, err := i.WriteIgnitionFile(ignitionJSON)
+		if err != nil {
+			return fmt.Errorf("writing ignition file: %w", err)
+		}
+		i.ignitionPath = ignPath
+		defer i.cleanupIgnitionFile()
+	}
+
+	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+
+	progress("Running coreos-installer...")
+	i.Logger.Info("executing coreos-installer", "args", args)
+
+	result, err := i.Runner.Run(ctx, "coreos-installer", args...)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatCommandError("coreos-installer failed", result, err)
+	}
+
+	progress("Installation complete!")
+	return nil
+}
+
+// buildFCOSInstallArgs constructs the coreos-installer argument list.
+// Disk path is positional (after subcommand); stream and ignition flags are named.
+func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
+	args := []string{
+		"install",
+		"--stream", cfg.Channel,
+	}
+
+	if cfg.IgnitionURL != "" {
+		args = append(args, "--ignition-url", cfg.IgnitionURL)
+	} else if ignitionPath != "" {
+		args = append(args, "--ignition-file", ignitionPath)
+	}
+
+	// disk path is the positional argument — must come last
+	args = append(args, diskPath)
+	return args
+}
+
+// WriteIgnitionFile writes the Ignition JSON to a secure temp file.
+func (i *FCOSInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	return writeIgnitionFileToTemp(i.Logger, ignitionJSON)
+}
+
+// cleanupIgnitionFile removes the temp ignition file (contains SSH keys).
+func (i *FCOSInstaller) cleanupIgnitionFile() {
+	if i.ignitionPath == "" {
+		return
+	}
+	if err := removeIgnitionFile(i.ignitionPath); err != nil && !os.IsNotExist(err) {
+		i.Logger.Warn("failed to clean up ignition file", "path", i.ignitionPath, "error", err)
+	}
+	i.ignitionPath = ""
+}

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -1,0 +1,347 @@
+package install
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func testFCOSLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestFCOSInstall_GeneratedConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testFCOSLogger())
+
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users: []model.UserConfig{
+			{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}},
+		},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// coreos-installer must be called, not flatcar-install
+	var coreosCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "flatcar-install" {
+			t.Error("flatcar-install must not be called by FCOSInstaller")
+		}
+		if spy.Calls[i].Name == "coreos-installer" {
+			coreosCall = &spy.Calls[i]
+		}
+	}
+	if coreosCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	// wipefs must NOT be called
+	for _, call := range spy.Calls {
+		if call.Name == "wipefs" {
+			t.Error("wipefs must not be called by FCOSInstaller")
+		}
+	}
+
+	// sfdisk must NOT be called
+	for _, call := range spy.Calls {
+		if call.Name == "sfdisk" {
+			t.Error("sfdisk must not be called by FCOSInstaller")
+		}
+	}
+
+	// First arg must be "install" subcommand
+	if len(coreosCall.Args) == 0 || coreosCall.Args[0] != "install" {
+		t.Fatalf("expected first arg 'install', got %v", coreosCall.Args)
+	}
+
+	// Must have --stream stable
+	if !argsContainPair(coreosCall.Args, "--stream", "stable") {
+		t.Errorf("expected --stream stable in args: %v", coreosCall.Args)
+	}
+
+	// Must have --ignition-file <temp path>
+	ignIdx := argIndex(coreosCall.Args, "--ignition-file")
+	if ignIdx < 0 || ignIdx+1 >= len(coreosCall.Args) {
+		t.Fatalf("expected --ignition-file in args: %v", coreosCall.Args)
+	}
+
+	// Disk path must be the last (positional) argument
+	last := coreosCall.Args[len(coreosCall.Args)-1]
+	if last != "/dev/sda" {
+		t.Errorf("expected disk path /dev/sda as last arg, got %q", last)
+	}
+}
+
+func TestFCOSInstall_StreamChannel(t *testing.T) {
+	for _, channel := range []string{"stable", "testing", "next"} {
+		t.Run(channel, func(t *testing.T) {
+			spy := runner.NewSpyRunner()
+			installer := NewFCOSInstaller(spy, testFCOSLogger())
+
+			cfg := &model.InstallConfig{
+				OS:       model.OSFCOS,
+				Channel:  channel,
+				Hostname: "fcos-node",
+				Disk:     model.DiskInfo{DevPath: "/dev/vda"},
+				Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+				Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+			}
+
+			if err := installer.Install(context.Background(), cfg, func(string) {}); err != nil {
+				t.Fatalf("channel %s: unexpected error: %v", channel, err)
+			}
+
+			var coreosCall *runner.SpyCall
+			for i := range spy.Calls {
+				if spy.Calls[i].Name == "coreos-installer" {
+					coreosCall = &spy.Calls[i]
+					break
+				}
+			}
+			if coreosCall == nil {
+				t.Fatal("coreos-installer was not called")
+			}
+			if !argsContainPair(coreosCall.Args, "--stream", channel) {
+				t.Errorf("expected --stream %s in args: %v", channel, coreosCall.Args)
+			}
+		})
+	}
+}
+
+func TestFCOSInstall_ExternalIgnitionURL(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testFCOSLogger())
+
+	cfg := &model.InstallConfig{
+		OS:          model.OSFCOS,
+		Channel:     "stable",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	if err := installer.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var coreosCall *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			coreosCall = &spy.Calls[i]
+			break
+		}
+	}
+	if coreosCall == nil {
+		t.Fatal("coreos-installer was not called")
+	}
+
+	if !argsContainPair(coreosCall.Args, "--ignition-url", "https://example.com/fcos.ign") {
+		t.Errorf("expected --ignition-url in args: %v", coreosCall.Args)
+	}
+
+	// --ignition-file must NOT be present
+	for _, arg := range coreosCall.Args {
+		if arg == "--ignition-file" {
+			t.Error("--ignition-file must not be set when IgnitionURL is provided")
+		}
+	}
+}
+
+func TestFCOSInstall_NilConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testFCOSLogger())
+
+	err := installer.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if err.Error() != "install config cannot be nil" {
+		t.Errorf("error = %q, want 'install config cannot be nil'", err.Error())
+	}
+}
+
+func TestFCOSInstall_VersionWarningIgnored(t *testing.T) {
+	// Version pinning is not supported for FCOS; the field should be silently ignored
+	// (with a log warning). The install must still succeed.
+	spy := runner.NewSpyRunner()
+
+	var warnMessages []string
+	handler := &capturingHandler{wrapped: slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}), warns: &warnMessages}
+	logger := slog.New(handler)
+	installer := NewFCOSInstaller(spy, logger)
+
+	cfg := &model.InstallConfig{
+		OS:       model.OSFCOS,
+		Channel:  "stable",
+		Version:  "38.20230514.3.0",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	if err := installer.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Version must NOT appear as --image-url or any version flag
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			for _, arg := range spy.Calls[i].Args {
+				if strings.Contains(arg, "38.20230514.3.0") {
+					t.Errorf("version string must not appear in coreos-installer args: %v", spy.Calls[i].Args)
+				}
+			}
+		}
+	}
+}
+
+func TestFCOSInstall_DiskByIDPath(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testFCOSLogger())
+
+	byIDPath := "/dev/disk/by-id/ata-Samsung_SSD_870_EVO_S6ENNX0T123456"
+	cfg := &model.InstallConfig{
+		OS:      model.OSFCOS,
+		Channel: "stable",
+		Disk: model.DiskInfo{
+			Path:    byIDPath,
+			DevPath: "/dev/sda",
+		},
+		Hostname: "fcos-node",
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA k"}}},
+	}
+
+	if err := installer.Install(context.Background(), cfg, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			last := spy.Calls[i].Args[len(spy.Calls[i].Args)-1]
+			if last != byIDPath {
+				t.Errorf("expected by-id path %q as last arg, got %q", byIDPath, last)
+			}
+			return
+		}
+	}
+	t.Fatal("coreos-installer was not called")
+}
+
+func TestBuildFCOSInstallArgs_Basic(t *testing.T) {
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+	}
+	args := buildFCOSInstallArgs(cfg, "/tmp/ign.json")
+
+	if args[0] != "install" {
+		t.Errorf("first arg must be 'install', got %q", args[0])
+	}
+	if !argsContainPair(args, "--stream", "stable") {
+		t.Errorf("expected --stream stable: %v", args)
+	}
+	if !argsContainPair(args, "--ignition-file", "/tmp/ign.json") {
+		t.Errorf("expected --ignition-file /tmp/ign.json: %v", args)
+	}
+	if args[len(args)-1] != "/dev/sda" {
+		t.Errorf("disk must be last arg, got %q", args[len(args)-1])
+	}
+}
+
+func TestBuildFCOSInstallArgs_IgnitionURL(t *testing.T) {
+	cfg := &model.InstallConfig{
+		Channel:     "testing",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/config.ign",
+	}
+	args := buildFCOSInstallArgs(cfg, "")
+
+	if !argsContainPair(args, "--ignition-url", "https://example.com/config.ign") {
+		t.Errorf("expected --ignition-url: %v", args)
+	}
+	for _, a := range args {
+		if a == "--ignition-file" {
+			t.Error("--ignition-file must not appear when IgnitionURL is set")
+		}
+	}
+}
+
+func TestBuildFCOSInstallArgs_NoIgnition(t *testing.T) {
+	cfg := &model.InstallConfig{
+		Channel: "next",
+		Disk:    model.DiskInfo{DevPath: "/dev/nvme0n1"},
+	}
+	args := buildFCOSInstallArgs(cfg, "")
+
+	for _, a := range args {
+		if a == "--ignition-file" || a == "--ignition-url" {
+			t.Errorf("unexpected ignition flag %q when neither IgnitionURL nor path set", a)
+		}
+	}
+	if args[len(args)-1] != "/dev/nvme0n1" {
+		t.Errorf("disk must be last arg, got %q", args[len(args)-1])
+	}
+}
+
+// Compile-time check: FCOSInstaller must implement the Installer interface.
+var _ Installer = (*FCOSInstaller)(nil)
+
+// argsContainPair returns true if args contains the flag immediately followed by value.
+func argsContainPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// argIndex returns the index of flag in args, or -1 if not found.
+func argIndex(args []string, flag string) int {
+	for i, a := range args {
+		if a == flag {
+			return i
+		}
+	}
+	return -1
+}
+
+// capturingHandler is a slog.Handler that captures Warn-level messages for assertions.
+type capturingHandler struct {
+	wrapped slog.Handler
+	warns   *[]string
+}
+
+func (h *capturingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= slog.LevelWarn
+}
+
+func (h *capturingHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		*h.warns = append(*h.warns, r.Message)
+	}
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *capturingHandler) WithGroup(name string) slog.Handler {
+	return h
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -193,6 +193,12 @@ func installDiskPath(cfg *model.InstallConfig) string {
 // the file is never readable by other users, even between creation and content write.
 // Returns the path to the created temp file.
 func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error) {
+	return writeIgnitionFileToTemp(i.Logger, ignitionJSON)
+}
+
+// writeIgnitionFileToTemp writes the Ignition JSON to a secure temp file and returns the path.
+// Shared by FlatcarInstaller and FCOSInstaller.
+func writeIgnitionFileToTemp(logger *slog.Logger, ignitionJSON string) (string, error) {
 	f, err := newIgnitionTempFile()
 	if err != nil {
 		return "", fmt.Errorf("creating temp ignition file: %w", err)
@@ -210,7 +216,7 @@ func (i *FlatcarInstaller) WriteIgnitionFile(ignitionJSON string) (string, error
 		return "", fmt.Errorf("closing ignition file: %w", err)
 	}
 
-	i.Logger.Info("ignition file written", "path", path)
+	logger.Info("ignition file written", "path", path)
 	return path, nil
 }
 


### PR DESCRIPTION
Closes #640

## What
Implements `FCOSInstaller` using `coreos-installer`, the FCOS counterpart to `FlatcarInstaller`.

## Why
Issue #640: FCOS uses `coreos-installer` with different CLI semantics. No wipefs or sfdisk needed.

## How tested
- `go test ./...` passes (all 17 packages)
- `go build ./...` + `go vet ./...` clean

**New `fcos_install_test.go`** covers all acceptance criteria:
- `coreos-installer install` called (not `flatcar-install`)
- `--stream <channel>` present
- `--ignition-file <tempfile>` for generated configs
- `--ignition-url` for external URL mode
- `wipefs` NOT called
- `sfdisk` NOT called
- Disk path is positional (last arg)
- Version warning + ignored
- Compile-time `Installer` interface check