### PR TITLE
feat(tui): OS selection, FCOS-conditional steps, stream cards, Flatcar string cleanup

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -152,6 +152,11 @@ func main() {
 		if err := w.FetchChannels(ctx); err != nil {
 			logger.Warn("channel info fetch failed", "error", err)
 		}
+
+		// Fetch FCOS stream metadata (non-fatal; requires bakery FCOS client from #641)
+		if err := w.FetchFCOSStreams(ctx); err != nil {
+			logger.Warn("FCOS stream fetch failed", "error", err)
+		}
 	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -36,7 +36,11 @@ func (m *Model) initForm() {
 			m.usernameInput = "core"
 		}
 		if m.Wizard.State.Config.Hostname == "" {
-			m.Wizard.State.Config.Hostname = "flatcar"
+			if m.Wizard.State.Config.OS == model.OSFCOS {
+				m.Wizard.State.Config.Hostname = "fcos"
+			} else {
+				m.Wizard.State.Config.Hostname = "flatcar"
+			}
 		}
 		if m.Wizard.State.Config.Timezone == "" {
 			m.Wizard.State.Config.Timezone = "UTC"

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -366,6 +366,187 @@ func (m *Model) renderZenChrome() string {
 	return b.String()
 }
 
+// viewOSCards renders the OS selection cards (Flatcar Container Linux / Fedora CoreOS).
+// This is the first sub-view inside StepWelcome.
+func (m *Model) viewOSCards() string {
+	var b strings.Builder
+
+	selectedBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("51")).
+		Padding(0, 1).
+		Width(60)
+	normalBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Width(60)
+	nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+	nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+
+	type osOption struct {
+		id   string
+		name string
+		desc string
+	}
+	options := []osOption{
+		{
+			id:   "flatcar",
+			name: "Flatcar Container Linux",
+			desc: "Immutable, auto-updating Linux for containers. Official Flatcar release.",
+		},
+		{
+			id:   "fcos",
+			name: "Fedora CoreOS",
+			desc: "Automatically updating, minimal, container-focused OS from the Fedora Project.",
+		},
+	}
+
+	b.WriteString("  Select operating system:\n\n")
+
+	for i, opt := range options {
+		selected := i == m.cursor
+
+		var card strings.Builder
+		cursor := "  "
+		nameStyle := nameNormal
+		if selected {
+			cursor = cursorStyle.Render("▸ ")
+			nameStyle = nameSelected
+		}
+		card.WriteString(cursor + nameStyle.Render(opt.name))
+		card.WriteString("\n")
+		card.WriteString("  " + descStyle.Render(opt.desc))
+
+		if selected {
+			b.WriteString(selectedBorder.Render(card.String()))
+		} else {
+			b.WriteString(normalBorder.Render(card.String()))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	b.WriteString(dim.Render("  ↑↓/jk select · enter continue"))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// osCardCount returns the number of OS selection cards.
+func (m *Model) osCardCount() int { return 2 }
+
+// fcosStreamList returns the ordered FCOS stream names.
+func (m *Model) fcosStreamList() []string {
+	return []string{"stable", "testing", "next"}
+}
+
+// fcosStreamCount returns the number of FCOS stream cards.
+func (m *Model) fcosStreamCount() int {
+	return len(m.fcosStreamList())
+}
+
+// fcosStreamMeta holds display info for each FCOS stream card.
+type fcosStreamMeta struct {
+	name    string
+	version string
+	desc    string
+}
+
+// getFCOSStreamMeta builds display metadata for each FCOS stream.
+func (m *Model) getFCOSStreamMeta() []fcosStreamMeta {
+	streams := m.fcosStreamList()
+	metas := make([]fcosStreamMeta, len(streams))
+
+	descs := map[string]string{
+		"stable":  "Production-ready. Thoroughly tested before release.",
+		"testing": "Next stable candidate. Wider testing before promotion.",
+		"next":    "Bleeding edge. Latest packages, for development only.",
+	}
+
+	for i, s := range streams {
+		metas[i] = fcosStreamMeta{name: s, desc: descs[s]}
+		// Populate version from fetched FCOS stream data when available (#641).
+		for _, info := range m.Wizard.State.FCOSStreams {
+			if info.Channel == s {
+				metas[i].version = info.Version
+				break
+			}
+		}
+	}
+	return metas
+}
+
+// viewFCOSStreamCards renders FCOS stream selection cards (stable/testing/next).
+func (m *Model) viewFCOSStreamCards() string {
+	var b strings.Builder
+
+	selectedBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("51")).
+		Padding(0, 1).
+		Width(60)
+	normalBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Width(60)
+	nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+	nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	versionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+
+	b.WriteString("  Select a release stream:\n\n")
+
+	metas := m.getFCOSStreamMeta()
+	for i, meta := range metas {
+		selected := i == m.cursor
+
+		var card strings.Builder
+		cursor := "  "
+		nameStyle := nameNormal
+		if selected {
+			cursor = cursorStyle.Render("▸ ")
+			nameStyle = nameSelected
+		}
+
+		displayName := strings.ToUpper(meta.name[:1]) + meta.name[1:]
+		name := nameStyle.Render(displayName)
+		ver := ""
+		if meta.version != "" {
+			ver = versionStyle.Render("v" + meta.version)
+		}
+		padding := 60 - 4 - len(displayName) - len("v"+meta.version)
+		if padding < 1 {
+			padding = 1
+		}
+		card.WriteString(cursor + name + strings.Repeat(" ", padding) + ver)
+		card.WriteString("\n")
+		card.WriteString("  " + descStyle.Render(meta.desc))
+
+		if selected {
+			b.WriteString(selectedBorder.Render(card.String()))
+		} else {
+			b.WriteString(normalBorder.Render(card.String()))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("  Fedora CoreOS community: ") + link.Render("https://discussion.fedoraproject.org"))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
 // channelList returns the ordered list of channel keys for the card selector.
 func (m *Model) channelList() []string {
 	return []string{"stable", "lts", "beta", "alpha"}
@@ -510,7 +691,11 @@ func (m *Model) viewChannelCards() string {
 	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
 	b.WriteString("\n")
-	b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		b.WriteString(dim.Render("  Fedora CoreOS community: ") + link.Render("https://discussion.fedoraproject.org"))
+	} else {
+		b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
+	}
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/tui/handleenter_test.go
+++ b/internal/tui/handleenter_test.go
@@ -125,9 +125,11 @@ func TestHandleEnter_Welcome_ChannelSelection(t *testing.T) {
 	w.State.CurrentStep = model.StepWelcome
 	w.State.Config.Channel = "stable" // pre-set to pass validation
 	w.State.Config.Hostname = "test"
+	w.State.Config.OS = model.OSFlatcar
 
 	m := New(w)
-	m.cursor = 2 // "beta" (channels are: stable, lts, beta, alpha)
+	m.welcomeSubView = 1 // already past OS selection
+	m.cursor = 2         // "beta" (channels are: stable, lts, beta, alpha)
 
 	_, _ = m.handleEnter()
 
@@ -140,9 +142,11 @@ func TestHandleEnter_Welcome_WithIgnitionURL(t *testing.T) {
 	w := newTestWizard()
 	w.State.CurrentStep = model.StepWelcome
 	w.State.Config.Channel = "stable"
+	w.State.Config.OS = model.OSFlatcar
 	w.State.Config.IgnitionURL = "https://example.com/config.ign"
 
 	m := New(w)
+	m.welcomeSubView = 1 // already past OS selection
 	m.cursor = 0
 
 	_, _ = m.handleEnter()
@@ -243,7 +247,7 @@ func TestMaxCursor_AllSteps(t *testing.T) {
 		disks  int
 		expect int
 	}{
-		{model.StepWelcome, 0, 4}, // 4 channels
+		{model.StepWelcome, 0, 2}, // 2 OS options (sub-view 0: Flatcar / FCOS)
 		{model.StepStorage, 3, 3}, // number of disks
 		{model.StepStorage, 0, 0}, // no disks
 		{model.StepSysext, 0, 0},  // empty sysexts

--- a/internal/tui/quality_ignitionurl_test.go
+++ b/internal/tui/quality_ignitionurl_test.go
@@ -13,8 +13,10 @@ func TestHandleEnter_Welcome_IgnitionURL_SkipsToStorage(t *testing.T) {
 	w.State.CurrentStep = model.StepWelcome
 	w.State.Config.IgnitionURL = "https://example.com/config.ign"
 	w.State.Config.Channel = "stable"
+	w.State.Config.OS = model.OSFlatcar
 
 	m := New(w)
+	m.welcomeSubView = 1 // already past OS selection
 	_, _ = m.handleEnter()
 
 	if m.Wizard.State.CurrentStep != model.StepStorage {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -68,6 +68,10 @@ type Model struct {
 	tailscaleRoutesIn  string
 	showAdvanced       bool
 
+	// welcomeSubView tracks sub-steps inside StepWelcome:
+	// 0 = OS picker (Flatcar / FCOS), 1 = channel / stream picker
+	welcomeSubView int
+
 	// Sysext list (bubbles/list)
 	sysextList      list.Model
 	sysextListReady bool
@@ -221,6 +225,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Intercept shift+tab before huh form — always means "go back a step"
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == "shift+tab" {
+		// On StepWelcome sub-view 1, shift+tab goes back to OS picker
+		if m.Wizard.State.CurrentStep == model.StepWelcome && m.welcomeSubView == 1 {
+			m.welcomeSubView = 0
+			m.cursor = 0
+			m.err = nil
+			return m, nil
+		}
 		if m.Wizard.State.CurrentStep > model.StepWelcome {
 			m.Wizard.Previous()
 			m.err = nil
@@ -374,6 +385,13 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.cursor = m.sysextListCursorIdx()
 			return m, cmd
 		}
+		// On StepWelcome sub-view 1, go back to sub-view 0 instead of Previous step.
+		if m.Wizard.State.CurrentStep == model.StepWelcome && m.welcomeSubView == 1 {
+			m.welcomeSubView = 0
+			m.cursor = 0
+			m.err = nil
+			return m, nil
+		}
 		m.Wizard.Previous()
 		m.err = nil
 		m.initStepFields()
@@ -424,6 +442,12 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m *Model) maxCursor() int {
 	switch m.Wizard.State.CurrentStep {
 	case model.StepWelcome:
+		if m.welcomeSubView == 0 {
+			return m.osCardCount()
+		}
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			return m.fcosStreamCount()
+		}
 		return m.channelCardCount()
 	case model.StepStorage:
 		return len(m.Wizard.State.Disks)
@@ -432,6 +456,9 @@ func (m *Model) maxCursor() int {
 	case model.StepNvidia:
 		return len(model.NvidiaDriverOptions)
 	case model.StepUpdate:
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			return 2
+		}
 		return 3
 	default:
 		return 1
@@ -444,10 +471,27 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 
 	switch step {
 	case model.StepWelcome:
-		// Apply channel selection from card cursor
-		channels := m.channelList()
-		if m.cursor >= 0 && m.cursor < len(channels) {
-			m.Wizard.State.Config.Channel = channels[m.cursor]
+		if m.welcomeSubView == 0 {
+			// Sub-view 0: OS selection — set OS and advance to channel/stream picker
+			osList := []string{model.OSFlatcar, model.OSFCOS}
+			if m.cursor >= 0 && m.cursor < len(osList) {
+				m.Wizard.State.Config.OS = osList[m.cursor]
+			}
+			m.welcomeSubView = 1
+			m.cursor = 0
+			return m, nil
+		}
+		// Sub-view 1: channel / stream selection
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			streams := m.fcosStreamList()
+			if m.cursor >= 0 && m.cursor < len(streams) {
+				m.Wizard.State.Config.Channel = streams[m.cursor]
+			}
+		} else {
+			channels := m.channelList()
+			if m.cursor >= 0 && m.cursor < len(channels) {
+				m.Wizard.State.Config.Channel = channels[m.cursor]
+			}
 		}
 		// If IgnitionURL is set, skip directly to Storage
 		if m.Wizard.State.Config.IgnitionURL != "" {
@@ -481,9 +525,16 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 			m.Wizard.State.Config.NvidiaDriverVersion = model.NvidiaDriverOptions[m.cursor].ID
 		}
 	case model.StepUpdate:
-		strategies := []string{"reboot", "off", "etcd-lock"}
-		if m.cursor >= 0 && m.cursor < len(strategies) {
-			m.Wizard.State.Config.UpdateStrategy.RebootStrategy = strategies[m.cursor]
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			fcosStrategies := []string{model.FCOSStrategyImmediate, model.FCOSStrategyDisabled}
+			if m.cursor >= 0 && m.cursor < len(fcosStrategies) {
+				m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy = fcosStrategies[m.cursor]
+			}
+		} else {
+			strategies := []string{"reboot", "off", "etcd-lock"}
+			if m.cursor >= 0 && m.cursor < len(strategies) {
+				m.Wizard.State.Config.UpdateStrategy.RebootStrategy = strategies[m.cursor]
+			}
 		}
 	case model.StepUser:
 		// Collect local keys first so they're always included even without GitHub.
@@ -695,7 +746,8 @@ func (m *Model) initStepFields() {
 	m.fieldIdx = 0
 	switch m.Wizard.State.CurrentStep {
 	case model.StepWelcome:
-		// Card-based channel selector — no text fields
+		// Card-based OS + channel selector — no text fields; reset sub-view
+		m.welcomeSubView = 0
 		m.fields = nil
 	case model.StepNvidia:
 		// Position cursor at the currently configured driver version.
@@ -765,7 +817,13 @@ func (m *Model) render() string {
 
 	switch m.Wizard.State.CurrentStep {
 	case model.StepWelcome:
-		b.WriteString(m.viewChannelCards())
+		if m.welcomeSubView == 0 {
+			b.WriteString(m.viewOSCards())
+		} else if m.Wizard.State.Config.OS == model.OSFCOS {
+			b.WriteString(m.viewFCOSStreamCards())
+		} else {
+			b.WriteString(m.viewChannelCards())
+		}
 	case model.StepStorage:
 		b.WriteString(m.viewStorage())
 	case model.StepSysext:
@@ -1129,6 +1187,13 @@ func wordWrap(s string, width int) []string {
 }
 
 func (m *Model) viewUpdate() string {
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		return m.viewUpdateFCOS()
+	}
+	return m.viewUpdateFlatcar()
+}
+
+func (m *Model) viewUpdateFlatcar() string {
 	var b strings.Builder
 	b.WriteString("Update Strategy\n\nChoose how Flatcar will handle OS updates:\n\n")
 
@@ -1173,11 +1238,55 @@ func (m *Model) viewUpdate() string {
 	return b.String()
 }
 
+func (m *Model) viewUpdateFCOS() string {
+	var b strings.Builder
+	b.WriteString("Update Strategy\n\nChoose how Fedora CoreOS (zincati) handles OS updates:\n\n")
+
+	type option struct {
+		name string
+		desc []string
+	}
+	options := []option{
+		{"immediate (Recommended)", []string{
+			"Auto-update and reboot immediately via zincati.",
+			"Best for: single nodes, dev environments",
+		}},
+		{"disabled", []string{
+			"Disable automatic updates via zincati ([updates] enabled = false).",
+			"You must apply updates and reboot manually.",
+			"Best for: manually managed infrastructure",
+		}},
+	}
+
+	for i, opt := range options {
+		cursor := "  "
+		if i == m.cursor {
+			cursor = "▸ "
+		}
+		line := fmt.Sprintf("%s%s", cursor, opt.name)
+		if i == m.cursor {
+			b.WriteString(selectedStyle.Render(line))
+		} else {
+			b.WriteString(line)
+		}
+		b.WriteString("\n")
+		for _, d := range opt.desc {
+			fmt.Fprintf(&b, "    %s\n", d)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
 func (m *Model) viewInstall() string {
 	var b strings.Builder
 	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 
-	b.WriteString("Installing Flatcar Container Linux...\n\n")
+	osName := "Flatcar Container Linux"
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		osName = "Fedora CoreOS"
+	}
+	fmt.Fprintf(&b, "Installing %s...\n\n", osName)
 
 	// Completed phases with green checkmarks
 	for _, msg := range m.Wizard.State.ProgressMessages {
@@ -1200,13 +1309,19 @@ func (m *Model) viewDone() string {
 	var b strings.Builder
 	cfg := &m.Wizard.State.Config
 
+	isFCOS := cfg.OS == model.OSFCOS
+	osName := "Flatcar Container Linux"
+	if isFCOS {
+		osName = "Fedora CoreOS"
+	}
+
 	if cfg.DryRun {
 		b.WriteString("\n✅ Installation Complete! (dry-run — no changes made)\n\n")
 	} else {
 		b.WriteString("\n✅ Installation Complete!\n\n")
 	}
 
-	b.WriteString("Flatcar Container Linux has been installed:\n\n")
+	fmt.Fprintf(&b, "%s has been installed:\n\n", osName)
 
 	if cfg.Disk.Model != "" {
 		fmt.Fprintf(&b, "  Disk:     %s (%s)\n", cfg.Disk.Model, cfg.Disk.SizeHuman)
@@ -1236,8 +1351,13 @@ func (m *Model) viewDone() string {
 	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 	b.WriteString("\n")
 	b.WriteString(dim.Render("Community & help:") + "\n")
-	b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
-	b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+	if isFCOS {
+		b.WriteString("  " + link.Render("https://discussion.fedoraproject.org") + dim.Render("  — Fedora CoreOS community") + "\n")
+		b.WriteString("  " + link.Render("https://docs.fedoraproject.org/en-US/fedora-coreos/") + dim.Render("  — Fedora CoreOS documentation") + "\n")
+	} else {
+		b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
+		b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+	}
 
 	b.WriteString("\n")
 	if cfg.DryRun {

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -174,7 +174,7 @@ func TestMaxCursor(t *testing.T) {
 	}{
 		{
 			step:     model.StepWelcome,
-			expected: 4, // stable, lts, beta, alpha
+			expected: 2, // sub-view 0: 2 OS options (Flatcar / FCOS)
 		},
 		{
 			step: model.StepStorage,

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -37,6 +37,10 @@ type State struct {
 	// Channel version info (fetched at startup)
 	Channels []bakery.ChannelInfo
 
+	// FCOSStreams holds FCOS stream metadata (stable/testing/next) fetched at startup.
+	// Populated by FetchFCOSStreams; empty until #641 wires the FCOS stream API.
+	FCOSStreams []bakery.ChannelInfo
+
 	// System checks (populated at startup)
 	SystemChecks []SystemCheck
 
@@ -368,10 +372,26 @@ func (w *Wizard) runSystemChecks() {
 	}
 }
 
+// FetchFCOSStreams fetches FCOS stream metadata (stable/testing/next) and stores
+// it in w.State.FCOSStreams. The FCOS stream API requires the bakery FCOS client
+// from #641; until that lands this is a no-op that clears any stale state.
+func (w *Wizard) FetchFCOSStreams(_ context.Context) error {
+	w.State.FCOSStreams = nil // populated by bakery FCOS client in #641
+	return nil
+}
+
 // FetchSysexts loads the sysext catalog for the configured architecture.
+// For FCOS the catalog is fetched via the FCOS bakery client (requires #641);
+// until that lands the sysext list is left empty so the step gracefully degrades.
 // If an NVIDIA GPU was detected during ProbeHardware, nvidia-runtime is
-// auto-selected and the default driver series is pre-configured.
+// auto-selected and the default driver series is pre-configured (Flatcar only).
 func (w *Wizard) FetchSysexts(ctx context.Context) error {
+	if w.State.Config.OS == model.OSFCOS {
+		// FCOS sysext catalog fetch requires FetchCatalogFCOS from #641.
+		// Leave Sysexts empty; StepSysext will render a "no extensions" notice.
+		w.State.Sysexts = nil
+		return nil
+	}
 	sysexts, err := w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
 	if err != nil {
 		return fmt.Errorf("fetching sysext catalog: %w", err)


### PR DESCRIPTION
Implements #643.

## Summary

This PR adds OS selection (Flatcar / FCOS) to the TUI wizard and makes all subsequent steps OS-aware.

## Changes

### New UX flow

StepWelcome now has two sub-views:
- **Sub-view 0**: OS picker — Flatcar Container Linux vs Fedora CoreOS selection cards
- **Sub-view 1**: Channel/stream picker — Flatcar channels (stable/lts/beta/alpha) or FCOS streams (stable/testing/next)

Esc / shift+tab on sub-view 1 returns to the OS picker rather than leaving the step.

### Files changed

- **`internal/tui/tui.go`**: Add `welcomeSubView int` to Model; update `maxCursor()`, `render()`, `handleEnter()`, `handleKey()`, `initStepFields()`, `viewInstall()`, `viewDone()`; split `viewUpdate()` into Flatcar and FCOS variants (`viewUpdateFlatcar`, `viewUpdateFCOS`)
- **`internal/tui/forms.go`**: Add `viewOSCards()`, `viewFCOSStreamCards()`, `fcosStreamList()`, `fcosStreamCount()`, `fcosStreamMeta`, `getFCOSStreamMeta()`; make community link OS-conditional in `viewChannelCards()`
- **`internal/wizard/wizard.go`**: Add `FCOSStreams []bakery.ChannelInfo` to State; add `FetchFCOSStreams()` stub; add FCOS early-return to `FetchSysexts()`
- **`internal/tui/form_logic.go`**: OS-conditional hostname default (`flatcar` vs `fcos`)
- **`cmd/knuckle/main.go`**: Wire `FetchFCOSStreams()` alongside `FetchChannels()`
- **Tests**: Update Welcome-step tests for the new two-step sub-view flow

### Notes

- FCOS install path depends on #641 (bakery FCOS client); `FetchFCOSStreams()` and `FetchSysexts()` for FCOS are stubs that return cleanly until #641 lands
- StepUpdate for FCOS shows zincati strategies (immediate / disabled) instead of update-engine strategies
- `viewDone()` shows FCOS community/docs links when OS is FCOS