### PR TITLE
feat(bakery): FCOS sysext catalog client for fedora-sysexts/community

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -113,7 +113,10 @@ func main() {
 	} else {
 		realRunner := runner.NewRealRunner(logger)
 		prober = probe.NewSystemProber(realRunner)
-		bakeryClient = bakery.NewHTTPClient()
+		bakeryClient = &bakery.DispatchingClient{
+			Flatcar: bakery.NewHTTPClient(),
+			FCOS:    bakery.NewFCOSHTTPClient(),
+		}
 		installer = &install.DispatchingInstaller{
 			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
 			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639

--- a/cmd/knuckle/main_test.go
+++ b/cmd/knuckle/main_test.go
@@ -37,6 +37,9 @@ func (b *errBakery) FetchCatalog(_ context.Context) ([]model.SysextEntry, error)
 func (b *errBakery) FetchCatalogArch(_ context.Context, _ string) ([]model.SysextEntry, error) {
 	return nil, errors.New("injected bakery error")
 }
+func (b *errBakery) FetchCatalogFCOS(_ context.Context, _ string, _ int) ([]model.SysextEntry, error) {
+	return nil, errors.New("injected bakery error")
+}
 
 // Compile-time interface checks.
 var _ probe.Prober = (*errProber)(nil)

--- a/internal/bakery/bakery.go
+++ b/internal/bakery/bakery.go
@@ -39,6 +39,9 @@ type Client interface {
 	// FetchCatalogArch fetches the catalog and selects assets for the given arch.
 	// arch must be "amd64" or "arm64". Falls back to x86-64 assets for amd64.
 	FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error)
+	// FetchCatalogFCOS fetches the FCOS community sysext catalog for the given arch
+	// and Fedora major version. fedoraVersion 0 disables version filtering.
+	FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error)
 }
 
 // HTTPClient fetches the catalog from the GitHub Releases API
@@ -385,4 +388,10 @@ func (m *MockClient) FetchCatalogArch(ctx context.Context, arch string) ([]model
 		return m.Entries, nil
 	}
 	return filtered, nil
+}
+
+// FetchCatalogFCOS returns all preconfigured entries (ignores arch and fedoraVersion
+// filtering — test fixtures should pre-filter as needed).
+func (m *MockClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	return m.FetchCatalog(ctx)
 }

--- a/internal/bakery/dispatch.go
+++ b/internal/bakery/dispatch.go
@@ -24,8 +24,15 @@ func (d *DispatchingClient) FetchCatalogArch(ctx context.Context, arch string) (
 	return d.Flatcar.FetchCatalogArch(ctx, arch)
 }
 
+// FetchCatalogFCOS delegates to the FCOS client's FetchCatalogFCOS.
+func (d *DispatchingClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	if d.FCOS == nil {
+		return nil, fmt.Errorf("fcos bakery client not configured")
+	}
+	return d.FCOS.FetchCatalogFCOS(ctx, arch, fedoraVersion)
+}
+
 // FetchCatalogForOS fetches the sysext catalog for the given OS and architecture.
-// FCOS may use a different catalog source or filtering in the future.
 func (d *DispatchingClient) FetchCatalogForOS(ctx context.Context, arch, os string) ([]model.SysextEntry, error) {
 	switch os {
 	case model.OSFCOS:

--- a/internal/bakery/fcos_catalog.go
+++ b/internal/bakery/fcos_catalog.go
@@ -1,0 +1,250 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
+)
+
+const (
+	// FCOSCatalogURL is the GitHub Releases API for the fedora-sysexts/community repo.
+	FCOSCatalogURL = "https://api.github.com/repos/fedora-sysexts/community/releases?per_page=100"
+
+	// maxFCOSCatalogPages caps the number of API pages fetched for the FCOS catalog.
+	// The community repo has 1500+ releases (one per extension × version × arch × Fedora version),
+	// so 20 pages (up to 2000 releases) ensures all unique extension names are covered
+	// given that the API returns newest releases first.
+	maxFCOSCatalogPages = 20
+)
+
+// NewFCOSHTTPClient creates an HTTPClient pre-configured for the FCOS sysext catalog
+// at fedora-sysexts/community.
+func NewFCOSHTTPClient() *HTTPClient {
+	c := NewHTTPClient()
+	c.CatalogURL = FCOSCatalogURL
+	return c
+}
+
+// ParseFCOSTagName parses a fedora-sysexts/community release tag into its components.
+//
+// Tag format: <name>-<version>-<fedoraVersion>-<arch>
+// where arch is "x86-64" or "arm64" and fedoraVersion is all-digits (e.g. "44").
+// "Index-only" tags (e.g. "tailscale", "latest") that lack an arch suffix return an error.
+//
+// Examples:
+//
+//	tailscale-0-1.98.3-1-44-x86-64     → name=tailscale, version=0-1.98.3-1, fedoraVersion=44, arch=x86-64
+//	docker-ce-3-29.5.3-1.fc44-44-arm64 → name=docker-ce, version=3-29.5.3-1.fc44, fedoraVersion=44, arch=arm64
+//	dnclient-0.9.4-44-x86-64           → name=dnclient, version=0.9.4, fedoraVersion=44, arch=x86-64
+func ParseFCOSTagName(tag string) (name, version, fedoraVersion, arch string, err error) {
+	// Step 1: strip known architecture suffix (must be the last component).
+	for _, knownArch := range []string{"x86-64", "arm64"} {
+		if strings.HasSuffix(tag, "-"+knownArch) {
+			arch = knownArch
+			tag = tag[:len(tag)-len("-"+knownArch)]
+			break
+		}
+	}
+	if arch == "" {
+		return "", "", "", "", fmt.Errorf("no arch suffix in tag %q", tag)
+	}
+
+	// Step 2: strip the last segment — it must be an all-digit Fedora major version.
+	lastDash := strings.LastIndex(tag, "-")
+	if lastDash < 0 {
+		return "", "", "", "", fmt.Errorf("missing fedora version segment in %q", tag)
+	}
+	fedoraVersion = tag[lastDash+1:]
+	if fedoraVersion == "" {
+		return "", "", "", "", fmt.Errorf("empty fedora version segment in %q", tag)
+	}
+	for _, ch := range fedoraVersion {
+		if ch < '0' || ch > '9' {
+			return "", "", "", "", fmt.Errorf("fedora version segment %q is not all-digits in %q", fedoraVersion, tag)
+		}
+	}
+	tag = tag[:lastDash]
+
+	// Step 3: find the first "-<digit>" boundary to split name from version.
+	// This correctly handles names like "docker-ce" (hyphen but no leading digit).
+	idx := -1
+	for i := 0; i < len(tag)-1; i++ {
+		if tag[i] == '-' && tag[i+1] >= '0' && tag[i+1] <= '9' {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		// Name-only tag (no version component) — e.g. name= "myext", version = "".
+		name = tag
+		if name == "" {
+			return "", "", "", "", fmt.Errorf("empty name in tag")
+		}
+		return name, "", fedoraVersion, arch, nil
+	}
+
+	name = tag[:idx]
+	version = tag[idx+1:]
+	if name == "" {
+		return "", "", "", "", fmt.Errorf("empty name in tag")
+	}
+	return name, version, fedoraVersion, arch, nil
+}
+
+// FetchCatalogFCOS fetches FCOS community sysexts for the given architecture and
+// Fedora major version. arch must be "amd64" or "arm64".
+// If fedoraVersion is 0, no Fedora version filtering is applied.
+//
+// The method pages through the GitHub Releases API (up to maxFCOSCatalogPages pages),
+// deduplicates by name (keeping the newest release per extension), and applies curated
+// metadata from fcos_descriptions.go when available.
+func (c *HTTPClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	// Map Go arch to the FCOS tag arch suffix.
+	var tagArch string
+	switch arch {
+	case "amd64":
+		tagArch = "x86-64"
+	case "arm64":
+		tagArch = "arm64"
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q: must be amd64 or arm64", arch)
+	}
+
+	const maxResponseSize = 5 << 20 // 5 MB per page
+	var allReleases []githubRelease
+	nextURL := c.CatalogURL
+
+	for page := 0; page < maxFCOSCatalogPages && nextURL != ""; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request (page %d): %w", page+1, err)
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "knuckle/1.0")
+		if c.AuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+c.AuthToken)
+		}
+
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching FCOS catalog (page %d): %w", page+1, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("FCOS catalog returned HTTP %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading FCOS catalog (page %d): %w", page+1, err)
+		}
+		if int64(len(body)) >= maxResponseSize {
+			return nil, fmt.Errorf("FCOS catalog response exceeds 5MB size limit")
+		}
+
+		var releases []githubRelease
+		if err := json.Unmarshal(body, &releases); err != nil {
+			return nil, fmt.Errorf("parsing FCOS catalog JSON (page %d): %w", page+1, err)
+		}
+		if len(releases) == 0 {
+			break
+		}
+		allReleases = append(allReleases, releases...)
+		nextURL, _ = parseLinkNext(resp.Header.Get("Link"))
+	}
+
+	// Build deduplicated entries (newest-first per name).
+	seen := make(map[string]bool)
+	sysexts := make([]model.SysextEntry, 0)
+
+	for _, rel := range allReleases {
+		name, version, relFedoraVer, relArch, err := ParseFCOSTagName(rel.TagName)
+		if err != nil {
+			continue // skip index-only / unrecognised tags
+		}
+		if relArch != tagArch {
+			continue
+		}
+		if fedoraVersion > 0 {
+			fv, err := strconv.Atoi(relFedoraVer)
+			if err != nil || fv != fedoraVersion {
+				continue
+			}
+		}
+		if seen[name] {
+			continue // keep only the newest release per extension
+		}
+
+		// Find the .raw asset matching the exact arch+fedoraVersion suffix and SHA256SUMS.
+		assetSuffix := "-" + relFedoraVer + "-" + relArch + ".raw"
+		var downloadURL, sha256sumsURL string
+		for _, asset := range rel.Assets {
+			switch {
+			case asset.Name == "SHA256SUMS":
+				sha256sumsURL = asset.BrowserDownloadURL
+			case strings.HasSuffix(asset.Name, assetSuffix):
+				if downloadURL == "" {
+					downloadURL = asset.BrowserDownloadURL
+				}
+			}
+		}
+		if downloadURL == "" {
+			continue
+		}
+		if len(downloadURL) > maxSysextURLLen {
+			continue
+		}
+		if sha256sumsURL != "" && len(sha256sumsURL) > maxSysextURLLen {
+			sha256sumsURL = ""
+		}
+		if validate.SysextName(name) != nil {
+			continue
+		}
+
+		// Fetch SHA256 hash for the asset (best-effort; soft-fail).
+		sha256Hash := ""
+		if sha256sumsURL != "" {
+			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
+			if h, err := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); err == nil {
+				sha256Hash = h
+			}
+		}
+
+		description := truncateDescription(rel.Body, 80)
+		category := ""
+		supportTier := ""
+
+		if meta, ok := LookupFCOS(name); ok {
+			if meta.Short != "" {
+				description = meta.Short
+			}
+			category = meta.Category
+			supportTier = meta.SupportTier
+		} else {
+			category = "Community"
+		}
+
+		seen[name] = true
+		sysexts = append(sysexts, model.SysextEntry{
+			Name:        name,
+			Description: description,
+			Version:     version,
+			URL:         downloadURL,
+			Sha256:      sha256Hash,
+			Category:    category,
+			SupportTier: supportTier,
+			Selected:    false,
+		})
+	}
+
+	return sysexts, nil
+}

--- a/internal/bakery/fcos_catalog_test.go
+++ b/internal/bakery/fcos_catalog_test.go
@@ -1,0 +1,328 @@
+package bakery_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/bakery"
+)
+
+// --- ParseFCOSTagName tests ---
+
+func TestParseFCOSTagName(t *testing.T) {
+	tests := []struct {
+		tag            string
+		wantName       string
+		wantVersion    string
+		wantFedoraVer  string
+		wantArch       string
+		wantErr        bool
+	}{
+		// Real community repo tag formats
+		{
+			tag: "tailscale-0-1.98.3-1-44-x86-64",
+			wantName: "tailscale", wantVersion: "0-1.98.3-1", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "docker-ce-3-29.5.3-1.fc44-44-x86-64",
+			wantName: "docker-ce", wantVersion: "3-29.5.3-1.fc44", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "vscode-1.123.0-1780481629.el8-44-arm64",
+			wantName: "vscode", wantVersion: "1.123.0-1780481629.el8", wantFedoraVer: "44", wantArch: "arm64",
+		},
+		{
+			tag: "vscodium-1.121.03429-el8-44-x86-64",
+			wantName: "vscodium", wantVersion: "1.121.03429-el8", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "dnclient-0.9.4-44-x86-64",
+			wantName: "dnclient", wantVersion: "0.9.4", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "nordvpn-gui-5.0.0-1-44-x86-64",
+			wantName: "nordvpn-gui", wantVersion: "5.0.0-1", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "microsoft-edge-148.0.3967.96-1-44-x86-64",
+			wantName: "microsoft-edge", wantVersion: "148.0.3967.96-1", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag: "openconnect-9.12.git.270.549fd2d-0.fc44-44-x86-64",
+			wantName: "openconnect", wantVersion: "9.12.git.270.549fd2d-0.fc44", wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		// Arm64 variant
+		{
+			tag: "tailscale-0-1.98.3-1-44-arm64",
+			wantName: "tailscale", wantVersion: "0-1.98.3-1", wantFedoraVer: "44", wantArch: "arm64",
+		},
+		// Index-only tags must return error
+		{tag: "tailscale", wantErr: true},
+		{tag: "latest", wantErr: true},
+		{tag: "docker-ce", wantErr: true},
+		{tag: "vscode", wantErr: true},
+		// Malformed: no arch suffix
+		{tag: "something-1.0-44", wantErr: true},
+		// Malformed: non-digit fedora version
+		{tag: "foo-1.0-rc1-x86-64", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.tag, func(t *testing.T) {
+			name, version, fedoraVer, arch, err := bakery.ParseFCOSTagName(tc.tag)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for tag %q, got name=%q ver=%q fed=%q arch=%q", tc.tag, name, version, fedoraVer, arch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for tag %q: %v", tc.tag, err)
+			}
+			if name != tc.wantName {
+				t.Errorf("name: got %q, want %q", name, tc.wantName)
+			}
+			if version != tc.wantVersion {
+				t.Errorf("version: got %q, want %q", version, tc.wantVersion)
+			}
+			if fedoraVer != tc.wantFedoraVer {
+				t.Errorf("fedoraVersion: got %q, want %q", fedoraVer, tc.wantFedoraVer)
+			}
+			if arch != tc.wantArch {
+				t.Errorf("arch: got %q, want %q", arch, tc.wantArch)
+			}
+		})
+	}
+}
+
+// --- FetchCatalogFCOS tests ---
+
+func fcosCatalogServer(t *testing.T, releases []map[string]any) *httptest.Server {
+	t.Helper()
+	body, _ := json.Marshal(releases)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestFetchCatalogFCOS_Basic(t *testing.T) {
+	releases := []map[string]any{
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body":     "Tailscale",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale-0-1.98.3-1-44-x86-64.raw"},
+				{"name": "SHA256SUMS", "browser_download_url": "https://example.com/SHA256SUMS"},
+			},
+		},
+		{
+			"tag_name": "docker-ce-3-29.5.3-1.fc44-44-x86-64",
+			"body":     "Docker CE",
+			"assets": []map[string]any{
+				{"name": "docker-ce-3-29.5.3-1.fc44-44-x86-64.raw", "browser_download_url": "https://example.com/docker-ce-3-29.5.3-1.fc44-44-x86-64.raw"},
+			},
+		},
+		// Arm64 entry — should be filtered out for amd64 request
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-arm64",
+			"body":     "Tailscale arm64",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-arm64.raw", "browser_download_url": "https://example.com/tailscale-0-1.98.3-1-44-arm64.raw"},
+			},
+		},
+		// Index-only tag — should be skipped
+		{
+			"tag_name": "tailscale",
+			"body":     "index",
+			"assets":   []map[string]any{},
+		},
+	}
+
+	srv := fcosCatalogServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
+	}
+	if entries[0].Name != "tailscale" {
+		t.Errorf("first entry: got %q, want %q", entries[0].Name, "tailscale")
+	}
+	if entries[1].Name != "docker-ce" {
+		t.Errorf("second entry: got %q, want %q", entries[1].Name, "docker-ce")
+	}
+}
+
+func TestFetchCatalogFCOS_Arm64(t *testing.T) {
+	releases := []map[string]any{
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-arm64",
+			"body":     "Tailscale arm64",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-arm64.raw", "browser_download_url": "https://example.com/tailscale-0-1.98.3-1-44-arm64.raw"},
+			},
+		},
+		// x86-64 entry — should be filtered out for arm64 request
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body":     "Tailscale x86-64",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale-0-1.98.3-1-44-x86-64.raw"},
+			},
+		},
+	}
+
+	srv := fcosCatalogServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "arm64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 arm64 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "tailscale" {
+		t.Errorf("expected tailscale, got %q", entries[0].Name)
+	}
+}
+
+func TestFetchCatalogFCOS_DeduplicatesByName(t *testing.T) {
+	// Same extension appears twice (different Fedora versions) — only the first (newest) should be kept.
+	releases := []map[string]any{
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body":     "Tailscale v1.98",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale-1.98.raw"},
+			},
+		},
+		{
+			"tag_name": "tailscale-0-1.97.0-1-44-x86-64",
+			"body":     "Tailscale v1.97 (older)",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.97.0-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale-1.97.raw"},
+			},
+		},
+	}
+
+	srv := fcosCatalogServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 deduplicated entry, got %d", len(entries))
+	}
+	if entries[0].Version != "0-1.98.3-1" {
+		t.Errorf("expected newest version, got %q", entries[0].Version)
+	}
+}
+
+func TestFetchCatalogFCOS_FedoraVersionFiltering(t *testing.T) {
+	releases := []map[string]any{
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body":     "for Fedora 44",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-x86-64.raw", "browser_download_url": "https://example.com/44.raw"},
+			},
+		},
+		{
+			"tag_name": "tailscale-0-1.98.3-1-43-x86-64",
+			"body":     "for Fedora 43",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-43-x86-64.raw", "browser_download_url": "https://example.com/43.raw"},
+			},
+		},
+	}
+
+	srv := fcosCatalogServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+
+	// Request Fedora 44 only
+	entries44, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries44) != 1 || entries44[0].URL != "https://example.com/44.raw" {
+		t.Fatalf("expected Fedora 44 entry, got %v", entries44)
+	}
+
+	// Request Fedora 43 only
+	entries43, err := client.FetchCatalogFCOS(context.Background(), "amd64", 43)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries43) != 1 || entries43[0].URL != "https://example.com/43.raw" {
+		t.Fatalf("expected Fedora 43 entry, got %v", entries43)
+	}
+
+	// fedoraVersion=0 disables version filtering — should return both
+	entriesAll, err := client.FetchCatalogFCOS(context.Background(), "amd64", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entriesAll) != 1 {
+		// Both have the same name → deduplication keeps first (44)
+		t.Fatalf("expected 1 deduplicated entry for version=0, got %d", len(entriesAll))
+	}
+}
+
+func TestFetchCatalogFCOS_InvalidArch(t *testing.T) {
+	client := bakery.NewHTTPClientWithURL("http://localhost:0")
+	_, err := client.FetchCatalogFCOS(context.Background(), "mips", 44)
+	if err == nil {
+		t.Fatal("expected error for unsupported arch")
+	}
+}
+
+func TestFetchCatalogFCOS_AppliesCuratedMetadata(t *testing.T) {
+	releases := []map[string]any{
+		{
+			"tag_name": "tailscale-0-1.98.3-1-44-x86-64",
+			"body":     "raw description",
+			"assets": []map[string]any{
+				{"name": "tailscale-0-1.98.3-1-44-x86-64.raw", "browser_download_url": "https://example.com/tailscale.raw"},
+			},
+		},
+	}
+
+	srv := fcosCatalogServer(t, releases)
+	defer srv.Close()
+
+	client := bakery.NewHTTPClientWithURL(srv.URL)
+	entries, err := client.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	// Curated metadata should override raw body
+	if entries[0].Description == "raw description" {
+		t.Error("expected curated description to override raw body")
+	}
+	if entries[0].Category == "" {
+		t.Error("expected non-empty category from curated metadata")
+	}
+}
+
+// Compile-time check: DispatchingClient implements Client (already present in dispatch_test.go,
+// but also verify HTTPClient and MockClient include FetchCatalogFCOS).
+var _ bakery.Client = (*bakery.MockClient)(nil)

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -1,0 +1,79 @@
+package bakery
+
+// Support tier constants for FCOS community sysexts.
+const (
+	// TierFCOSCommunity marks extensions published by the fedora-sysexts community project.
+	// These are community-maintained builds not directly associated with the Fedora or FCOS
+	// upstream teams.
+	TierFCOSCommunity = "FCOS Community"
+)
+
+// fcosCatalog is the curated metadata catalog for fedora-sysexts/community extensions.
+// When the community repo ships an extension not listed here, LookupFCOS returns ok=false
+// and the entry is displayed under "Community" with the raw GitHub release body.
+var fcosCatalog = map[string]ExtensionMeta{
+	"docker-ce": {
+		Category:    "Container Runtime",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Docker CE — community edition container engine for FCOS",
+		Long:        "Docker CE provides the full Docker container engine (daemon, CLI, containerd, runc) built for Fedora CoreOS. Enables running and managing OCI containers on FCOS nodes. Start the daemon with systemctl enable --now docker after provisioning.",
+		Caveats:     nil,
+	},
+	"tailscale": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Tailscale — zero-config WireGuard mesh VPN for FCOS nodes",
+		Long:        "Tailscale creates an encrypted WireGuard mesh network between nodes with no manual firewall rules or key exchange required. Ships tailscale, tailscaled, and a systemd service unit. Authenticate nodes with tailscale up after provisioning.",
+		Caveats:     nil,
+	},
+	"vscode": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Visual Studio Code — Microsoft's source code editor for FCOS",
+		Long:        "Visual Studio Code is a lightweight but powerful source code editor supporting debugging, syntax highlighting, intelligent code completion, and extensions. Ships the code binary. Intended for developer workstation use-cases on FCOS, not server deployments.",
+		Caveats:     []string{"Not intended for headless server deployments — requires a graphical environment or SSH X11 forwarding."},
+	},
+	"vscodium": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "VSCodium — community build of VS Code without Microsoft telemetry",
+		Long:        "VSCodium is a community-maintained binary distribution of Visual Studio Code built from the same MIT-licensed source but without Microsoft branding and telemetry. Ships the codium binary. Compatible with most VS Code extensions via the Open VSX Registry.",
+		Caveats:     []string{"Not intended for headless server deployments — requires a graphical environment or SSH X11 forwarding."},
+	},
+	"nordvpn-gui": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "NordVPN GUI — NordVPN Linux graphical client for FCOS",
+		Long:        "NordVPN GUI provides the official NordVPN Linux desktop client for connecting to NordVPN servers. Requires a NordVPN subscription. Ships the nordvpn GUI binary and supporting files.",
+		Caveats:     []string{"Requires a valid NordVPN subscription.", "Not intended for headless server deployments."},
+	},
+	"microsoft-edge": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Microsoft Edge — Chromium-based browser from Microsoft for FCOS",
+		Long:        "Microsoft Edge is Microsoft's Chromium-based web browser. Ships the microsoft-edge binary and supporting files for FCOS. Intended for developer workstation or kiosk use-cases.",
+		Caveats:     []string{"Not intended for headless server deployments — requires a graphical environment."},
+	},
+	"dnclient": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Defined Networking client — zero-trust overlay network for FCOS",
+		Long:        "dnclient is the Defined Networking overlay VPN client providing zero-trust networking between hosts. Ships the dnclient binary and a systemd service unit. Requires a Defined Networking account and enrolment token.",
+		Caveats:     []string{"Requires a Defined Networking account and enrolment token."},
+	},
+	"openconnect": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "OpenConnect — open-source VPN client for Cisco AnyConnect and others",
+		Long:        "OpenConnect is an open-source VPN client compatible with Cisco AnyConnect, Juniper, Pulse, and GlobalProtect servers. Ships the openconnect binary for FCOS. Typically invoked manually or via a wrapper script.",
+		Caveats:     nil,
+	},
+}
+
+// LookupFCOS returns curated metadata for the named FCOS community extension.
+// Returns the metadata and true if found; zero ExtensionMeta and false if not in catalog.
+// Unknown extensions should be displayed with Category "Community" and the raw release body.
+func LookupFCOS(name string) (ExtensionMeta, bool) {
+	meta, ok := fcosCatalog[name]
+	return meta, ok
+}

--- a/internal/demo/demo.go
+++ b/internal/demo/demo.go
@@ -95,6 +95,11 @@ func (b *Bakery) FetchCatalogArch(_ context.Context, _ string) ([]model.SysextEn
 	}, nil
 }
 
+// FetchCatalogFCOS returns the same demo sysexts for FCOS (ignores arch/fedoraVersion).
+func (b *Bakery) FetchCatalogFCOS(ctx context.Context, _ string, _ int) ([]model.SysextEntry, error) {
+	return b.FetchCatalogArch(ctx, "amd64")
+}
+
 // Installer simulates an installation with realistic progress messages and timing.
 type Installer struct{}
 

--- a/internal/fcos/streams.go
+++ b/internal/fcos/streams.go
@@ -1,0 +1,93 @@
+// Package fcos provides helpers for querying FCOS stream metadata.
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	streamBaseURL = "https://builds.coreos.fedoraproject.org/streams"
+	streamTimeout = 15 * time.Second
+)
+
+// streamJSON is the top-level structure of an FCOS stream JSON file.
+// https://builds.coreos.fedoraproject.org/streams/<stream>.json
+type streamJSON struct {
+	Architectures map[string]archData `json:"architectures"`
+}
+
+type archData struct {
+	Artifacts map[string]artifactData `json:"artifacts"`
+}
+
+type artifactData struct {
+	Release string `json:"release"`
+}
+
+var httpClient = &http.Client{Timeout: streamTimeout}
+
+// FetchStreamFedoraVersion fetches the FCOS stream JSON for the given stream name
+// (e.g. "stable", "testing", "next") and returns the Fedora major version number
+// embedded in the release string.
+//
+// The release string format is "<fedoraMajor>.<date>.<patch>.<build>" (e.g. "44.20260510.3.1"),
+// so the Fedora major version is the first dot-separated component.
+func FetchStreamFedoraVersion(ctx context.Context, stream string) (int, error) {
+	url := fmt.Sprintf("%s/%s.json", streamBaseURL, stream)
+	return FetchStreamFedoraVersionFromURL(ctx, url)
+}
+
+// FetchStreamFedoraVersionFromURL is the URL-addressable variant of FetchStreamFedoraVersion.
+// It is exported for testing with a local httptest server.
+func FetchStreamFedoraVersionFromURL(ctx context.Context, url string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetching stream JSON: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("stream returned HTTP %d", resp.StatusCode)
+	}
+
+	const maxSize = 2 << 20 // 2 MB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
+	if err != nil {
+		return 0, fmt.Errorf("reading response: %w", err)
+	}
+
+	var data streamJSON
+	if err := json.Unmarshal(body, &data); err != nil {
+		return 0, fmt.Errorf("parsing stream JSON: %w", err)
+	}
+
+	// Iterate over any architecture / artifact pair to extract the release string.
+	for _, arch := range data.Architectures {
+		for _, artifact := range arch.Artifacts {
+			if artifact.Release == "" {
+				continue
+			}
+			majorStr, _, _ := strings.Cut(artifact.Release, ".")
+			major, err := strconv.Atoi(majorStr)
+			if err == nil && major > 0 {
+				return major, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("no release version found in stream JSON")
+}

--- a/internal/fcos/streams_test.go
+++ b/internal/fcos/streams_test.go
@@ -1,0 +1,93 @@
+package fcos_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/fcos"
+)
+
+func serveFCOSStream(t *testing.T, release string) *httptest.Server {
+	t.Helper()
+	payload := map[string]any{
+		"architectures": map[string]any{
+			"x86_64": map[string]any{
+				"artifacts": map[string]any{
+					"metal": map[string]any{
+						"release": release,
+					},
+				},
+			},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestFetchStreamFedoraVersion(t *testing.T) {
+	srv := serveFCOSStream(t, "44.20260510.3.1")
+	defer srv.Close()
+
+	ver, err := fcos.FetchStreamFedoraVersionFromURL(context.Background(), srv.URL+"/streams/stable.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 44 {
+		t.Fatalf("expected fedora version 44, got %d", ver)
+	}
+}
+
+func TestFetchStreamFedoraVersion_41(t *testing.T) {
+	srv := serveFCOSStream(t, "41.20241109.3.0")
+	defer srv.Close()
+
+	ver, err := fcos.FetchStreamFedoraVersionFromURL(context.Background(), srv.URL+"/streams/testing.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != 41 {
+		t.Fatalf("expected fedora version 41, got %d", ver)
+	}
+}
+
+func TestFetchStreamFedoraVersion_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fcos.FetchStreamFedoraVersionFromURL(context.Background(), srv.URL+"/streams/bogus.json")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestFetchStreamFedoraVersion_EmptyArchitectures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"architectures":{}}`))
+	}))
+	defer srv.Close()
+
+	_, err := fcos.FetchStreamFedoraVersionFromURL(context.Background(), srv.URL+"/streams/stable.json")
+	if err == nil {
+		t.Fatal("expected error for empty architectures")
+	}
+}
+
+func TestFetchStreamFedoraVersion_ContextCancelled(t *testing.T) {
+	srv := serveFCOSStream(t, "44.20260510.3.1")
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := fcos.FetchStreamFedoraVersionFromURL(ctx, srv.URL+"/streams/stable.json")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/internal/headless/headless_351_coverage_test.go
+++ b/internal/headless/headless_351_coverage_test.go
@@ -133,3 +133,7 @@ func (m *mockBakeryClientForResolve) FetchCatalog(ctx context.Context) ([]model.
 func (m *mockBakeryClientForResolve) FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error) {
 	return m.entries, nil
 }
+
+func (m *mockBakeryClientForResolve) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	return m.entries, nil
+}

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -1228,6 +1228,11 @@ func (m *archCaptureMockClient) FetchCatalogArch(ctx context.Context, arch strin
 	return []model.SysextEntry{{Name: "docker", Version: "24.0", URL: "https://example.com/docker-arm64.raw"}}, nil
 }
 
+func (m *archCaptureMockClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	*m.capturedArch = arch
+	return nil, nil
+}
+
 func TestRun_DryRunSkipsReboot(t *testing.T) {
 	// DryRun=true with Reboot=true should NOT reboot.
 	cfg := &Config{

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
+	"github.com/projectbluefin/knuckle/internal/fcos"
 	"github.com/projectbluefin/knuckle/internal/ignition"
 	"github.com/projectbluefin/knuckle/internal/install"
 	"github.com/projectbluefin/knuckle/internal/model"
@@ -17,6 +18,9 @@ import (
 
 // fetchAllChannelsFn is a package-level hook so tests can inject a mock.
 var fetchAllChannelsFn = bakery.FetchAllChannels
+
+// fetchFCOSStreamVersionFn is a package-level hook so tests can inject a mock.
+var fetchFCOSStreamVersionFn = fcos.FetchStreamFedoraVersion
 
 // State holds the complete wizard state
 type State struct {
@@ -36,6 +40,11 @@ type State struct {
 
 	// Channel version info (fetched at startup)
 	Channels []bakery.ChannelInfo
+
+	// FCOSFedoraVersion is the Fedora major version for the selected FCOS stream.
+	// Populated by FetchSysexts when cfg.OS == model.OSFCOS.
+	// Zero means the version could not be determined (no version filtering applied).
+	FCOSFedoraVersion int
 
 	// System checks (populated at startup)
 	SystemChecks []SystemCheck
@@ -369,10 +378,27 @@ func (w *Wizard) runSystemChecks() {
 }
 
 // FetchSysexts loads the sysext catalog for the configured architecture.
+// For FCOS installs it first resolves the Fedora major version from the stream
+// JSON and stores it in State.FCOSFedoraVersion, then delegates to
+// FetchCatalogFCOS. For Flatcar installs it uses FetchCatalogArch.
 // If an NVIDIA GPU was detected during ProbeHardware, nvidia-runtime is
 // auto-selected and the default driver series is pre-configured.
 func (w *Wizard) FetchSysexts(ctx context.Context) error {
-	sysexts, err := w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	var sysexts []model.SysextEntry
+	var err error
+
+	if w.State.Config.OS == model.OSFCOS {
+		// Resolve the Fedora major version from the FCOS stream — soft-fail so that
+		// the catalog fetch still proceeds without version filtering if this fails.
+		fedVer, ferr := fetchFCOSStreamVersionFn(ctx, w.State.Config.Channel)
+		if ferr == nil {
+			w.State.FCOSFedoraVersion = fedVer
+		}
+		sysexts, err = w.Bakery.FetchCatalogFCOS(ctx, w.State.Config.Arch, w.State.FCOSFedoraVersion)
+	} else {
+		sysexts, err = w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
+	}
+
 	if err != nil {
 		return fmt.Errorf("fetching sysext catalog: %w", err)
 	}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -39,6 +39,10 @@ func (m *mockBakery) FetchCatalogArch(ctx context.Context, arch string) ([]model
 	return m.sysexts, m.err
 }
 
+func (m *mockBakery) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	return m.sysexts, m.err
+}
+
 type mockInstaller struct {
 	called bool
 	cfg    *model.InstallConfig


### PR DESCRIPTION
## Summary

Implements issue #641: FCOS sysext catalog client for `fedora-sysexts/community`.

## Sub-scopes implemented

### A — `internal/fcos/streams.go`
New package. `FetchStreamFedoraVersion(ctx, stream) (int, error)` fetches `https://builds.coreos.fedoraproject.org/streams/<stream>.json` and extracts the Fedora major version from the release string (e.g. `"44.20260510.3.1"` → `44`). Exports `FetchStreamFedoraVersionFromURL` for httptest testing.

### B — `ParseFCOSTagName` in `internal/bakery/fcos_catalog.go`
Parses `fedora-sysexts/community` release tag format `<name>-<version>-<fedoraVersion>-<arch>`. Handles hyphenated names (`docker-ce`, `nordvpn-gui`, `microsoft-edge`). Rejects index-only tags (no arch suffix) with a clear error.

### C+D — `FetchCatalogFCOS` on `HTTPClient`
- `const FCOSCatalogURL` → `fedora-sysexts/community` releases API
- `const maxFCOSCatalogPages = 20` (community repo has 1500+ releases; 20 pages covers all unique extension names)
- `NewFCOSHTTPClient()` convenience constructor
- `FetchCatalogFCOS(ctx, arch, fedoraVersion)`:
  - arch mapping (`amd64` → `x86-64`, `arm64` → `arm64`)
  - per-Fedora-version filtering (`fedoraVersion=0` disables)
  - deduplication by name (newest wins; API returns newest-first)
  - SHA256 hash fetch (best-effort, soft-fail)
  - curated metadata overlay from `fcos_descriptions.go`

### E — `internal/bakery/fcos_descriptions.go`
Curated `ExtensionMeta` for 8 common FCOS community extensions: `docker-ce`, `tailscale`, `vscode`, `vscodium`, `nordvpn-gui`, `microsoft-edge`, `dnclient`, `openconnect`. New `TierFCOSCommunity` tier constant.

## Interface/wiring changes

- `bakery.Client` gains `FetchCatalogFCOS(ctx, arch, fedoraVersion)`
- `DispatchingClient` implements it (delegates to FCOS client)
- `MockClient` and `demo.Bakery` implement it
- `main.go` wires `DispatchingClient{Flatcar: NewHTTPClient(), FCOS: NewFCOSHTTPClient()}`
- `wizard.FetchSysexts` dispatches to `FetchCatalogFCOS` for FCOS, calling `FetchStreamFedoraVersion` first to populate `State.FCOSFedoraVersion`
- `wizard.State` gains `FCOSFedoraVersion int` field

## Tests

- `internal/fcos/streams_test.go`: httptest server, 404, empty arch, cancelled context
- `internal/bakery/fcos_catalog_test.go`: `ParseFCOSTagName` table tests for all real tag formats; `FetchCatalogFCOS` arch filtering, dedup, Fedora version filtering, invalid arch, curated metadata

All 18 packages pass `go test ./...` and `go vet ./...`.

Closes #641
