### PR TITLE
feat(headless): add os field, FCOS stream validation, NvidiaDriverVersion guard

### DIFF
--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -69,6 +69,30 @@ This document is the authoritative reference for every field in that file.
 }
 ```
 
+### FCOS minimal install
+
+```json
+{
+  "os": "fcos",
+  "channel": "stable",
+  "hostname": "fcos-node",
+  "disk": "/dev/sda",
+  "network": { "mode": "dhcp" },
+  "users": [
+    {
+      "username": "core",
+      "ssh_keys": ["ssh-ed25519 AAAA... you@host"]
+    }
+  ]
+}
+```
+
+> **FCOS limitations**
+> - `version`: ignored — `coreos-installer` always installs the latest stream build
+> - `nvidia_driver_version`: not supported on FCOS (validation error)
+> - `update_strategy`: has no effect — use zincati configuration in a custom Ignition config
+> - `update_strategy: etcd-lock` is Flatcar-specific and unavailable on FCOS
+
 ---
 
 ## Full field reference
@@ -77,17 +101,18 @@ This document is the authoritative reference for every field in that file.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `channel` | string | no | `"stable"` | Flatcar release channel. One of `stable`, `beta`, `alpha`, `lts`, `edge`. |
-| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. |
+| `os` | string | no | `"flatcar"` | Target OS. One of `flatcar`, `fcos`. Selects the installer and available channels. |
+| `channel` | string | no | `"stable"` | Release channel. For Flatcar: `stable`, `beta`, `alpha`, `lts`, `edge`. For FCOS: `stable`, `testing`, `next`. |
+| `version` | string | no | _(latest)_ | Pin to a specific Flatcar version, e.g. `"3510.2.8"`. Omit to use the latest for the channel. **Ignored for FCOS** — `coreos-installer` always installs the latest stream build; a warning is logged. |
 | `hostname` | string | yes | — | Machine hostname. Must be a valid RFC 1123 hostname label. |
 | `disk` | string | yes* | — | Target disk path. Use a stable `/dev/disk/by-id/...` path in production. `*` Not required when `ignition_url` is set. |
 | `network` | object | yes | — | See [Network](#network). |
 | `users` | array | yes* | — | One or more user accounts. `*` Not required when `ignition_url` is set. |
-| `update_strategy` | string | no | `"reboot"` | Flatcar update strategy. One of `reboot`, `off`, `etcd-lock`. |
-| `arch` | string | no | `"amd64"` | CPU architecture. One of `amd64`, `arm64`. `arm64` is not available on the `lts` channel. |
+| `update_strategy` | string | no | `"reboot"` | Flatcar update strategy. One of `reboot`, `off`, `etcd-lock`. **Not applicable for FCOS** (use zincati config in Ignition). |
+| `arch` | string | no | `"amd64"` | CPU architecture. One of `amd64`, `arm64`. `arm64` is not available on the Flatcar `lts` channel. |
 | `timezone` | string | no | `"UTC"` | System timezone (IANA format, e.g. `"America/New_York"`). |
 | `sysexts` | string[] | no | `[]` | List of system extension names from the bakery catalog (e.g. `["docker", "kubernetes"]`). |
-| `nvidia_driver_version` | string | no | _(none)_ | NVIDIA kernel driver series. One of `570-open` (default/recommended), `550-open`, `535-open`, `460`. Omit to skip NVIDIA setup. |
+| `nvidia_driver_version` | string | no | _(none)_ | NVIDIA kernel driver series. One of `570-open` (default/recommended), `550-open`, `535-open`, `460`. Omit to skip NVIDIA setup. **Not supported for FCOS.** |
 | `tailscale` | object | no | — | See [Tailscale](#tailscale). Omit or leave `auth_key` blank to skip. |
 | `swap` | object | no | _(enabled, 4 GiB)_ | See [Swap](#swap). Omit for the default (4 GiB enabled). |
 | `ignition_url` | string | no | — | URL of an external Ignition config. When set, knuckle downloads this config instead of generating one — only `disk` is then required. Must be HTTPS. |
@@ -229,8 +254,9 @@ The URL must be HTTPS and reachable from the installer environment.
 
 Knuckle validates the config before touching the disk. Key rules:
 
-- `channel` must be one of `stable`, `beta`, `alpha`, `lts`, `edge`
-- `version`, if set, must match `X.Y.Z` (all numeric components)
+- `os` must be `flatcar` or `fcos` (defaults to `flatcar`)
+- `channel` must be one of `stable`, `beta`, `alpha`, `lts`, `edge` (Flatcar) or `stable`, `testing`, `next` (FCOS)
+- `version`, if set, must match `X.Y.Z` (all numeric components); ignored with a warning for FCOS
 - `hostname` must be a valid RFC 1123 hostname label (no dots; max 63 chars)
 - `disk` must start with `/dev/` and not contain `..` path traversal
 - Static network: `interface`, `address` (CIDR), and `gateway` are all required
@@ -238,10 +264,11 @@ Knuckle validates the config before touching the disk. Key rules:
 - Each user needs a valid POSIX username and at least one auth method
 - `password` must be a valid crypt hash (not plaintext)
 - `update_strategy` must be `reboot`, `off`, or `etcd-lock`
-- `nvidia_driver_version` must be one of `570-open`, `550-open`, `535-open`, `460`
+- `nvidia_driver_version` must be one of `570-open`, `550-open`, `535-open`, `460`; **not allowed for FCOS**
 - `swap.size_mb` must be between 0 and 32768 (MiB)
 - `tailscale.auth_key` must begin with `tskey-auth-`
 - `ignition_url` must be an HTTPS URL
+- `arch: arm64` is not available on the Flatcar `lts` channel
 
 ---
 

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -246,9 +246,18 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Version
-	if err := validate.FlatcarVersion(c.Version); err != nil {
-		return fmt.Errorf("version: %w", err)
+	// Version: Flatcar supports version pinning; FCOS does not (coreos-installer has no
+	// equivalent flag). For FCOS, skip version validation — Run() will log a warning
+	// if the caller supplied a non-empty version.
+	if c.OS != model.OSFCOS {
+		if err := validate.FlatcarVersion(c.Version); err != nil {
+			return fmt.Errorf("version: %w", err)
+		}
+	}
+
+	// NvidiaDriverVersion is not supported on FCOS
+	if c.OS == model.OSFCOS && c.NvidiaDriverVersion != "" {
+		return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
 	}
 
 	// Hostname
@@ -417,6 +426,13 @@ func Run(ctx context.Context, cfg *Config, installer install.Installer, logger *
 	fmt.Println("→ Validating configuration...")
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
+	}
+	// FCOS does not support version pinning — coreos-installer always installs the
+	// latest build for the stream. Warn if the caller supplied a version string.
+	if cfg.OS == model.OSFCOS && cfg.Version != "" {
+		logger.Warn("version field ignored for FCOS: coreos-installer does not support version pinning",
+			"version", cfg.Version)
+		fmt.Printf("  ⚠ version %q ignored — FCOS does not support version pinning\n", cfg.Version)
 	}
 	if cfg.Disk != "" && !cfg.DryRun {
 		if err := validateBlockDeviceFunc(cfg.Disk); err != nil {

--- a/internal/headless/headless_test.go
+++ b/internal/headless/headless_test.go
@@ -1867,3 +1867,92 @@ func TestRun_ConsistencyCheckFails(t *testing.T) {
 		t.Error("installer should not be called after consistency failure")
 	}
 }
+
+// --- FCOS validation tests ---
+
+func TestValidate_FCOS_NvidiaDriverVersion_Rejected(t *testing.T) {
+cfg := &Config{
+OS:                  "fcos",
+Channel:             "stable",
+Hostname:            "fcos-node",
+Network:             NetworkConfig{Mode: "dhcp"},
+Users:               []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+Disk:                "/dev/vda",
+NvidiaDriverVersion: "570-open",
+}
+err := cfg.Validate()
+if err == nil {
+t.Fatal("expected error: nvidia_driver_version should be rejected for FCOS")
+}
+if !strings.Contains(err.Error(), "nvidia_driver_version") {
+t.Errorf("error should mention nvidia_driver_version, got: %v", err)
+}
+if !strings.Contains(err.Error(), "FCOS") {
+t.Errorf("error should mention FCOS, got: %v", err)
+}
+}
+
+func TestValidate_FCOS_Version_NoError(t *testing.T) {
+// FCOS ignores the version field — no validation error should be returned.
+cfg := &Config{
+OS:             "fcos",
+Channel:        "stable",
+Hostname:       "fcos-node",
+Network:        NetworkConfig{Mode: "dhcp"},
+Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+Disk:           "/dev/vda",
+Version:        "9.9.9",
+UpdateStrategy: "reboot",
+}
+if err := cfg.Validate(); err != nil {
+t.Errorf("unexpected error for FCOS config with version field: %v", err)
+}
+}
+
+func TestValidate_FCOS_Channel_Valid(t *testing.T) {
+for _, ch := range []string{"stable", "testing", "next"} {
+cfg := &Config{
+OS:             "fcos",
+Channel:        ch,
+Hostname:       "fcos-node",
+Network:        NetworkConfig{Mode: "dhcp"},
+Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+Disk:           "/dev/vda",
+UpdateStrategy: "reboot",
+}
+if err := cfg.Validate(); err != nil {
+t.Errorf("channel %q: unexpected error: %v", ch, err)
+}
+}
+}
+
+func TestRun_FCOS_VersionWarning(t *testing.T) {
+// Run should succeed and log a warning when FCOS config has a version field set.
+catalog := []model.SysextEntry{}
+defer mockBakery(catalog, nil)()
+
+cfg := &Config{
+OS:             "fcos",
+Channel:        "stable",
+Hostname:       "fcos-node",
+Network:        NetworkConfig{Mode: "dhcp"},
+Users:          []UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAAC3Nz test@test"}}},
+Disk:           "/dev/vda",
+Version:        "44.1.0",
+UpdateStrategy: "reboot",
+DryRun:         true,
+}
+
+installer := &mockInstaller{}
+// Capture log output to verify warning is emitted
+var logBuf strings.Builder
+logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+if err := Run(context.Background(), cfg, installer, logger); err != nil {
+t.Fatalf("Run: unexpected error: %v", err)
+}
+logOutput := logBuf.String()
+if !strings.Contains(logOutput, "version") {
+t.Errorf("expected log warning about version field, got: %q", logOutput)
+}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -291,6 +291,11 @@ func CheckConsistency(cfg *model.InstallConfig) error {
 		return fmt.Errorf("no channel selected")
 	}
 
+	// NVIDIA is not supported on FCOS
+	if cfg.OS == model.OSFCOS && cfg.NvidiaDriverVersion != "" {
+		return fmt.Errorf("nvidia_driver_version: not supported on FCOS")
+	}
+
 	// NVIDIA driver version must be a known series if set
 	if cfg.NvidiaDriverVersion != "" {
 		valid := false


### PR DESCRIPTION
## Summary

Implements the final pieces of FCOS headless support from issue #642.

### Changes

**`internal/headless/headless.go`**
- `Validate()`: guard `validate.FlatcarVersion()` — skipped for FCOS; FCOS + `nvidia_driver_version` now returns an explicit validation error
- `Run()`: log a `Warn` and print a notice when `version` is set on an FCOS config (field silently ignored at install time)

**`internal/validate/validate.go`**
- `CheckConsistency()`: reject `nvidia_driver_version != ""` when `cfg.OS == model.OSFCOS`

**`docs/HEADLESS-CONFIG.md`**
- Added `os` field to the field reference table
- Updated `channel` description for both Flatcar and FCOS channels
- Annotated `version` and `nvidia_driver_version` rows with FCOS caveats
- Added FCOS minimal quick-start example with limitations callout
- Updated validation rules section with OS-aware rules

**`internal/headless/headless_test.go`**
- `TestValidate_FCOS_NvidiaDriverVersion_Rejected`: FCOS + nvidia → validation error
- `TestValidate_FCOS_Version_NoError`: FCOS + version set → no error
- `TestValidate_FCOS_Channel_Valid`: stable/testing/next all pass for FCOS
- `TestRun_FCOS_VersionWarning`: Run() emits a log warning for FCOS + version

Closes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FCOS (Fedora CoreOS) support as a configuration option alongside Flatcar.
  * Introduced new `os` field to specify operating system type.

* **Documentation**
  * Added FCOS quick-start guide with example configuration.
  * Documented FCOS-specific field limitations and unsupported features.

* **Improvements**
  * Enhanced validation to enforce FCOS field constraints and compatibility rules.
  * Users now receive warnings when specifying unsupported fields with FCOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->