### PR TITLE
feat(install): FCOSInstaller using coreos-installer

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -116,7 +116,7 @@ func main() {
 		bakeryClient = bakery.NewHTTPClient()
 		installer = &install.DispatchingInstaller{
 			Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
-			// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+			FCOS:    install.NewFCOSInstaller(cmdRunner, logger),
 		}
 	}
 
@@ -214,7 +214,7 @@ func runHeadlessWithRunner(configPath string, dryRun bool, logFile string, cmdRu
 
 	installer := &install.DispatchingInstaller{
 		Flatcar: install.NewFlatcarInstaller(cmdRunner, logger),
-		// FCOS: install.NewFCOSInstaller(cmdRunner, logger), // wired by #639
+		FCOS:    install.NewFCOSInstaller(cmdRunner, logger),
 	}
 
 	// Run headless install with a 30-minute wall-clock timeout.

--- a/docs/HEADLESS-CONFIG.md
+++ b/docs/HEADLESS-CONFIG.md
@@ -245,6 +245,18 @@ Knuckle validates the config before touching the disk. Key rules:
 
 ---
 
+## FCOS version pinning
+
+When `os` is `fcos`, the `version` field is **not supported** in v1. `coreos-installer`
+installs the latest image for the requested stream by default; there is no `-V` equivalent
+for stream-based version pinning without constructing an explicit `--image-url`.
+
+If `version` is set alongside `os: fcos`, knuckle logs a warning and proceeds with the
+stream default (i.e., the version value is silently ignored). A future release may support
+explicit image URLs for reproducible FCOS installs.
+
+---
+
 ## CLI flags override JSON
 
 Two CLI flags can override JSON config fields:

--- a/internal/install/fcos_install.go
+++ b/internal/install/fcos_install.go
@@ -1,0 +1,147 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/projectbluefin/knuckle/internal/ignition"
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+// FCOSInstaller runs coreos-installer via the runner.
+//
+// coreos-installer differs from flatcar-install in three key ways:
+//   - Disk path is a positional argument after the "install" subcommand.
+//   - Stream is passed as --stream rather than -C.
+//   - Disk preparation (wipefs, GPT repair) is handled internally — callers
+//     must NOT invoke wipefs or sfdisk before or after coreos-installer.
+type FCOSInstaller struct {
+	Runner       runner.Runner
+	Generator    *ignition.Generator
+	Logger       *slog.Logger
+	ignitionPath string // dynamically set temp file path
+}
+
+// NewFCOSInstaller creates an FCOSInstaller with the given runner and logger.
+func NewFCOSInstaller(r runner.Runner, logger *slog.Logger) *FCOSInstaller {
+	return &FCOSInstaller{
+		Runner:    r,
+		Generator: ignition.NewGenerator(),
+		Logger:    logger,
+	}
+}
+
+// Install performs the FCOS installation:
+//  1. Generate FCOS Butane → compile Ignition (uses GenerateFCOSButane)
+//  2. Write ignition to secure temp file (reuses WriteIgnitionFile)
+//  3. Run: coreos-installer install --stream <stream> [--ignition-file <path>] <disk>
+//  4. Done — no wipefs or sfdisk steps.
+func (i *FCOSInstaller) Install(ctx context.Context, cfg *model.InstallConfig, progress func(step string)) error {
+	if cfg == nil {
+		return fmt.Errorf("install config cannot be nil")
+	}
+
+	if cfg.Version != "" {
+		// coreos-installer does not support a -V equivalent for stream-based
+		// version pinning; pinning requires constructing an explicit --image-url.
+		// For v1 we log a warning and proceed with the stream default.
+		// See docs/HEADLESS-CONFIG.md §FCOS version pinning.
+		i.Logger.Warn("FCOS version pinning is not supported in v1; using stream default",
+			"requested_version", cfg.Version)
+	}
+
+	if cfg.IgnitionURL != "" {
+		progress("Using external Ignition config...")
+	} else {
+		progress("Generating Butane config...")
+		butaneYAML, err := i.Generator.GenerateFCOSButane(cfg)
+		if err != nil {
+			return fmt.Errorf("generating fcos butane config: %w", err)
+		}
+
+		progress("Compiling Ignition config...")
+		ignitionJSON, err := compileToIgnitionFunc(butaneYAML)
+		if err != nil {
+			return fmt.Errorf("compiling butane: %w", err)
+		}
+
+		progress("Writing Ignition config...")
+		ignPath, err := i.writeIgnitionFile(ignitionJSON)
+		if err != nil {
+			return fmt.Errorf("writing ignition file: %w", err)
+		}
+		i.ignitionPath = ignPath
+		defer i.cleanupFCOSIgnitionFile()
+	}
+
+	args := buildFCOSInstallArgs(cfg, i.ignitionPath)
+
+	progress("Running coreos-installer...")
+	i.Logger.Info("executing coreos-installer", "args", args)
+
+	result, err := i.Runner.Run(ctx, "coreos-installer", args...)
+	if err != nil || (result != nil && result.ExitCode != 0) {
+		return formatCommandError("coreos-installer install failed", result, err)
+	}
+
+	progress("Installation complete!")
+	return nil
+}
+
+// buildFCOSInstallArgs constructs the argument list for coreos-installer.
+// The disk path is a positional argument that must come last.
+func buildFCOSInstallArgs(cfg *model.InstallConfig, ignitionPath string) []string {
+	diskPath := installDiskPath(cfg)
+	args := []string{
+		"install",
+		"--stream", cfg.Channel,
+	}
+
+	if cfg.IgnitionURL != "" {
+		args = append(args, "--ignition-url", cfg.IgnitionURL)
+	} else if ignitionPath != "" {
+		args = append(args, "--ignition-file", ignitionPath)
+	}
+
+	// Disk path is positional — must be the final argument.
+	args = append(args, diskPath)
+	return args
+}
+
+// writeIgnitionFile writes ignition JSON to a secure temp file and returns
+// its path. Delegates to the package-level newIgnitionTempFile seam so tests
+// can inject failures.
+func (i *FCOSInstaller) writeIgnitionFile(ignitionJSON string) (string, error) {
+	f, err := newIgnitionTempFile()
+	if err != nil {
+		return "", fmt.Errorf("creating temp ignition file: %w", err)
+	}
+	path := f.Name()
+
+	if _, err := f.WriteString(ignitionJSON); err != nil {
+		_ = f.Close()
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("writing ignition content: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		_ = removeIgnitionFile(path)
+		return "", fmt.Errorf("closing ignition file: %w", err)
+	}
+
+	i.Logger.Info("ignition file written", "path", path)
+	return path, nil
+}
+
+// cleanupFCOSIgnitionFile removes the temp ignition file (contains SSH keys).
+func (i *FCOSInstaller) cleanupFCOSIgnitionFile() {
+	if i.ignitionPath == "" {
+		return
+	}
+	if err := removeIgnitionFile(i.ignitionPath); err != nil {
+		i.Logger.Warn("failed to clean up fcos ignition file", "path", i.ignitionPath, "error", err)
+	}
+	i.ignitionPath = ""
+}

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -248,5 +249,192 @@ func TestBuildFCOSInstallArgs_ExternalURL(t *testing.T) {
 	want := []string{"install", "--stream", "beta", "--ignition-url", "https://example.com/fcos.ign", "/dev/vda"}
 	if strings.Join(args, " ") != strings.Join(want, " ") {
 		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+func TestFCOSInstall_ButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+	}
+	origCompile := compileToIgnitionFunc
+	t.Cleanup(func() { compileToIgnitionFunc = origCompile })
+	compileToIgnitionFunc = func(_ string) (string, error) {
+		return "", fmt.Errorf("compile error")
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from butane/compile, got nil")
+	}
+}
+
+func TestFCOSInstall_TempFileError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	origTempFile := newIgnitionTempFile
+	t.Cleanup(func() { newIgnitionTempFile = origTempFile })
+	newIgnitionTempFile = func() (ignitionTempFile, error) {
+		return nil, fmt.Errorf("disk full")
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from temp file creation, got nil")
+	}
+	if !strings.Contains(err.Error(), "writing ignition file") {
+		t.Errorf("error = %q, want to contain 'writing ignition file'", err.Error())
+	}
+}
+
+func TestFCOSInstall_RunnerError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	spy.AllError = fmt.Errorf("coreos-installer not found")
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:     "stable",
+		Disk:        model.DiskInfo{DevPath: "/dev/sda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from runner, got nil")
+	}
+}
+
+type fcosFailRunner struct{}
+
+func (fcosFailRunner) Run(_ context.Context, name string, args ...string) (*runner.Result, error) {
+	return &runner.Result{Command: name, Args: args, ExitCode: 1, Stderr: "installation failed"}, nil
+}
+func (fcosFailRunner) RunWithInput(_ context.Context, _ string, name string, args ...string) (*runner.Result, error) {
+	return nil, fmt.Errorf("unexpected RunWithInput")
+}
+
+func TestFCOSInstall_RunnerNonZeroExit(t *testing.T) {
+	installer := NewFCOSInstaller(fcosFailRunner{}, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:     "stable",
+		Disk:        model.DiskInfo{DevPath: "/dev/sda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from non-zero exit, got nil")
+	}
+}
+
+func TestFCOSCleanup_EmptyPath(t *testing.T) {
+	installer := NewFCOSInstaller(runner.NewSpyRunner(), testLogger())
+	installer.ignitionPath = ""
+	installer.cleanupFCOSIgnitionFile() // should not panic
+}
+
+func TestFCOSCleanup_RemoveError(t *testing.T) {
+	installer := NewFCOSInstaller(runner.NewSpyRunner(), testLogger())
+	installer.ignitionPath = "/nonexistent/path/abc.json"
+
+	origRemove := removeIgnitionFile
+	t.Cleanup(func() { removeIgnitionFile = origRemove })
+	removeIgnitionFile = func(_ string) error {
+		return fmt.Errorf("permission denied")
+	}
+
+	installer.cleanupFCOSIgnitionFile() // should log warning, not panic
+	if installer.ignitionPath != "" {
+		t.Error("ignitionPath should be cleared even on remove error")
+	}
+}
+
+func TestFCOSInstall_GenerateButaneError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	// A sysext with a non-HTTPS URL triggers GenerateFCOSButane to return an error.
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+		Sysexts: []model.SysextEntry{{Name: "bad", URL: "http://example.com/bad.raw", Selected: true}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected butane error for non-HTTPS sysext URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "generating fcos butane config") {
+		t.Errorf("error = %q, want 'generating fcos butane config'", err.Error())
+	}
+}
+
+type writeErrFile struct{ name string }
+
+func (w *writeErrFile) Name() string                      { return w.name }
+func (w *writeErrFile) WriteString(_ string) (int, error) { return 0, fmt.Errorf("write error") }
+func (w *writeErrFile) Close() error                      { return nil }
+
+func TestFCOSInstall_WriteIgnitionWriteError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	origTempFile := newIgnitionTempFile
+	t.Cleanup(func() { newIgnitionTempFile = origTempFile })
+	newIgnitionTempFile = func() (ignitionTempFile, error) {
+		return &writeErrFile{name: "/tmp/knuckle-test-write-err.json"}, nil
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from write failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "writing ignition file") {
+		t.Errorf("error = %q, want 'writing ignition file'", err.Error())
+	}
+}
+
+type closeErrFile struct {
+	name    string
+	content strings.Builder
+}
+
+func (c *closeErrFile) Name() string                      { return c.name }
+func (c *closeErrFile) WriteString(s string) (int, error) { return c.content.WriteString(s) }
+func (c *closeErrFile) Close() error                      { return fmt.Errorf("close error") }
+
+func TestFCOSInstall_WriteIgnitionCloseError(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	origTempFile := newIgnitionTempFile
+	t.Cleanup(func() { newIgnitionTempFile = origTempFile })
+	newIgnitionTempFile = func() (ignitionTempFile, error) {
+		return &closeErrFile{name: "/tmp/knuckle-test-close-err.json"}, nil
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from close failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "writing ignition file") {
+		t.Errorf("error = %q, want 'writing ignition file'", err.Error())
 	}
 }

--- a/internal/install/fcos_install_test.go
+++ b/internal/install/fcos_install_test.go
@@ -1,0 +1,252 @@
+package install
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func TestFCOSInstall_BasicArgs(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Hostname: "fcos-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var call *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			call = &spy.Calls[i]
+			break
+		}
+	}
+	if call == nil {
+		t.Fatalf("coreos-installer was not called; got: %v", spy.Calls)
+	}
+
+	args := call.Args
+	if len(args) < 1 || args[0] != "install" {
+		t.Errorf("first arg must be 'install', got %v", args)
+	}
+
+	streamIdx := -1
+	for i, a := range args {
+		if a == "--stream" {
+			streamIdx = i
+			break
+		}
+	}
+	if streamIdx == -1 {
+		t.Fatalf("--stream flag not found in args: %v", args)
+	}
+	if args[streamIdx+1] != "stable" {
+		t.Errorf("--stream value = %q, want 'stable'", args[streamIdx+1])
+	}
+
+	// Disk must be the last positional argument.
+	if args[len(args)-1] != "/dev/sda" {
+		t.Errorf("disk path must be last arg, got %q in %v", args[len(args)-1], args)
+	}
+
+	// --ignition-file must appear when no IgnitionURL is set.
+	found := false
+	for _, a := range args {
+		if a == "--ignition-file" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--ignition-file not found in args: %v", args)
+	}
+}
+
+func TestFCOSInstall_NoWipefs(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	_ = installer.Install(context.Background(), cfg, func(string) {})
+
+	for _, call := range spy.Calls {
+		if call.Name == "wipefs" {
+			t.Error("wipefs must not be called for FCOS install")
+		}
+	}
+}
+
+func TestFCOSInstall_NoSfdisk(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	_ = installer.Install(context.Background(), cfg, func(string) {})
+
+	for _, call := range spy.Calls {
+		if call.Name == "sfdisk" {
+			t.Error("sfdisk must not be called for FCOS install")
+		}
+	}
+}
+
+func TestFCOSInstall_ExternalURL(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:     "beta",
+		Hostname:    "fcos-url-node",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var call *runner.SpyCall
+	for i := range spy.Calls {
+		if spy.Calls[i].Name == "coreos-installer" {
+			call = &spy.Calls[i]
+			break
+		}
+	}
+	if call == nil {
+		t.Fatalf("coreos-installer was not called; got: %v", spy.Calls)
+	}
+
+	urlIdx := -1
+	for i, a := range call.Args {
+		if a == "--ignition-url" {
+			urlIdx = i
+			break
+		}
+	}
+	if urlIdx == -1 {
+		t.Fatalf("--ignition-url not found in args: %v", call.Args)
+	}
+	if call.Args[urlIdx+1] != "https://example.com/fcos.ign" {
+		t.Errorf("--ignition-url value = %q, want URL", call.Args[urlIdx+1])
+	}
+
+	for _, a := range call.Args {
+		if a == "--ignition-file" {
+			t.Error("--ignition-file must not appear when IgnitionURL is set")
+		}
+	}
+}
+
+func TestFCOSInstall_VersionIgnored(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel:  "stable",
+		Version:  "40.20240101.3.0",
+		Hostname: "fcos-ver-node",
+		Disk:     model.DiskInfo{DevPath: "/dev/sda"},
+		Network:  model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:    []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	err := installer.Install(context.Background(), cfg, func(string) {})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No --version flag should appear in coreos-installer args.
+	for _, call := range spy.Calls {
+		if call.Name == "coreos-installer" {
+			for _, a := range call.Args {
+				if strings.HasPrefix(a, "--version") {
+					t.Errorf("--version flag must not be passed to coreos-installer, got %v", call.Args)
+				}
+			}
+		}
+	}
+}
+
+func TestFCOSInstall_ByIDPath(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk: model.DiskInfo{
+			Path:    "/dev/disk/by-id/ata-fcos-test",
+			DevPath: "/dev/sda",
+		},
+		Network: model.NetworkConfig{Mode: model.NetworkDHCP},
+		Users:   []model.UserConfig{{Username: "core", SSHKeys: []string{"ssh-ed25519 AAAA test"}}},
+	}
+
+	_ = installer.Install(context.Background(), cfg, func(string) {})
+
+	for _, call := range spy.Calls {
+		if call.Name == "coreos-installer" {
+			last := call.Args[len(call.Args)-1]
+			if last != "/dev/disk/by-id/ata-fcos-test" {
+				t.Errorf("disk arg = %q, want by-id path", last)
+			}
+			return
+		}
+	}
+	t.Fatal("coreos-installer not called")
+}
+
+func TestFCOSInstall_NilConfig(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	installer := NewFCOSInstaller(spy, testLogger())
+
+	err := installer.Install(context.Background(), nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error for nil config, got nil")
+	}
+}
+
+func TestBuildFCOSInstallArgs_Generated(t *testing.T) {
+	cfg := &model.InstallConfig{
+		Channel: "stable",
+		Disk:    model.DiskInfo{DevPath: "/dev/sda"},
+	}
+	args := buildFCOSInstallArgs(cfg, "/tmp/ignition-abc.json")
+
+	want := []string{"install", "--stream", "stable", "--ignition-file", "/tmp/ignition-abc.json", "/dev/sda"}
+	if strings.Join(args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+func TestBuildFCOSInstallArgs_ExternalURL(t *testing.T) {
+	cfg := &model.InstallConfig{
+		Channel:     "beta",
+		Disk:        model.DiskInfo{DevPath: "/dev/vda"},
+		IgnitionURL: "https://example.com/fcos.ign",
+	}
+	args := buildFCOSInstallArgs(cfg, "")
+
+	want := []string{"install", "--stream", "beta", "--ignition-url", "https://example.com/fcos.ign", "/dev/vda"}
+	if strings.Join(args, " ") != strings.Join(want, " ") {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements `FCOSInstaller` alongside `FlatcarInstaller` in `internal/install/`, closes #640.

### Key differences from FlatcarInstaller

| | FlatcarInstaller | FCOSInstaller |
|---|---|---|
| Binary | `flatcar-install` | `coreos-installer` |
| Disk arg | `-d <disk>` | positional after `install` |
| Stream/channel | `-C <channel>` | `--stream <channel>` |
| Wipe disk | wipefs before | handled internally |
| GPT repair | sfdisk after | handled internally |
| Version pinning | `-V <version>` | not supported in v1 (warning logged) |

### Files changed

- **`internal/install/fcos_install.go`** — `FCOSInstaller` struct, `NewFCOSInstaller`, `Install`, `buildFCOSInstallArgs`, ignition file helpers. Reuses existing package-level seams (`compileToIgnitionFunc`, `newIgnitionTempFile`, `removeIgnitionFile`) and `installDiskPath` helper.
- **`internal/install/fcos_install_test.go`** — 9 new tests: basic args, no-wipefs, no-sfdisk, external URL, version ignored, by-id path, nil config, `buildFCOSInstallArgs` (generated + URL).
- **`cmd/knuckle/main.go`** — wire `FCOS: install.NewFCOSInstaller(cmdRunner, logger)` into both `DispatchingInstaller` instantiation sites (TUI and headless paths).
- **`docs/HEADLESS-CONFIG.md`** — add §FCOS version pinning explaining the v1 limitation.

### Tests

All 17 tests pass (`go test ./...`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FCOS installer is now fully enabled in both TUI and headless installation modes.

* **Documentation**
  * Added clarification that FCOS v1 installations use stream defaults and do not support version pinning; provided versions are logged as warnings and ignored.

* **Tests**
  * Added comprehensive test coverage for FCOS installation behavior, including argument validation, ignition file handling, and version field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->