### PR TITLE
feat(iso): FCOS live ISO build via coreos-installer iso customize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,14 @@ jobs:
       - name: install ISO build dependencies
         run: sudo apt-get update && sudo apt-get install -y xorriso mtools cpio systemd-boot-efi
 
+      - name: install coreos-installer
+        run: |
+          curl -fsSL --retry 3 \
+            https://github.com/coreos/coreos-installer/releases/latest/download/coreos-installer_amd64 \
+            -o /usr/local/bin/coreos-installer
+          chmod +x /usr/local/bin/coreos-installer
+          coreos-installer --version
+
       - name: build installer ISO (amd64, stable)
         run: |
           chmod +x ./scripts/build-iso.sh

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,11 @@ default:
     @echo "  just hardware-repro — boot installer ISO in a hardware-like VM and capture install logs"
     @echo "  just e2e       — full end-to-end: build ISO → boot → install → verify"
     @echo ""
+    @echo "FCOS:"
+    @echo "  just tools-fcos          — install coreos-installer"
+    @echo "  just build-fcos-iso      — build FCOS live ISO (stable, amd64)"
+    @echo "  just build-fcos-iso arch=arm64 stream=testing"
+    @echo ""
     @echo "Pre-release (requires network):"
     @echo "  just catalog-check       — report new bakery extensions missing descriptions"
     @echo "  just nvidia-check        — verify NVIDIA driver series vs Flatcar docs"
@@ -809,6 +814,31 @@ e2e:
 # KNUCKLE_ARCH=arm64 just iso  — builds arm64 ISO
 iso *CHANNEL='stable':
     ./scripts/build-iso.sh --channel {{CHANNEL}} --arch {{KNUCKLE_ARCH}}
+
+# Check that coreos-installer is installed (required for FCOS ISO builds)
+check-fcos-tools:
+    @which coreos-installer || (echo "coreos-installer not found — run: just tools-fcos" && exit 1)
+
+# Install coreos-installer static binary to /usr/local/bin (idempotent)
+tools-fcos:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v coreos-installer &>/dev/null; then
+        echo "coreos-installer already installed: $(coreos-installer --version)"
+        exit 0
+    fi
+    echo "Installing coreos-installer..."
+    curl -L https://github.com/coreos/coreos-installer/releases/latest/download/coreos-installer_amd64 \
+        -o /usr/local/bin/coreos-installer
+    chmod +x /usr/local/bin/coreos-installer
+    coreos-installer --version
+    echo "tools-fcos ok"
+
+# Build FCOS installer ISO (requires coreos-installer — run: just tools-fcos)
+# Produces output/knuckle-fcos-installer-<stream>-<arch>.iso
+# Override stream/arch: just build-fcos-iso arch="arm64" stream="testing"
+build-fcos-iso arch="amd64" stream="stable": check-fcos-tools
+    ./scripts/build-fcos-iso.sh --arch {{arch}} --stream {{stream}}
 
 # Boot ISO in QEMU with UEFI (Ctrl-a x to quit)
 # KNUCKLE_ARCH=arm64 just boot-iso  — boots arm64 ISO (requires qemu-system-aarch64)

--- a/internal/iso/iso.go
+++ b/internal/iso/iso.go
@@ -1,5 +1,6 @@
 // Package iso generates Ignition configs and helpers for building
-// self-contained Flatcar installer disk images with knuckle embedded.
+// self-contained installer disk images with knuckle embedded.
+// Supports both Flatcar Container Linux and Fedora CoreOS (FCOS).
 package iso
 
 import "encoding/json"
@@ -34,8 +35,10 @@ type user struct {
 	SSHAuthorizedKeys []string `json:"sshAuthorizedKeys,omitempty"`
 }
 
-// knuckleServiceUnit is the systemd unit that launches knuckle on tty1.
-const knuckleServiceUnit = `[Unit]
+// knuckleServiceUnitFlatcar is the systemd unit that launches knuckle on
+// Flatcar live images. Flatcar live does not autologin on tty1, so no
+// conflict directives are needed.
+const knuckleServiceUnitFlatcar = `[Unit]
 Description=Knuckle Flatcar Installer
 After=multi-user.target
 ConditionPathExists=/opt/knuckle
@@ -54,13 +57,48 @@ RestartSec=2
 [Install]
 WantedBy=multi-user.target`
 
+// knuckleServiceUnitFCOS is the systemd unit that launches knuckle on FCOS
+// live images. FCOS runs getty@tty1.service with autologin for the "core"
+// user by default, so we declare a conflict to prevent both services from
+// fighting over tty1.
+const knuckleServiceUnitFCOS = `[Unit]
+Description=Knuckle FCOS Installer
+After=multi-user.target
+Conflicts=getty@tty1.service
+Before=getty@tty1.service
+ConditionPathExists=/opt/knuckle
+
+[Service]
+Type=idle
+ExecStart=/opt/knuckle
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target`
+
 // GenerateInstallerIgnition creates Ignition JSON for the installer image.
-// The knuckle binary must be placed at /opt/knuckle on the filesystem
-// (via virt-customize or equivalent) before booting with this config.
+// The knuckle binary must be placed at /opt/knuckle on the filesystem before
+// booting with this config (via squashfs overlay for Flatcar, or an Ignition
+// storage.files entry for FCOS).
+//
+// os selects the OS-specific service unit body: "fcos" picks the FCOS unit
+// (which includes Conflicts/Before for getty@tty1.service); any other value
+// (including "flatcar" or "") picks the Flatcar unit.
 //
 // If sshPubKey is non-empty, it is added to the "core" user for debug access.
-func GenerateInstallerIgnition(sshPubKey string) ([]byte, error) {
+func GenerateInstallerIgnition(os, sshPubKey string) ([]byte, error) {
 	enabled := true
+
+	serviceUnit := knuckleServiceUnitFlatcar
+	if os == "fcos" {
+		serviceUnit = knuckleServiceUnitFCOS
+	}
 
 	cfg := ignitionConfig{
 		Ignition: ignitionMeta{Version: "3.3.0"},
@@ -70,7 +108,7 @@ func GenerateInstallerIgnition(sshPubKey string) ([]byte, error) {
 				{
 					Name:     "knuckle-installer.service",
 					Enabled:  &enabled,
-					Contents: knuckleServiceUnit,
+					Contents: serviceUnit,
 				},
 			},
 		},

--- a/internal/iso/iso_bench_test.go
+++ b/internal/iso/iso_bench_test.go
@@ -9,7 +9,7 @@ func BenchmarkGenerateInstallerIgnition(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := GenerateInstallerIgnition(sshKey)
+		_, err := GenerateInstallerIgnition("flatcar", sshKey)
 		if err != nil {
 			b.Fatalf("GenerateInstallerIgnition() error: %v", err)
 		}
@@ -19,7 +19,17 @@ func BenchmarkGenerateInstallerIgnition(b *testing.B) {
 func BenchmarkGenerateInstallerIgnitionNoSSH(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := GenerateInstallerIgnition("")
+		_, err := GenerateInstallerIgnition("flatcar", "")
+		if err != nil {
+			b.Fatalf("GenerateInstallerIgnition() error: %v", err)
+		}
+	}
+}
+
+func BenchmarkGenerateInstallerIgnitionFCOS(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := GenerateInstallerIgnition("fcos", "")
 		if err != nil {
 			b.Fatalf("GenerateInstallerIgnition() error: %v", err)
 		}

--- a/internal/iso/iso_test.go
+++ b/internal/iso/iso_test.go
@@ -2,12 +2,13 @@ package iso
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
 func TestGenerateInstallerIgnition(t *testing.T) {
-	t.Run("without SSH key", func(t *testing.T) {
-		data, err := GenerateInstallerIgnition("")
+	t.Run("flatcar without SSH key", func(t *testing.T) {
+		data, err := GenerateInstallerIgnition("flatcar", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -46,15 +47,20 @@ func TestGenerateInstallerIgnition(t *testing.T) {
 			t.Error("knuckle unit has no contents")
 		}
 
+		// Flatcar unit must NOT have tty1 conflict directives
+		if strings.Contains(contents, "Conflicts=getty@tty1.service") {
+			t.Error("flatcar unit must not contain Conflicts=getty@tty1.service")
+		}
+
 		// No passwd section when no SSH key
 		if _, exists := raw["passwd"]; exists {
 			t.Error("passwd should be omitted when no SSH key provided")
 		}
 	})
 
-	t.Run("with SSH key", func(t *testing.T) {
+	t.Run("flatcar with SSH key", func(t *testing.T) {
 		key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 test@example.com"
-		data, err := GenerateInstallerIgnition(key)
+		data, err := GenerateInstallerIgnition("flatcar", key)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,8 +88,87 @@ func TestGenerateInstallerIgnition(t *testing.T) {
 		}
 	})
 
-	t.Run("output is valid JSON", func(t *testing.T) {
-		data, err := GenerateInstallerIgnition("ssh-rsa AAAA foo@bar")
+	t.Run("flatcar output is valid JSON", func(t *testing.T) {
+		data, err := GenerateInstallerIgnition("flatcar", "ssh-rsa AAAA foo@bar")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !json.Valid(data) {
+			t.Error("output is not valid JSON")
+		}
+	})
+
+	t.Run("empty os defaults to flatcar unit", func(t *testing.T) {
+		data, err := GenerateInstallerIgnition("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		systemd := raw["systemd"].(map[string]any)
+		units := systemd["units"].([]any)
+		knuckleUnit := units[1].(map[string]any)
+		contents := knuckleUnit["contents"].(string)
+		if strings.Contains(contents, "Conflicts=getty@tty1.service") {
+			t.Error("default (empty os) unit must not contain Conflicts=getty@tty1.service")
+		}
+	})
+
+	t.Run("fcos unit has tty1 conflict directives", func(t *testing.T) {
+		data, err := GenerateInstallerIgnition("fcos", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		systemd, ok := raw["systemd"].(map[string]any)
+		if !ok {
+			t.Fatal("missing systemd key")
+		}
+		units := systemd["units"].([]any)
+		knuckleUnit := units[1].(map[string]any)
+		contents, ok := knuckleUnit["contents"].(string)
+		if !ok || contents == "" {
+			t.Error("fcos knuckle unit has no contents")
+		}
+		if !strings.Contains(contents, "Conflicts=getty@tty1.service") {
+			t.Error("fcos unit must contain Conflicts=getty@tty1.service")
+		}
+		if !strings.Contains(contents, "Before=getty@tty1.service") {
+			t.Error("fcos unit must contain Before=getty@tty1.service")
+		}
+	})
+
+	t.Run("fcos with SSH key", func(t *testing.T) {
+		key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGdllynsgXbmcFXhVJAIAkDbYjqZ2OgHgZJVFmFKtvF7 fcos@test"
+		data, err := GenerateInstallerIgnition("fcos", key)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		passwd, ok := raw["passwd"].(map[string]any)
+		if !ok {
+			t.Fatal("missing passwd when SSH key provided for fcos")
+		}
+		users := passwd["users"].([]any)
+		u := users[0].(map[string]any)
+		keys := u["sshAuthorizedKeys"].([]any)
+		if len(keys) != 1 || keys[0] != key {
+			t.Errorf("sshAuthorizedKeys = %v, want [%s]", keys, key)
+		}
+	})
+
+	t.Run("fcos output is valid JSON", func(t *testing.T) {
+		data, err := GenerateInstallerIgnition("fcos", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/scripts/build-fcos-iso.sh
+++ b/scripts/build-fcos-iso.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Build a bootable FCOS live ISO containing the knuckle installer.
+#
+# Uses coreos-installer to:
+#  1. Download the FCOS live ISO for the target stream + architecture
+#  2. Customise the live image: inject the knuckle binary (as a base64 Ignition
+#     file) and enable the knuckle-installer systemd service via --live-ignition
+#
+# The resulting ISO boots directly into a live FCOS environment where knuckle
+# runs on tty1.  The Conflicts=getty@tty1.service directive in the service unit
+# prevents the default FCOS autologin getty from competing with the TUI.
+#
+# Requirements: coreos-installer, jq (optional — for ignition pretty-print)
+#   Install: curl -L https://github.com/coreos/coreos-installer/releases/latest/download/coreos-installer_amd64 \
+#              -o /usr/local/bin/coreos-installer && chmod +x /usr/local/bin/coreos-installer
+#
+# Usage: ./scripts/build-fcos-iso.sh [--stream stable|testing|next] [--arch amd64|arm64] [--binary /path/to/knuckle] [--ssh-key "ssh-ed25519 ..."]
+set -euo pipefail
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+STREAM="stable"
+ARCH="amd64"
+BINARY_OVERRIDE=""
+SSH_PUB_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --stream=*) STREAM="${1#--stream=}"; shift ;;
+        --stream)   STREAM="$2"; shift 2 ;;
+        --arch=*)   ARCH="${1#--arch=}"; shift ;;
+        --arch)     ARCH="$2"; shift 2 ;;
+        --binary=*) BINARY_OVERRIDE="${1#--binary=}"; shift ;;
+        --binary)   BINARY_OVERRIDE="$2"; shift 2 ;;
+        --ssh-key=*) SSH_PUB_KEY="${1#--ssh-key=}"; shift ;;
+        --ssh-key)  SSH_PUB_KEY="$2"; shift 2 ;;
+        stable|testing|next) STREAM="$1"; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Validate arguments ───────────────────────────────────────────────────────
+case "$STREAM" in
+    stable|testing|next) ;;
+    *) echo "error: --stream must be stable, testing, or next (got '$STREAM')" >&2; exit 1 ;;
+esac
+case "$ARCH" in
+    amd64|arm64) ;;
+    *) echo "error: --arch must be amd64 or arm64 (got '$ARCH')" >&2; exit 1 ;;
+esac
+
+# coreos-installer uses "x86_64" and "aarch64" internally
+case "$ARCH" in
+    amd64)  COREOS_ARCH="x86_64" ;;
+    arm64)  COREOS_ARCH="aarch64" ;;
+esac
+
+# ── Dependency check ─────────────────────────────────────────────────────────
+if ! command -v coreos-installer &>/dev/null; then
+    echo "error: coreos-installer not found" >&2
+    echo "  Install: curl -L https://github.com/coreos/coreos-installer/releases/latest/download/coreos-installer_amd64 \\" >&2
+    echo "             -o /usr/local/bin/coreos-installer && chmod +x /usr/local/bin/coreos-installer" >&2
+    echo "  Or run:  just tools-fcos" >&2
+    exit 1
+fi
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/.fcos-iso-build"
+OUTPUT_DIR="$ROOT_DIR/output"
+
+BINARY=""
+if [[ -n "$BINARY_OVERRIDE" ]]; then
+    BINARY="$BINARY_OVERRIDE"
+elif [[ -f "$ROOT_DIR/bin/knuckle-${ARCH}" ]]; then
+    BINARY="$ROOT_DIR/bin/knuckle-${ARCH}"
+elif [[ -f "$ROOT_DIR/bin/knuckle" ]]; then
+    BINARY="$ROOT_DIR/bin/knuckle"
+elif [[ -f "$ROOT_DIR/knuckle" ]]; then
+    BINARY="$ROOT_DIR/knuckle"
+fi
+
+echo "=== Building knuckle FCOS installer ISO (stream: $STREAM, arch: $ARCH) ==="
+
+# ── 1. Build knuckle binary ───────────────────────────────────────────────────
+if [[ ! -f "$BINARY" ]]; then
+    echo "[1/4] Building knuckle ($ARCH)..."
+    VERSION="$(git -C "$ROOT_DIR" describe --tags --always 2>/dev/null || echo dev)"
+    (cd "$ROOT_DIR" && GOOS=linux GOARCH="$ARCH" CGO_ENABLED=0 \
+        go build -ldflags="-s -w -X main.version=${VERSION}" -o "bin/knuckle-${ARCH}" ./cmd/knuckle)
+    BINARY="$ROOT_DIR/bin/knuckle-${ARCH}"
+else
+    echo "[1/4] Using existing knuckle binary: $BINARY"
+fi
+echo "  binary : $(du -h "$BINARY" | cut -f1)"
+
+# ── 2. Download FCOS live ISO ─────────────────────────────────────────────────
+mkdir -p "$BUILD_DIR"
+echo "[2/4] Downloading FCOS live ISO (stream: $STREAM, arch: $COREOS_ARCH)..."
+
+# coreos-installer download writes a versioned filename; find it after download.
+# Use a hash of stream+arch as a cache key — re-download if not present.
+ISO_CACHE_DIR="$BUILD_DIR/iso-cache-${STREAM}-${ARCH}"
+mkdir -p "$ISO_CACHE_DIR"
+
+LIVE_ISO=""
+# Check for a previously downloaded ISO
+EXISTING_ISO="$(ls "$ISO_CACHE_DIR"/*.iso 2>/dev/null | head -1 || true)"
+if [[ -n "$EXISTING_ISO" ]]; then
+    echo "  Using cached FCOS ISO: $(basename "$EXISTING_ISO")"
+    LIVE_ISO="$EXISTING_ISO"
+else
+    echo "  Fetching from builds.coreos.fedoraproject.org..."
+    coreos-installer download \
+        --stream "$STREAM" \
+        --platform metal \
+        --format iso \
+        --architecture "$COREOS_ARCH" \
+        --directory "$ISO_CACHE_DIR"
+    LIVE_ISO="$(ls "$ISO_CACHE_DIR"/*.iso | head -1)"
+    echo "  Downloaded: $(basename "$LIVE_ISO") ($(du -h "$LIVE_ISO" | cut -f1))"
+fi
+
+# ── 3. Generate live Ignition config ─────────────────────────────────────────
+# The Ignition config is applied in the LIVE FCOS environment (--live-ignition),
+# not on the installed system.  It:
+#   - Writes the knuckle binary to /opt/knuckle (base64-encoded)
+#   - Enables sshd for debug access
+#   - Installs + enables knuckle-installer.service (with tty1 conflict fix)
+echo "[3/4] Generating live Ignition config..."
+
+IGN_FILE="$BUILD_DIR/live-ignition.ign"
+
+# Encode the binary as a base64 data URL for the Ignition storage.files entry.
+BINARY_B64="$(base64 -w0 "$BINARY")"
+BINARY_SIZE="$(stat -c%s "$BINARY")"
+
+# Build passwd section if an SSH key was provided
+PASSWD_JSON="null"
+if [[ -n "$SSH_PUB_KEY" ]]; then
+    PASSWD_JSON="{\"users\":[{\"name\":\"core\",\"sshAuthorizedKeys\":[$(printf '%s' "$SSH_PUB_KEY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')]}"
+    PASSWD_JSON="${PASSWD_JSON}]}"
+fi
+
+# Write the Ignition 3.3.0 JSON.
+# The service unit includes Conflicts=getty@tty1.service because FCOS live
+# images autologin the "core" user on tty1 by default.
+python3 - "$IGN_FILE" "$BINARY_B64" "$BINARY_SIZE" "$PASSWD_JSON" <<'PYEOF'
+import json, sys, os
+
+ign_file   = sys.argv[1]
+binary_b64 = sys.argv[2]
+binary_size = int(sys.argv[3])
+passwd_raw  = sys.argv[4]
+
+service_unit = """\
+[Unit]
+Description=Knuckle FCOS Installer
+After=multi-user.target
+Conflicts=getty@tty1.service
+Before=getty@tty1.service
+ConditionPathExists=/opt/knuckle
+
+[Service]
+Type=idle
+ExecStart=/opt/knuckle
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target"""
+
+enabled = True
+
+config = {
+    "ignition": {"version": "3.3.0"},
+    "storage": {
+        "files": [
+            {
+                "path": "/opt/knuckle",
+                "mode": 0o755,
+                "contents": {
+                    "source": f"data:;base64,{binary_b64}",
+                    "verification": {}
+                }
+            }
+        ]
+    },
+    "systemd": {
+        "units": [
+            {"name": "sshd.service", "enabled": True},
+            {
+                "name": "knuckle-installer.service",
+                "enabled": True,
+                "contents": service_unit
+            }
+        ]
+    }
+}
+
+if passwd_raw != "null":
+    config["passwd"] = json.loads(passwd_raw)
+
+with open(ign_file, "w") as f:
+    json.dump(config, f, indent=2)
+
+print(f"  Ignition: {ign_file}")
+print(f"  binary size: {binary_size} bytes embedded")
+PYEOF
+
+# ── 4. Customize FCOS ISO ─────────────────────────────────────────────────────
+echo "[4/4] Customising FCOS live ISO with coreos-installer..."
+
+mkdir -p "$OUTPUT_DIR"
+ISO_OUT="$OUTPUT_DIR/knuckle-fcos-installer-${STREAM}-${ARCH}.iso"
+
+coreos-installer iso customize \
+    --live-ignition "$IGN_FILE" \
+    --output "$ISO_OUT" \
+    "$LIVE_ISO"
+
+echo ""
+echo "ISO built: $ISO_OUT ($(du -h "$ISO_OUT" | cut -f1))"
+echo ""
+echo "Test with QEMU (UEFI, amd64):"
+echo "  OVMF=/usr/share/OVMF/OVMF_CODE.fd"
+echo "  qemu-system-x86_64 -m 4096 -enable-kvm \\"
+echo "    -drive if=pflash,format=raw,readonly=on,file=\$OVMF \\"
+echo "    -cdrom $ISO_OUT \\"
+echo "    -drive if=virtio,file=target.qcow2,format=qcow2 \\"
+echo "    -nographic"
+echo ""
+echo "Write to USB:"
+echo "  sudo dd if=$ISO_OUT of=/dev/sdX bs=4M status=progress"


### PR DESCRIPTION
## Summary

Implements FCOS live ISO build support via `coreos-installer iso customize` (issue #644).

### Changes

**`internal/iso/iso.go`**
- Renamed `knuckleServiceUnit` → `knuckleServiceUnitFlatcar` (no behavior change for Flatcar)
- Added `knuckleServiceUnitFCOS`: identical service unit but with `Conflicts=getty@tty1.service` and `Before=getty@tty1.service` to prevent a tty1 fight with the FCOS live image's autologin getty
- Changed `GenerateInstallerIgnition(sshPubKey)` → `GenerateInstallerIgnition(os, sshPubKey)` — selects the appropriate unit body based on `os`; `""` or `"flatcar"` uses the Flatcar unit

**`scripts/build-fcos-iso.sh`** _(new)_
Four-step build script:
1. Build knuckle binary (or reuse existing)
2. Download FCOS live ISO via `coreos-installer download --stream <stream> --platform metal --format iso`
3. Generate a live Ignition 3.3.0 config embedding the knuckle binary as a base64 `storage.files` entry at `/opt/knuckle`, plus the FCOS service unit
4. `coreos-installer iso customize --live-ignition live-ignition.ign --output <out> fcos-live.iso`

Uses `--live-ignition` (not `--dest-ignition`) so the Ignition config runs in the LIVE FCOS environment — installing knuckle and starting its service — rather than on the post-install system.

**`Justfile`**
- `check-fcos-tools` — guard that errors with a hint if `coreos-installer` is not in `$PATH`
- `tools-fcos` — idempotent install of `coreos-installer` static binary to `/usr/local/bin`
- `build-fcos-iso arch="amd64" stream="stable"` — depends on `check-fcos-tools`, delegates to `build-fcos-iso.sh`
- Updated `default` target help to list the new FCOS recipes

**`.github/workflows/ci.yml`**
- Added `install coreos-installer` step to the `iso-boot-smoke` job (after `install ISO build dependencies`) so the tool is available for future FCOS ISO build steps

**`internal/iso/iso_test.go`**
- Updated all existing test cases for the new two-arg `GenerateInstallerIgnition(os, sshPubKey)` signature
- Added: flatcar unit must NOT have tty1 conflict directives; empty `os` defaults to Flatcar unit; FCOS unit has `Conflicts`/`Before`; FCOS SSH key handling; FCOS valid JSON

**`internal/iso/iso_bench_test.go`**
- Updated for new signature; added `BenchmarkGenerateInstallerIgnitionFCOS`

### Acceptance criteria

- [x] `coreos-installer` build dep documented and guarded in Justfile
- [x] CI workflow updated to install `coreos-installer` for ISO build jobs
- [x] `just build-fcos-iso` recipe exists (produces ISO via `build-fcos-iso.sh`)
- [x] tty1 conflict fix applied (`Conflicts=getty@tty1.service`)
- [x] `GenerateInstallerIgnition` is OS-aware (FCOS variant)
- [ ] ISO boots knuckle TUI on FCOS live environment (manual verification on ghost)

Closes #644