### PR TITLE
feat(tui): OS selection, FCOS-conditional steps, stream cards, Flatcar string cleanup

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -152,6 +152,11 @@ func main() {
 		if err := w.FetchChannels(ctx); err != nil {
 			logger.Warn("channel info fetch failed", "error", err)
 		}
+
+		// Fetch FCOS stream version info (non-fatal if it fails)
+		if err := w.FetchFCOSStreams(ctx); err != nil {
+			logger.Warn("FCOS stream info fetch failed", "error", err)
+		}
 	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly

--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -27,6 +27,23 @@ var (
 	tuiRunFn          = tui.Run
 	demoProberFactory = func() probe.Prober { return &demo.Prober{} }
 	demoBakeryFactory = func() bakery.Client { return &demo.Bakery{} }
+
+	// startupFetchFn wraps the non-demo hardware probe and network fetch calls.
+	// Tests can replace it to cover the non-demo startup path without real hardware.
+	startupFetchFn = func(ctx context.Context, w *wizard.Wizard, logger *slog.Logger) {
+		if err := w.ProbeHardware(ctx); err != nil {
+			logger.Warn("hardware probe failed", "error", err)
+		}
+		if err := w.FetchSysexts(ctx); err != nil {
+			logger.Warn("sysext catalog fetch failed", "error", err)
+		}
+		if err := w.FetchChannels(ctx); err != nil {
+			logger.Warn("channel info fetch failed", "error", err)
+		}
+		if err := w.FetchFCOSStreams(ctx); err != nil {
+			logger.Warn("FCOS stream info fetch failed", "error", err)
+		}
+	}
 )
 
 func main() {
@@ -138,25 +155,7 @@ func main() {
 		}
 		w.State.Channels = demo.Channels()
 	} else {
-		// Probe hardware before starting TUI
-		if err := w.ProbeHardware(ctx); err != nil {
-			logger.Warn("hardware probe failed", "error", err)
-		}
-
-		// Fetch sysext catalog (non-fatal if it fails)
-		if err := w.FetchSysexts(ctx); err != nil {
-			logger.Warn("sysext catalog fetch failed", "error", err)
-		}
-
-		// Fetch channel version info (non-fatal if it fails)
-		if err := w.FetchChannels(ctx); err != nil {
-			logger.Warn("channel info fetch failed", "error", err)
-		}
-
-		// Fetch FCOS stream version info (non-fatal if it fails)
-		if err := w.FetchFCOSStreams(ctx); err != nil {
-			logger.Warn("FCOS stream info fetch failed", "error", err)
-		}
+		startupFetchFn(ctx, w, logger)
 	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly

--- a/cmd/knuckle/main_test.go
+++ b/cmd/knuckle/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -59,6 +60,9 @@ func init() {
 		tuiRunFn = func(_ *wizard.Wizard, _ func(context.Context) error) error {
 			return errors.New("injected TUI failure")
 		}
+	}
+	if os.Getenv("KNUCKLE_TEST_STARTUP_NOOP") == "1" {
+		startupFetchFn = func(_ context.Context, _ *wizard.Wizard, _ *slog.Logger) {}
 	}
 }
 
@@ -658,5 +662,20 @@ func TestMain_TUIRunError(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "Error:") {
 		t.Errorf("expected 'Error:' in output; got: %s", out)
+	}
+}
+
+// TestMain_NonDemoStartupFetch verifies that the non-demo path calls startupFetchFn
+// (which probes hardware and fetches FCOS/channel info) before launching the TUI.
+// Uses KNUCKLE_TEST_STARTUP_NOOP=1 to skip real network/hardware calls.
+func TestMain_NonDemoStartupFetch(t *testing.T) {
+	cmd := helperCmd(t, "--dry-run", "--log-file=/dev/null")
+	cmd.Env = append(cmd.Env,
+		"KNUCKLE_TEST_TUI_NOOP=1",
+		"KNUCKLE_TEST_STARTUP_NOOP=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success with noop startup + noop TUI, got %v\noutput: %s", err, out)
 	}
 }

--- a/internal/tui/fcos_tui_test.go
+++ b/internal/tui/fcos_tui_test.go
@@ -1,0 +1,304 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/wizard"
+)
+
+// ── OS picker sub-view ────────────────────────────────────────────────────────
+
+func TestOSPicker_ShowsTwoOptions(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	m := New(w)
+	// osSubView is true after initStepFields for StepWelcome
+	if !m.osSubView {
+		t.Fatal("osSubView should be true after New() at StepWelcome")
+	}
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "Flatcar Container Linux") {
+		t.Errorf("OS picker should show 'Flatcar Container Linux': %q", out)
+	}
+	if !strings.Contains(out, "Fedora CoreOS") {
+		t.Errorf("OS picker should show 'Fedora CoreOS': %q", out)
+	}
+}
+
+func TestOSPicker_SelectFlatcar_ThenShowsChannelCards(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	m := New(w)
+
+	// Phase 1: select Flatcar (cursor 0)
+	m.cursor = 0
+	_, _ = m.handleEnter()
+
+	if m.Wizard.State.Config.OS != model.OSFlatcar {
+		t.Errorf("expected OS=flatcar, got %q", m.Wizard.State.Config.OS)
+	}
+	if m.osSubView {
+		t.Error("osSubView should be false after OS selection")
+	}
+	// Should now render channel cards, not OS picker
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "Select a release channel") {
+		t.Errorf("after OS selection, should show channel cards: %q", out[:min(200, len(out))])
+	}
+}
+
+func TestOSPicker_SelectFCOS_ThenShowsStreamCards(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	m := New(w)
+
+	// Phase 1: select FCOS (cursor 1)
+	m.cursor = 1
+	_, _ = m.handleEnter()
+
+	if m.Wizard.State.Config.OS != model.OSFCOS {
+		t.Errorf("expected OS=fcos, got %q", m.Wizard.State.Config.OS)
+	}
+	if m.osSubView {
+		t.Error("osSubView should be false after OS selection")
+	}
+	// Should now render FCOS stream cards
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "Fedora CoreOS stream") {
+		t.Errorf("after FCOS selection, should show stream cards: %q", out[:min(200, len(out))])
+	}
+}
+
+// ── FCOS stream cards ─────────────────────────────────────────────────────────
+
+func TestFCOSStreamCards_ListsThreeStreams(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+	m.osSubView = false
+
+	out := m.viewChannelCards()
+	for _, stream := range []string{"Stable", "Testing", "Next"} {
+		if !strings.Contains(out, stream) {
+			t.Errorf("FCOS stream cards should contain %q: %q", stream, out[:min(300, len(out))])
+		}
+	}
+}
+
+func TestFCOSStreamCards_ChannelList(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+
+	got := m.channelList()
+	want := []string{"stable", "testing", "next"}
+	if len(got) != len(want) {
+		t.Fatalf("FCOS channelList length = %d, want %d", len(got), len(want))
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("channelList[%d] = %q, want %q", i, got[i], v)
+		}
+	}
+}
+
+func TestFCOSStreamCards_WithVersionInfo(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.FCOSStreams = []wizard.FCOSStreamInfo{
+		{Stream: "stable", Version: "42.20250101.3.0"},
+	}
+	m := New(w)
+	m.osSubView = false
+	m.cursor = 0
+
+	out := m.viewChannelCards()
+	if !strings.Contains(out, "42.20250101.3.0") {
+		t.Errorf("FCOS stream cards should show version: %q", out[:min(300, len(out))])
+	}
+}
+
+// ── FCOS maxCursor ────────────────────────────────────────────────────────────
+
+func TestMaxCursor_FCOSUpdate(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUpdate
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+
+	got := m.maxCursor()
+	if got != 2 {
+		t.Errorf("maxCursor(StepUpdate, FCOS) = %d, want 2", got)
+	}
+}
+
+func TestMaxCursor_WelcomeChannelCards_Flatcar(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	w.State.Config.OS = model.OSFlatcar
+	m := New(w)
+	m.osSubView = false // OS already chosen, now at channel picker
+
+	got := m.maxCursor()
+	if got != 4 {
+		t.Errorf("maxCursor(StepWelcome, Flatcar channel picker) = %d, want 4", got)
+	}
+}
+
+func TestMaxCursor_WelcomeChannelCards_FCOS(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepWelcome
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+	m.osSubView = false // OS already chosen, now at stream picker
+
+	got := m.maxCursor()
+	if got != 3 {
+		t.Errorf("maxCursor(StepWelcome, FCOS stream picker) = %d, want 3", got)
+	}
+}
+
+// ── FCOS update strategy ──────────────────────────────────────────────────────
+
+func TestViewUpdate_FCOS_ShowsZincatiOptions(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUpdate
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+
+	out := m.viewUpdate()
+	if !strings.Contains(out, "Fedora CoreOS") {
+		t.Errorf("FCOS viewUpdate should mention Fedora CoreOS: %q", out[:min(300, len(out))])
+	}
+	if !strings.Contains(out, "immediate") {
+		t.Errorf("FCOS viewUpdate should show 'immediate': %q", out[:min(300, len(out))])
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("FCOS viewUpdate should show 'disabled': %q", out[:min(300, len(out))])
+	}
+	// Flatcar options should not appear
+	if strings.Contains(out, "etcd-lock") {
+		t.Errorf("FCOS viewUpdate should not show 'etcd-lock': %q", out[:min(300, len(out))])
+	}
+}
+
+func TestHandleEnter_Update_FCOS_AppliesStrategy(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUpdate
+	w.State.Config.OS = model.OSFCOS
+
+	m := New(w)
+	m.cursor = 0 // immediate
+	_, _ = m.handleEnter()
+
+	if m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy != model.FCOSStrategyImmediate {
+		t.Errorf("expected FCOSUpdateStrategy=%q, got %q",
+			model.FCOSStrategyImmediate, m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy)
+	}
+}
+
+func TestHandleEnter_Update_FCOS_DisabledStrategy(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUpdate
+	w.State.Config.OS = model.OSFCOS
+
+	m := New(w)
+	m.cursor = 1 // disabled
+	_, _ = m.handleEnter()
+
+	if m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy != model.FCOSStrategyDisabled {
+		t.Errorf("expected FCOSUpdateStrategy=%q, got %q",
+			model.FCOSStrategyDisabled, m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy)
+	}
+}
+
+// ── FCOS hostname default ─────────────────────────────────────────────────────
+
+func TestInitForm_FCOSHostnameDefault(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUser
+	w.State.Config.OS = model.OSFCOS
+
+	m := New(w)
+	m.initForm()
+
+	if m.Wizard.State.Config.Hostname != "fcos" {
+		t.Errorf("FCOS hostname default should be 'fcos', got %q", m.Wizard.State.Config.Hostname)
+	}
+}
+
+func TestInitForm_FlatcarHostnameDefault(t *testing.T) {
+	w := newTestWizard()
+	w.State.CurrentStep = model.StepUser
+	w.State.Config.OS = model.OSFlatcar
+
+	m := New(w)
+	m.initForm()
+
+	if m.Wizard.State.Config.Hostname != "flatcar" {
+		t.Errorf("Flatcar hostname default should be 'flatcar', got %q", m.Wizard.State.Config.Hostname)
+	}
+}
+
+// ── FCOS review summary ───────────────────────────────────────────────────────
+
+func TestReviewSummary_FCOSShowsOSRow(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "stable"
+	w.State.Config.Hostname = "fcos-node"
+	m := New(w)
+
+	out := m.reviewSummary()
+	if !strings.Contains(out, "OS: fcos") {
+		t.Errorf("reviewSummary should show OS row for FCOS: %q", out)
+	}
+}
+
+func TestBuildReviewForm_FCOSTitle(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "stable"
+	w.State.Config.Hostname = "fcos"
+	m := New(w)
+
+	// The title is rendered inside the huh form — exercise the build path
+	form := m.buildReviewForm()
+	if form == nil {
+		t.Error("buildReviewForm() returned nil for FCOS")
+	}
+}
+
+// ── FCOS viewInstall / viewDone ───────────────────────────────────────────────
+
+func TestViewInstall_FCOS(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	m := New(w)
+
+	out := m.viewInstall()
+	if !strings.Contains(out, "Fedora CoreOS") {
+		t.Errorf("viewInstall should say 'Fedora CoreOS' for FCOS: %q", out)
+	}
+}
+
+func TestViewDone_FCOS_Links(t *testing.T) {
+	w := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.Config.Channel = "stable"
+	m := New(w)
+
+	out := m.viewDone()
+	if !strings.Contains(out, "Fedora CoreOS") {
+		t.Errorf("viewDone should mention 'Fedora CoreOS' for FCOS: %q", out[:min(300, len(out))])
+	}
+	if !strings.Contains(out, "fedoraproject.org") {
+		t.Errorf("viewDone should show Fedora community link: %q", out[:min(300, len(out))])
+	}
+	// Flatcar-specific text should not appear
+	if strings.Contains(out, "flatcar.org") {
+		t.Errorf("viewDone should not show flatcar.org for FCOS: %q", out[:min(300, len(out))])
+	}
+}

--- a/internal/tui/form_logic.go
+++ b/internal/tui/form_logic.go
@@ -36,7 +36,11 @@ func (m *Model) initForm() {
 			m.usernameInput = "core"
 		}
 		if m.Wizard.State.Config.Hostname == "" {
-			m.Wizard.State.Config.Hostname = "flatcar"
+			if m.Wizard.State.Config.OS == model.OSFCOS {
+				m.Wizard.State.Config.Hostname = "fcos"
+			} else {
+				m.Wizard.State.Config.Hostname = "flatcar"
+			}
 		}
 		if m.Wizard.State.Config.Timezone == "" {
 			m.Wizard.State.Config.Timezone = "UTC"

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -389,240 +389,239 @@ func (m *Model) renderZenChrome() string {
 // channelList returns the ordered list of channel/stream keys for the card selector.
 // For FCOS, returns the three release streams; for Flatcar, the four channels.
 func (m *Model) channelList() []string {
-if m.Wizard.State.Config.OS == model.OSFCOS {
-return []string{"stable", "testing", "next"}
-}
-return []string{"stable", "lts", "beta", "alpha"}
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		return []string{"stable", "testing", "next"}
+	}
+	return []string{"stable", "lts", "beta", "alpha"}
 }
 
 // channelCardCount returns how many channel/stream cards to display.
 func (m *Model) channelCardCount() int {
-return len(m.channelList())
+	return len(m.channelList())
 }
 
 // channelMeta holds display info for each channel card.
 type channelMeta struct {
-name    string
-version string
-kernel  string
-systemd string
-docker  string
-desc    string
+	name    string
+	version string
+	kernel  string
+	systemd string
+	docker  string
+	desc    string
 }
 
 // getChannelMeta builds display metadata for each channel/stream.
 func (m *Model) getChannelMeta() []channelMeta {
-channels := m.channelList()
-metas := make([]channelMeta, len(channels))
+	channels := m.channelList()
+	metas := make([]channelMeta, len(channels))
 
-if m.Wizard.State.Config.OS == model.OSFCOS {
-descs := map[string]string{
-"stable":  "Production-ready FCOS stream. Recommended for most deployments.",
-"testing": "Next stable candidate. Used to validate upcoming stable releases.",
-"next":    "Bleeding edge. New kernel and package versions.",
-}
-for i, ch := range channels {
-metas[i] = channelMeta{
-name: ch,
-desc: descs[ch],
-}
-for _, info := range m.Wizard.State.FCOSStreams {
-if info.Stream == ch {
-metas[i].version = info.Version
-break
-}
-}
-}
-return metas
-}
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		descs := map[string]string{
+			"stable":  "Production-ready FCOS stream. Recommended for most deployments.",
+			"testing": "Next stable candidate. Used to validate upcoming stable releases.",
+			"next":    "Bleeding edge. New kernel and package versions.",
+		}
+		for i, ch := range channels {
+			metas[i] = channelMeta{
+				name: ch,
+				desc: descs[ch],
+			}
+			for _, info := range m.Wizard.State.FCOSStreams {
+				if info.Stream == ch {
+					metas[i].version = info.Version
+					break
+				}
+			}
+		}
+		return metas
+	}
 
-// Default descriptions for Flatcar channels
-descs := map[string]string{
-"stable": "Tested for production. Default for most deployments.",
-"lts":    "Long-term support. Extended maintenance window.",
-"beta":   "Next stable candidate. Test before production.",
-"alpha":  "Bleeding edge. New kernel, systemd, core packages.",
-}
+	// Default descriptions for Flatcar channels
+	descs := map[string]string{
+		"stable": "Tested for production. Default for most deployments.",
+		"lts":    "Long-term support. Extended maintenance window.",
+		"beta":   "Next stable candidate. Test before production.",
+		"alpha":  "Bleeding edge. New kernel, systemd, core packages.",
+	}
 
-for i, ch := range channels {
-metas[i] = channelMeta{
-name: ch,
-desc: descs[ch],
-}
-for _, info := range m.Wizard.State.Channels {
-if info.Channel == ch {
-metas[i].version = info.Version
-metas[i].kernel = info.Kernel
-metas[i].systemd = info.Systemd
-metas[i].docker = info.Docker
-break
-}
-}
-}
-return metas
+	for i, ch := range channels {
+		metas[i] = channelMeta{
+			name: ch,
+			desc: descs[ch],
+		}
+		for _, info := range m.Wizard.State.Channels {
+			if info.Channel == ch {
+				metas[i].version = info.Version
+				metas[i].kernel = info.Kernel
+				metas[i].systemd = info.Systemd
+				metas[i].docker = info.Docker
+				break
+			}
+		}
+	}
+	return metas
 }
 
 // viewChannelCards renders the OS picker (when osSubView) or channel/stream selector cards.
 func (m *Model) viewChannelCards() string {
-if m.osSubView {
-return m.viewOSPicker()
-}
+	if m.osSubView {
+		return m.viewOSPicker()
+	}
 
-var b strings.Builder
-cfg := &m.Wizard.State.Config
+	var b strings.Builder
+	cfg := &m.Wizard.State.Config
 
-selectedBorder := lipgloss.NewStyle().
-Border(lipgloss.RoundedBorder()).
-BorderForeground(lipgloss.Color("51")).
-Padding(0, 1).
-Width(60)
-normalBorder := lipgloss.NewStyle().
-Border(lipgloss.RoundedBorder()).
-BorderForeground(lipgloss.Color("240")).
-Padding(0, 1).
-Width(60)
-nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
-nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-versionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
-detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+	selectedBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("51")).
+		Padding(0, 1).
+		Width(60)
+	normalBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Width(60)
+	nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+	nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	versionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
 
-if cfg.OS == model.OSFCOS {
-b.WriteString("  Select a Fedora CoreOS stream:\n\n")
-} else {
-b.WriteString("  Select a release channel:\n\n")
-}
+	if cfg.OS == model.OSFCOS {
+		b.WriteString("  Select a Fedora CoreOS stream:\n\n")
+	} else {
+		b.WriteString("  Select a release channel:\n\n")
+	}
 
-metas := m.getChannelMeta()
-for i, meta := range metas {
-selected := i == m.cursor
+	metas := m.getChannelMeta()
+	for i, meta := range metas {
+		selected := i == m.cursor
 
-var card strings.Builder
+		var card strings.Builder
 
-cursor := "  "
-nameStyle := nameNormal
-if selected {
-cursor = cursorStyle.Render("▸ ")
-nameStyle = nameSelected
-}
+		cursor := "  "
+		nameStyle := nameNormal
+		if selected {
+			cursor = cursorStyle.Render("▸ ")
+			nameStyle = nameSelected
+		}
 
-var displayName string
-if meta.name == "lts" {
-displayName = "LTS"
-} else {
-displayName = strings.ToUpper(meta.name[:1]) + meta.name[1:]
-}
-name := nameStyle.Render(displayName)
-ver := ""
-if meta.version != "" {
-ver = versionStyle.Render("v" + meta.version)
-}
-padding := 60 - 4 - len(displayName) - len("v"+meta.version)
-if padding < 1 {
-padding = 1
-}
-card.WriteString(cursor + name + strings.Repeat(" ", padding) + ver)
-card.WriteString("\n")
+		var displayName string
+		if meta.name == "lts" {
+			displayName = "LTS"
+		} else {
+			displayName = strings.ToUpper(meta.name[:1]) + meta.name[1:]
+		}
+		name := nameStyle.Render(displayName)
+		ver := ""
+		if meta.version != "" {
+			ver = versionStyle.Render("v" + meta.version)
+		}
+		padding := 60 - 4 - len(displayName) - len("v"+meta.version)
+		if padding < 1 {
+			padding = 1
+		}
+		card.WriteString(cursor + name + strings.Repeat(" ", padding) + ver)
+		card.WriteString("\n")
 
-card.WriteString("  " + descStyle.Render(meta.desc))
+		card.WriteString("  " + descStyle.Render(meta.desc))
 
-if meta.kernel != "" || meta.systemd != "" || meta.docker != "" {
-card.WriteString("\n")
-parts := []string{}
-if meta.kernel != "" {
-parts = append(parts, "linux "+meta.kernel)
-}
-if meta.systemd != "" {
-parts = append(parts, "systemd "+meta.systemd)
-}
-if meta.docker != "" {
-parts = append(parts, "docker "+meta.docker)
-}
-card.WriteString("  " + detailStyle.Render(strings.Join(parts, " · ")))
-}
+		if meta.kernel != "" || meta.systemd != "" || meta.docker != "" {
+			card.WriteString("\n")
+			parts := []string{}
+			if meta.kernel != "" {
+				parts = append(parts, "linux "+meta.kernel)
+			}
+			if meta.systemd != "" {
+				parts = append(parts, "systemd "+meta.systemd)
+			}
+			if meta.docker != "" {
+				parts = append(parts, "docker "+meta.docker)
+			}
+			card.WriteString("  " + detailStyle.Render(strings.Join(parts, " · ")))
+		}
 
-if selected {
-b.WriteString(selectedBorder.Render(card.String()))
-} else {
-b.WriteString(normalBorder.Render(card.String()))
-}
-b.WriteString("\n")
-}
+		if selected {
+			b.WriteString(selectedBorder.Render(card.String()))
+		} else {
+			b.WriteString(normalBorder.Render(card.String()))
+		}
+		b.WriteString("\n")
+	}
 
-b.WriteString("\n")
-dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
-b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
-b.WriteString("\n\n")
-if cfg.OS == model.OSFCOS {
-b.WriteString(dim.Render("  Fedora CoreOS community: ") + link.Render("https://discussion.fedoraproject.org/tag/coreos"))
-} else {
-b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
-}
-b.WriteString("\n")
+	b.WriteString("\n")
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+	b.WriteString("\n\n")
+	if cfg.OS == model.OSFCOS {
+		b.WriteString(dim.Render("  Fedora CoreOS community: ") + link.Render("https://discussion.fedoraproject.org/tag/coreos"))
+	} else {
+		b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
+	}
+	b.WriteString("\n")
 
-return b.String()
+	return b.String()
 }
 
 // viewOSPicker renders two OS selection cards: Flatcar Container Linux and Fedora CoreOS.
 func (m *Model) viewOSPicker() string {
-var b strings.Builder
+	var b strings.Builder
 
-selectedBorder := lipgloss.NewStyle().
-Border(lipgloss.RoundedBorder()).
-BorderForeground(lipgloss.Color("51")).
-Padding(0, 1).
-Width(60)
-normalBorder := lipgloss.NewStyle().
-Border(lipgloss.RoundedBorder()).
-BorderForeground(lipgloss.Color("240")).
-Padding(0, 1).
-Width(60)
-nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
-nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+	selectedBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("51")).
+		Padding(0, 1).
+		Width(60)
+	normalBorder := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Width(60)
+	nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+	nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
 
-b.WriteString("  Select an operating system:\n\n")
+	b.WriteString("  Select an operating system:\n\n")
 
-type osOption struct {
-id   string
-name string
-desc string
+	type osOption struct {
+		id   string
+		name string
+		desc string
+	}
+	options := []osOption{
+		{model.OSFlatcar, "Flatcar Container Linux", "Immutable, container-optimised Linux. Ideal for Kubernetes nodes and edge workloads."},
+		{model.OSFCOS, "Fedora CoreOS", "Fedora's immutable, auto-updating container host. Based on rpm-ostree with Ignition provisioning."},
+	}
+
+	for i, opt := range options {
+		selected := i == m.cursor
+
+		cursor := "  "
+		nameStyle := nameNormal
+		if selected {
+			cursor = cursorStyle.Render("▸ ")
+			nameStyle = nameSelected
+		}
+
+		var card strings.Builder
+		card.WriteString(cursor + nameStyle.Render(opt.name) + "\n")
+		card.WriteString("  " + descStyle.Render(opt.desc))
+
+		if selected {
+			b.WriteString(selectedBorder.Render(card.String()))
+		} else {
+			b.WriteString(normalBorder.Render(card.String()))
+		}
+		b.WriteString("\n")
+	}
+
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	b.WriteString("\n")
+	b.WriteString(dim.Render("  ↑↓/jk select · enter continue"))
+	b.WriteString("\n")
+
+	return b.String()
 }
-options := []osOption{
-{model.OSFlatcar, "Flatcar Container Linux", "Immutable, container-optimised Linux. Ideal for Kubernetes nodes and edge workloads."},
-{model.OSFCOS, "Fedora CoreOS", "Fedora's immutable, auto-updating container host. Based on rpm-ostree with Ignition provisioning."},
-}
-
-for i, opt := range options {
-selected := i == m.cursor
-
-cursor := "  "
-nameStyle := nameNormal
-if selected {
-cursor = cursorStyle.Render("▸ ")
-nameStyle = nameSelected
-}
-
-var card strings.Builder
-card.WriteString(cursor + nameStyle.Render(opt.name) + "\n")
-card.WriteString("  " + descStyle.Render(opt.desc))
-
-if selected {
-b.WriteString(selectedBorder.Render(card.String()))
-} else {
-b.WriteString(normalBorder.Render(card.String()))
-}
-b.WriteString("\n")
-}
-
-dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-b.WriteString("\n")
-b.WriteString(dim.Render("  ↑↓/jk select · enter continue"))
-b.WriteString("\n")
-
-return b.String()
-}
-

--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -205,10 +205,15 @@ func (m *Model) buildTailscaleForm() *huh.Form {
 
 // buildReviewForm creates the huh confirm for the Review step.
 func (m *Model) buildReviewForm() *huh.Form {
+	cfg := &m.Wizard.State.Config
+	title := "⚠️  DESTRUCTIVE OPERATION — Install Flatcar to disk?"
+	if cfg.OS == model.OSFCOS {
+		title = "⚠️  DESTRUCTIVE OPERATION — Install Fedora CoreOS to disk?"
+	}
 	return huh.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("⚠️  DESTRUCTIVE OPERATION — Install Flatcar to disk?").
+				Title(title).
 				Description(m.reviewSummary()).
 				Affirmative("Yes, install").
 				Negative("Go back").
@@ -220,6 +225,9 @@ func (m *Model) buildReviewForm() *huh.Form {
 func (m *Model) reviewSummary() string {
 	cfg := &m.Wizard.State.Config
 	var b strings.Builder
+	if cfg.OS != "" {
+		fmt.Fprintf(&b, "OS: %s\n", cfg.OS)
+	}
 	fmt.Fprintf(&b, "Channel: %s", cfg.Channel)
 	if cfg.Version != "" {
 		fmt.Fprintf(&b, " (v%s)", cfg.Version)
@@ -378,152 +386,243 @@ func (m *Model) renderZenChrome() string {
 	return b.String()
 }
 
-// channelList returns the ordered list of channel keys for the card selector.
+// channelList returns the ordered list of channel/stream keys for the card selector.
+// For FCOS, returns the three release streams; for Flatcar, the four channels.
 func (m *Model) channelList() []string {
-	return []string{"stable", "lts", "beta", "alpha"}
+if m.Wizard.State.Config.OS == model.OSFCOS {
+return []string{"stable", "testing", "next"}
+}
+return []string{"stable", "lts", "beta", "alpha"}
 }
 
-// channelCardCount returns how many channel cards to display.
+// channelCardCount returns how many channel/stream cards to display.
 func (m *Model) channelCardCount() int {
-	return len(m.channelList())
+return len(m.channelList())
 }
 
 // channelMeta holds display info for each channel card.
 type channelMeta struct {
-	name    string
-	version string
-	kernel  string
-	systemd string
-	docker  string
-	desc    string
+name    string
+version string
+kernel  string
+systemd string
+docker  string
+desc    string
 }
 
-// getChannelMeta builds display metadata for each channel.
+// getChannelMeta builds display metadata for each channel/stream.
 func (m *Model) getChannelMeta() []channelMeta {
-	channels := m.channelList()
-	metas := make([]channelMeta, len(channels))
+channels := m.channelList()
+metas := make([]channelMeta, len(channels))
 
-	// Default descriptions
-	descs := map[string]string{
-		"stable": "Tested for production. Default for most deployments.",
-		"lts":    "Long-term support. Extended maintenance window.",
-		"beta":   "Next stable candidate. Test before production.",
-		"alpha":  "Bleeding edge. New kernel, systemd, core packages.",
-	}
-
-	for i, ch := range channels {
-		metas[i] = channelMeta{
-			name: ch,
-			desc: descs[ch],
-		}
-		// Fill in version info from fetched channel data
-		for _, info := range m.Wizard.State.Channels {
-			if info.Channel == ch {
-				metas[i].version = info.Version
-				metas[i].kernel = info.Kernel
-				metas[i].systemd = info.Systemd
-				metas[i].docker = info.Docker
-				break
-			}
-		}
-	}
-	return metas
+if m.Wizard.State.Config.OS == model.OSFCOS {
+descs := map[string]string{
+"stable":  "Production-ready FCOS stream. Recommended for most deployments.",
+"testing": "Next stable candidate. Used to validate upcoming stable releases.",
+"next":    "Bleeding edge. New kernel and package versions.",
+}
+for i, ch := range channels {
+metas[i] = channelMeta{
+name: ch,
+desc: descs[ch],
+}
+for _, info := range m.Wizard.State.FCOSStreams {
+if info.Stream == ch {
+metas[i].version = info.Version
+break
+}
+}
+}
+return metas
 }
 
-// viewChannelCards renders Flatcar-website-style channel selector cards.
+// Default descriptions for Flatcar channels
+descs := map[string]string{
+"stable": "Tested for production. Default for most deployments.",
+"lts":    "Long-term support. Extended maintenance window.",
+"beta":   "Next stable candidate. Test before production.",
+"alpha":  "Bleeding edge. New kernel, systemd, core packages.",
+}
+
+for i, ch := range channels {
+metas[i] = channelMeta{
+name: ch,
+desc: descs[ch],
+}
+for _, info := range m.Wizard.State.Channels {
+if info.Channel == ch {
+metas[i].version = info.Version
+metas[i].kernel = info.Kernel
+metas[i].systemd = info.Systemd
+metas[i].docker = info.Docker
+break
+}
+}
+}
+return metas
+}
+
+// viewChannelCards renders the OS picker (when osSubView) or channel/stream selector cards.
 func (m *Model) viewChannelCards() string {
-	var b strings.Builder
-
-	// Styles
-	selectedBorder := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("51")).
-		Padding(0, 1).
-		Width(60)
-	normalBorder := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1).
-		Width(60)
-	nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
-	nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	versionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
-	detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
-
-	b.WriteString("  Select a release channel:\n\n")
-
-	metas := m.getChannelMeta()
-	for i, meta := range metas {
-		selected := i == m.cursor
-
-		// Build card content
-		var card strings.Builder
-
-		// Line 1: cursor + name + version (right-aligned)
-		cursor := "  "
-		nameStyle := nameNormal
-		if selected {
-			cursor = cursorStyle.Render("▸ ")
-			nameStyle = nameSelected
-		}
-
-		var displayName string
-		if meta.name == "lts" {
-			displayName = "LTS"
-		} else {
-			displayName = strings.ToUpper(meta.name[:1]) + meta.name[1:]
-		}
-		name := nameStyle.Render(displayName)
-		ver := ""
-		if meta.version != "" {
-			ver = versionStyle.Render("v" + meta.version)
-		}
-		// Pad between name and version: ensure non-negative (handles long names)
-		padding := 60 - 4 - len(displayName) - len("v"+meta.version)
-		if padding < 1 {
-			padding = 1 // Minimum 1 space separator
-		}
-		card.WriteString(cursor + name + strings.Repeat(" ", padding) + ver)
-		card.WriteString("\n")
-
-		// Line 2: description
-		card.WriteString("  " + descStyle.Render(meta.desc))
-
-		// Line 3: component versions (if available)
-		if meta.kernel != "" || meta.systemd != "" || meta.docker != "" {
-			card.WriteString("\n")
-			parts := []string{}
-			if meta.kernel != "" {
-				parts = append(parts, "linux "+meta.kernel)
-			}
-			if meta.systemd != "" {
-				parts = append(parts, "systemd "+meta.systemd)
-			}
-			if meta.docker != "" {
-				parts = append(parts, "docker "+meta.docker)
-			}
-			card.WriteString("  " + detailStyle.Render(strings.Join(parts, " · ")))
-		}
-
-		// Render with border
-		if selected {
-			b.WriteString(selectedBorder.Render(card.String()))
-		} else {
-			b.WriteString(normalBorder.Render(card.String()))
-		}
-		b.WriteString("\n")
-	}
-
-	// Show advanced hint + community link
-	b.WriteString("\n")
-	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
-	b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
-	b.WriteString("\n")
-	b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
-	b.WriteString("\n")
-
-	return b.String()
+if m.osSubView {
+return m.viewOSPicker()
 }
+
+var b strings.Builder
+cfg := &m.Wizard.State.Config
+
+selectedBorder := lipgloss.NewStyle().
+Border(lipgloss.RoundedBorder()).
+BorderForeground(lipgloss.Color("51")).
+Padding(0, 1).
+Width(60)
+normalBorder := lipgloss.NewStyle().
+Border(lipgloss.RoundedBorder()).
+BorderForeground(lipgloss.Color("240")).
+Padding(0, 1).
+Width(60)
+nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+versionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+
+if cfg.OS == model.OSFCOS {
+b.WriteString("  Select a Fedora CoreOS stream:\n\n")
+} else {
+b.WriteString("  Select a release channel:\n\n")
+}
+
+metas := m.getChannelMeta()
+for i, meta := range metas {
+selected := i == m.cursor
+
+var card strings.Builder
+
+cursor := "  "
+nameStyle := nameNormal
+if selected {
+cursor = cursorStyle.Render("▸ ")
+nameStyle = nameSelected
+}
+
+var displayName string
+if meta.name == "lts" {
+displayName = "LTS"
+} else {
+displayName = strings.ToUpper(meta.name[:1]) + meta.name[1:]
+}
+name := nameStyle.Render(displayName)
+ver := ""
+if meta.version != "" {
+ver = versionStyle.Render("v" + meta.version)
+}
+padding := 60 - 4 - len(displayName) - len("v"+meta.version)
+if padding < 1 {
+padding = 1
+}
+card.WriteString(cursor + name + strings.Repeat(" ", padding) + ver)
+card.WriteString("\n")
+
+card.WriteString("  " + descStyle.Render(meta.desc))
+
+if meta.kernel != "" || meta.systemd != "" || meta.docker != "" {
+card.WriteString("\n")
+parts := []string{}
+if meta.kernel != "" {
+parts = append(parts, "linux "+meta.kernel)
+}
+if meta.systemd != "" {
+parts = append(parts, "systemd "+meta.systemd)
+}
+if meta.docker != "" {
+parts = append(parts, "docker "+meta.docker)
+}
+card.WriteString("  " + detailStyle.Render(strings.Join(parts, " · ")))
+}
+
+if selected {
+b.WriteString(selectedBorder.Render(card.String()))
+} else {
+b.WriteString(normalBorder.Render(card.String()))
+}
+b.WriteString("\n")
+}
+
+b.WriteString("\n")
+dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
+b.WriteString(dim.Render("  Ctrl+A advanced options · ↑↓/jk select · enter continue"))
+b.WriteString("\n\n")
+if cfg.OS == model.OSFCOS {
+b.WriteString(dim.Render("  Fedora CoreOS community: ") + link.Render("https://discussion.fedoraproject.org/tag/coreos"))
+} else {
+b.WriteString(dim.Render("  Join the Flatcar community: ") + link.Render("https://flatcar.org/discord"))
+}
+b.WriteString("\n")
+
+return b.String()
+}
+
+// viewOSPicker renders two OS selection cards: Flatcar Container Linux and Fedora CoreOS.
+func (m *Model) viewOSPicker() string {
+var b strings.Builder
+
+selectedBorder := lipgloss.NewStyle().
+Border(lipgloss.RoundedBorder()).
+BorderForeground(lipgloss.Color("51")).
+Padding(0, 1).
+Width(60)
+normalBorder := lipgloss.NewStyle().
+Border(lipgloss.RoundedBorder()).
+BorderForeground(lipgloss.Color("240")).
+Padding(0, 1).
+Width(60)
+nameSelected := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("51"))
+nameNormal := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("51")).Bold(true)
+
+b.WriteString("  Select an operating system:\n\n")
+
+type osOption struct {
+id   string
+name string
+desc string
+}
+options := []osOption{
+{model.OSFlatcar, "Flatcar Container Linux", "Immutable, container-optimised Linux. Ideal for Kubernetes nodes and edge workloads."},
+{model.OSFCOS, "Fedora CoreOS", "Fedora's immutable, auto-updating container host. Based on rpm-ostree with Ignition provisioning."},
+}
+
+for i, opt := range options {
+selected := i == m.cursor
+
+cursor := "  "
+nameStyle := nameNormal
+if selected {
+cursor = cursorStyle.Render("▸ ")
+nameStyle = nameSelected
+}
+
+var card strings.Builder
+card.WriteString(cursor + nameStyle.Render(opt.name) + "\n")
+card.WriteString("  " + descStyle.Render(opt.desc))
+
+if selected {
+b.WriteString(selectedBorder.Render(card.String()))
+} else {
+b.WriteString(normalBorder.Render(card.String()))
+}
+b.WriteString("\n")
+}
+
+dim := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+b.WriteString("\n")
+b.WriteString(dim.Render("  ↑↓/jk select · enter continue"))
+b.WriteString("\n")
+
+return b.String()
+}
+

--- a/internal/tui/forms_test.go
+++ b/internal/tui/forms_test.go
@@ -19,6 +19,7 @@ func TestViewChannelCardsLongVersionNoPanic(t *testing.T) {
 	}
 	m := New(w)
 	m.cursor = 0
+	m.osSubView = false // skip OS picker, test channel cards
 
 	// This should not panic even with a very long version string
 	// Regression test for #248 (negative padding fix)
@@ -40,6 +41,7 @@ func TestViewChannelCardsSelectsCurrent(t *testing.T) {
 	}
 	m := New(w)
 	m.cursor = 0
+	m.osSubView = false // skip OS picker, test channel cards
 
 	out := m.viewChannelCards()
 	if !strings.Contains(out, "▸") {

--- a/internal/tui/handleenter_test.go
+++ b/internal/tui/handleenter_test.go
@@ -127,8 +127,12 @@ func TestHandleEnter_Welcome_ChannelSelection(t *testing.T) {
 	w.State.Config.Hostname = "test"
 
 	m := New(w)
-	m.cursor = 2 // "beta" (channels are: stable, lts, beta, alpha)
+	// Phase 1: OS picker — select Flatcar (cursor 0)
+	m.cursor = 0
+	_, _ = m.handleEnter()
 
+	// Phase 2: channel picker — select "beta" (index 2 in stable,lts,beta,alpha)
+	m.cursor = 2
 	_, _ = m.handleEnter()
 
 	if m.Wizard.State.Config.Channel != "beta" {
@@ -143,8 +147,12 @@ func TestHandleEnter_Welcome_WithIgnitionURL(t *testing.T) {
 	w.State.Config.IgnitionURL = "https://example.com/config.ign"
 
 	m := New(w)
+	// Phase 1: OS picker — select Flatcar
 	m.cursor = 0
+	_, _ = m.handleEnter()
 
+	// Phase 2: channel picker — with IgnitionURL set, should skip to Storage
+	m.cursor = 0
 	_, _ = m.handleEnter()
 
 	if m.Wizard.State.CurrentStep != model.StepStorage {
@@ -243,7 +251,7 @@ func TestMaxCursor_AllSteps(t *testing.T) {
 		disks  int
 		expect int
 	}{
-		{model.StepWelcome, 0, 4}, // 4 channels
+		{model.StepWelcome, 0, 2}, // 2 OS choices (Flatcar | FCOS) in OS picker
 		{model.StepStorage, 3, 3}, // number of disks
 		{model.StepStorage, 0, 0}, // no disks
 		{model.StepSysext, 0, 0},  // empty sysexts

--- a/internal/tui/quality_ignitionurl_test.go
+++ b/internal/tui/quality_ignitionurl_test.go
@@ -15,6 +15,12 @@ func TestHandleEnter_Welcome_IgnitionURL_SkipsToStorage(t *testing.T) {
 	w.State.Config.Channel = "stable"
 
 	m := New(w)
+	// Phase 1: OS picker — select Flatcar (cursor 0)
+	m.cursor = 0
+	_, _ = m.handleEnter()
+
+	// Phase 2: channel picker — IgnitionURL set → should skip to Storage
+	m.cursor = 0
 	_, _ = m.handleEnter()
 
 	if m.Wizard.State.CurrentStep != model.StepStorage {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -68,6 +68,10 @@ type Model struct {
 	tailscaleRoutesIn  string
 	showAdvanced       bool
 
+	// osSubView tracks whether the StepWelcome OS picker is shown (true)
+	// or the channel/stream card picker is shown (false).
+	osSubView bool
+
 	// Sysext list (bubbles/list)
 	sysextList      list.Model
 	sysextListReady bool
@@ -444,6 +448,9 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m *Model) maxCursor() int {
 	switch m.Wizard.State.CurrentStep {
 	case model.StepWelcome:
+		if m.osSubView {
+			return 2 // Flatcar | FCOS
+		}
 		return m.channelCardCount()
 	case model.StepStorage:
 		return len(m.Wizard.State.Disks)
@@ -452,6 +459,9 @@ func (m *Model) maxCursor() int {
 	case model.StepNvidia:
 		return len(model.NvidiaDriverOptions)
 	case model.StepUpdate:
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			return 2 // immediate | disabled
+		}
 		return 3
 	default:
 		return 1
@@ -464,7 +474,17 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 
 	switch step {
 	case model.StepWelcome:
-		// Apply channel selection from card cursor
+		if m.osSubView {
+			// OS picker — cursor 0 = Flatcar, cursor 1 = FCOS
+			osList := []string{model.OSFlatcar, model.OSFCOS}
+			if m.cursor >= 0 && m.cursor < len(osList) {
+				m.Wizard.State.Config.OS = osList[m.cursor]
+			}
+			m.osSubView = false
+			m.cursor = 0
+			return m, nil
+		}
+		// Apply channel/stream selection from card cursor
 		channels := m.channelList()
 		if m.cursor >= 0 && m.cursor < len(channels) {
 			m.Wizard.State.Config.Channel = channels[m.cursor]
@@ -501,9 +521,16 @@ func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 			m.Wizard.State.Config.NvidiaDriverVersion = model.NvidiaDriverOptions[m.cursor].ID
 		}
 	case model.StepUpdate:
-		strategies := []string{"reboot", "off", "etcd-lock"}
-		if m.cursor >= 0 && m.cursor < len(strategies) {
-			m.Wizard.State.Config.UpdateStrategy.RebootStrategy = strategies[m.cursor]
+		if m.Wizard.State.Config.OS == model.OSFCOS {
+			strategies := []string{model.FCOSStrategyImmediate, model.FCOSStrategyDisabled}
+			if m.cursor >= 0 && m.cursor < len(strategies) {
+				m.Wizard.State.Config.UpdateStrategy.FCOSUpdateStrategy = strategies[m.cursor]
+			}
+		} else {
+			strategies := []string{"reboot", "off", "etcd-lock"}
+			if m.cursor >= 0 && m.cursor < len(strategies) {
+				m.Wizard.State.Config.UpdateStrategy.RebootStrategy = strategies[m.cursor]
+			}
 		}
 	case model.StepUser:
 		// Collect local keys first so they're always included even without GitHub.
@@ -617,8 +644,14 @@ func (m *Model) applyFields() {
 			switch f.key {
 			case "channel":
 				if f.value != "" {
-					if err := validate.Channel(f.value); err != nil {
-						m.err = err
+					var chanErr error
+					if cfg.OS == model.OSFCOS {
+						chanErr = validate.FCOSStream(f.value)
+					} else {
+						chanErr = validate.Channel(f.value)
+					}
+					if chanErr != nil {
+						m.err = chanErr
 						return
 					}
 					cfg.Channel = f.value
@@ -715,7 +748,9 @@ func (m *Model) initStepFields() {
 	m.fieldIdx = 0
 	switch m.Wizard.State.CurrentStep {
 	case model.StepWelcome:
-		// Card-based channel selector — no text fields
+		// Show OS picker first; channel cards follow after OS selection.
+		m.osSubView = true
+		m.cursor = 0
 		m.fields = nil
 	case model.StepNvidia:
 		// Position cursor at the currently configured driver version.
@@ -1150,27 +1185,45 @@ func wordWrap(s string, width int) []string {
 
 func (m *Model) viewUpdate() string {
 	var b strings.Builder
-	b.WriteString("Update Strategy\n\nChoose how Flatcar will handle OS updates:\n\n")
+	cfg := m.Wizard.State.Config
 
 	type option struct {
 		name string
 		desc []string
 	}
-	options := []option{
-		{"reboot (Recommended)", []string{
-			"Auto-update and reboot immediately when an update is applied.",
-			"Best for: single nodes, dev environments",
-		}},
-		{"off", []string{
-			"Updates are downloaded but never applied automatically.",
-			"You must run 'update_engine_client -update' manually.",
-			"Best for: manually managed infrastructure",
-		}},
-		{"etcd-lock", []string{
-			"Coordinates reboots with other nodes via etcd distributed lock.",
-			"Only one node reboots at a time in the cluster.",
-			"Best for: multi-node clusters running etcd",
-		}},
+
+	var options []option
+	if cfg.OS == model.OSFCOS {
+		b.WriteString("Update Strategy\n\nChoose how Fedora CoreOS will handle OS updates:\n\n")
+		options = []option{
+			{"immediate (Recommended)", []string{
+				"Zincati auto-updates and reboots as soon as an update is staged.",
+				"Best for: single nodes, dev environments",
+			}},
+			{"disabled", []string{
+				"Zincati is disabled — no automatic updates.",
+				"You must update manually with 'rpm-ostree upgrade'.",
+				"Best for: air-gapped or manually managed infrastructure",
+			}},
+		}
+	} else {
+		b.WriteString("Update Strategy\n\nChoose how Flatcar will handle OS updates:\n\n")
+		options = []option{
+			{"reboot (Recommended)", []string{
+				"Auto-update and reboot immediately when an update is applied.",
+				"Best for: single nodes, dev environments",
+			}},
+			{"off", []string{
+				"Updates are downloaded but never applied automatically.",
+				"You must run 'update_engine_client -update' manually.",
+				"Best for: manually managed infrastructure",
+			}},
+			{"etcd-lock", []string{
+				"Coordinates reboots with other nodes via etcd distributed lock.",
+				"Only one node reboots at a time in the cluster.",
+				"Best for: multi-node clusters running etcd",
+			}},
+		}
 	}
 
 	for i, opt := range options {
@@ -1197,7 +1250,11 @@ func (m *Model) viewInstall() string {
 	var b strings.Builder
 	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 
-	b.WriteString("Installing Flatcar Container Linux...\n\n")
+	osName := "Flatcar Container Linux"
+	if m.Wizard.State.Config.OS == model.OSFCOS {
+		osName = "Fedora CoreOS"
+	}
+	fmt.Fprintf(&b, "Installing %s...\n\n", osName)
 
 	// Completed phases with green checkmarks
 	for _, msg := range m.Wizard.State.ProgressMessages {
@@ -1226,7 +1283,11 @@ func (m *Model) viewDone() string {
 		b.WriteString("\n✅ Installation Complete!\n\n")
 	}
 
-	b.WriteString("Flatcar Container Linux has been installed:\n\n")
+	osName := "Flatcar Container Linux"
+	if cfg.OS == model.OSFCOS {
+		osName = "Fedora CoreOS"
+	}
+	fmt.Fprintf(&b, "%s has been installed:\n\n", osName)
 
 	if cfg.Disk.Model != "" {
 		fmt.Fprintf(&b, "  Disk:     %s (%s)\n", cfg.Disk.Model, cfg.Disk.SizeHuman)
@@ -1256,8 +1317,13 @@ func (m *Model) viewDone() string {
 	link := lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
 	b.WriteString("\n")
 	b.WriteString(dim.Render("Community & help:") + "\n")
-	b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
-	b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+	if cfg.OS == model.OSFCOS {
+		b.WriteString("  " + link.Render("https://discussion.fedoraproject.org/tag/coreos") + dim.Render("  — Fedora CoreOS community") + "\n")
+		b.WriteString("  " + link.Render("https://docs.fedoraproject.org/en-US/fedora-coreos/") + dim.Render("  — Fedora CoreOS documentation") + "\n")
+	} else {
+		b.WriteString("  " + link.Render("https://flatcar.org/discord") + dim.Render("  — Flatcar community on Discord") + "\n")
+		b.WriteString("  " + link.Render("https://www.flatcar.org/docs/") + dim.Render("  — Flatcar documentation") + "\n")
+	}
 
 	b.WriteString("\n")
 	if cfg.DryRun {

--- a/internal/tui/tui_forms_helpers_test.go
+++ b/internal/tui/tui_forms_helpers_test.go
@@ -77,7 +77,8 @@ func TestViewChannelCards_SelectedChannel(t *testing.T) {
 	w := newTestWizard()
 	w.State.Config.Channel = "stable"
 	m := New(w)
-	m.cursor = 0 // points at "stable"
+	m.cursor = 0
+	m.osSubView = false // skip OS picker, test channel cards directly
 	out := m.viewChannelCards()
 	if !strings.Contains(out, "Stable") {
 		t.Errorf("viewChannelCards should show 'Stable': %q", out)
@@ -89,6 +90,7 @@ func TestViewChannelCards_LTSDisplayName(t *testing.T) {
 	w.State.Config.Channel = "lts"
 	m := New(w)
 	m.cursor = 1 // points at "lts" (index 1 in channelList)
+	m.osSubView = false // skip OS picker, test channel cards directly
 	out := m.viewChannelCards()
 	if !strings.Contains(out, "LTS") {
 		t.Errorf("viewChannelCards should show 'LTS' for lts channel: %q", out)
@@ -103,6 +105,7 @@ func TestViewChannelCards_WithVersionInfo(t *testing.T) {
 	}
 	m := New(w)
 	m.cursor = 0
+	m.osSubView = false // skip OS picker, test channel cards directly
 	out := m.viewChannelCards()
 	if !strings.Contains(out, "4593.2.0") {
 		t.Errorf("viewChannelCards should show version when channels loaded: %q", out)

--- a/internal/tui/tui_forms_helpers_test.go
+++ b/internal/tui/tui_forms_helpers_test.go
@@ -89,7 +89,7 @@ func TestViewChannelCards_LTSDisplayName(t *testing.T) {
 	w := newTestWizard()
 	w.State.Config.Channel = "lts"
 	m := New(w)
-	m.cursor = 1 // points at "lts" (index 1 in channelList)
+	m.cursor = 1        // points at "lts" (index 1 in channelList)
 	m.osSubView = false // skip OS picker, test channel cards directly
 	out := m.viewChannelCards()
 	if !strings.Contains(out, "LTS") {

--- a/internal/tui/tui_new_coverage_test.go
+++ b/internal/tui/tui_new_coverage_test.go
@@ -347,6 +347,7 @@ func TestViewChannelCards_WithComponentVersions(t *testing.T) {
 		},
 	}
 	m := New(w)
+	m.osSubView = false // skip OS picker, test channel cards directly
 	out := m.viewChannelCards()
 	// The component-version rendering path (kernel/systemd/docker) should have run.
 	if !strings.Contains(out, "linux") || !strings.Contains(out, "6.1.90") {

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -174,7 +174,7 @@ func TestMaxCursor(t *testing.T) {
 	}{
 		{
 			step:     model.StepWelcome,
-			expected: 4, // stable, lts, beta, alpha
+			expected: 2, // OS picker (Flatcar | FCOS) — shown first via osSubView
 		},
 		{
 			step: model.StepStorage,

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -18,6 +18,24 @@ import (
 // fetchAllChannelsFn is a package-level hook so tests can inject a mock.
 var fetchAllChannelsFn = bakery.FetchAllChannels
 
+// fetchFCOSStreamVersionFn fetches the Fedora version label for an FCOS stream.
+// Tests can replace this to avoid network calls.
+var fetchFCOSStreamVersionFn = fetchFCOSStreamVersion
+
+// fetchFCOSStreamVersion fetches the current release version for an FCOS stream.
+// Returns the stream name itself as fallback; empty string on any hard error.
+func fetchFCOSStreamVersion(ctx context.Context, stream string) (string, error) {
+	return stream, nil // version data requires #641; stream name is shown until then
+}
+
+// FCOSStreamInfo holds minimal display data for an FCOS stream.
+type FCOSStreamInfo struct {
+	Stream  string // "stable", "testing", "next"
+	Version string // version label, e.g. stream name or future Fedora release version
+}
+
+
+
 // State holds the complete wizard state
 type State struct {
 	CurrentStep model.WizardStep
@@ -36,6 +54,9 @@ type State struct {
 
 	// Channel version info (fetched at startup)
 	Channels []bakery.ChannelInfo
+
+	// FCOS stream info (fetched at startup when OS == FCOS)
+	FCOSStreams []FCOSStreamInfo
 
 	// System checks (populated at startup)
 	SystemChecks []SystemCheck
@@ -369,9 +390,17 @@ func (w *Wizard) runSystemChecks() {
 }
 
 // FetchSysexts loads the sysext catalog for the configured architecture.
+// For FCOS, sysexts are not yet supported (no FCOS-specific catalog) — the
+// step is skipped via skipStepFor(). Full FCOS catalog support requires #641.
 // If an NVIDIA GPU was detected during ProbeHardware, nvidia-runtime is
 // auto-selected and the default driver series is pre-configured.
 func (w *Wizard) FetchSysexts(ctx context.Context) error {
+	if w.State.Config.OS == model.OSFCOS {
+		// FCOS sysext catalog support requires #641 (FetchCatalogFCOS).
+		// For now, leave Sysexts empty so the step is a no-op for FCOS.
+		w.State.Sysexts = nil
+		return nil
+	}
 	sysexts, err := w.Bakery.FetchCatalogArch(ctx, w.State.Config.Arch)
 	if err != nil {
 		return fmt.Errorf("fetching sysext catalog: %w", err)
@@ -404,6 +433,24 @@ func (w *Wizard) FetchChannels(ctx context.Context) error {
 		return nil
 	}
 	return err
+}
+
+// FetchFCOSStreams loads version info for the three FCOS streams (stable, testing, next).
+// Version info is best-effort — failures are non-fatal; the picker will show streams
+// without version numbers rather than blocking the TUI.
+func (w *Wizard) FetchFCOSStreams(ctx context.Context) error {
+	streams := []string{"stable", "testing", "next"}
+	infos := make([]FCOSStreamInfo, 0, len(streams))
+	for _, s := range streams {
+		version, err := fetchFCOSStreamVersionFn(ctx, s)
+		info := FCOSStreamInfo{Stream: s}
+		if err == nil {
+			info.Version = version
+		}
+		infos = append(infos, info)
+	}
+	w.State.FCOSStreams = infos
+	return nil
 }
 
 // Execute runs the installation

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -34,8 +34,6 @@ type FCOSStreamInfo struct {
 	Version string // version label, e.g. stream name or future Fedora release version
 }
 
-
-
 // State holds the complete wizard state
 type State struct {
 	CurrentStep model.WizardStep

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2271,7 +2271,6 @@ func TestPrevious_TailscaleBoundarySkipsOrVisitsNvidia(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 // TestNext_FCOS_SkipsNvidiaEvenWhenSelected verifies that when OS is FCOS,
 // the nvidia step is unconditionally skipped — even if the nvidia-runtime
 // sysext happens to be in the selection list. Covers wizard.go:130-132.

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2392,4 +2392,3 @@ func TestIsNvidiaSelected_FCOSAlwaysFalse(t *testing.T) {
 		t.Error("isNvidiaSelected should return false for FCOS regardless of sysext selection")
 	}
 }
-

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -2271,6 +2271,7 @@ func TestPrevious_TailscaleBoundarySkipsOrVisitsNvidia(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 // TestNext_FCOS_SkipsNvidiaEvenWhenSelected verifies that when OS is FCOS,
 // the nvidia step is unconditionally skipped — even if the nvidia-runtime
 // sysext happens to be in the selection list. Covers wizard.go:130-132.
@@ -2320,3 +2321,76 @@ func TestPrevious_FCOS_SkipsNvidiaEvenWhenSelected(t *testing.T) {
 		t.Errorf("expected StepSysext after backward skip on FCOS, got %v", w.State.CurrentStep)
 	}
 }
+
+func TestFetchFCOSStreams_Success(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	orig := fetchFCOSStreamVersionFn
+	t.Cleanup(func() { fetchFCOSStreamVersionFn = orig })
+	fetchFCOSStreamVersionFn = func(_ context.Context, s string) (string, error) {
+		return "v" + s, nil
+	}
+
+	if err := w.FetchFCOSStreams(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(w.State.FCOSStreams) != 3 {
+		t.Fatalf("expected 3 streams, got %d", len(w.State.FCOSStreams))
+	}
+	if w.State.FCOSStreams[0].Version != "vstable" {
+		t.Errorf("stream 0 version: got %q, want vstable", w.State.FCOSStreams[0].Version)
+	}
+}
+
+func TestFetchFCOSStreams_ErrorNonFatal(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	orig := fetchFCOSStreamVersionFn
+	t.Cleanup(func() { fetchFCOSStreamVersionFn = orig })
+	fetchFCOSStreamVersionFn = func(_ context.Context, s string) (string, error) {
+		return "", fmt.Errorf("network error")
+	}
+
+	if err := w.FetchFCOSStreams(context.Background()); err != nil {
+		t.Fatalf("FetchFCOSStreams must not return error on version fetch failure, got: %v", err)
+	}
+	if len(w.State.FCOSStreams) != 3 {
+		t.Fatalf("expected 3 stream entries even on error, got %d", len(w.State.FCOSStreams))
+	}
+	for _, info := range w.State.FCOSStreams {
+		if info.Version != "" {
+			t.Errorf("version should be empty on error, got %q for %s", info.Version, info.Stream)
+		}
+	}
+}
+
+func TestFetchFCOSStreamVersion_ReturnsStreamName(t *testing.T) {
+	got, err := fetchFCOSStreamVersion(context.Background(), "stable")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "stable" {
+		t.Errorf("got %q, want stable", got)
+	}
+}
+
+func TestFetchSysexts_FCOSSkipsLookup(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+
+	if err := w.FetchSysexts(context.Background()); err != nil {
+		t.Fatalf("FetchSysexts on FCOS should not error, got: %v", err)
+	}
+	if w.State.Sysexts != nil {
+		t.Errorf("FetchSysexts on FCOS should leave Sysexts nil, got %v", w.State.Sysexts)
+	}
+}
+
+func TestIsNvidiaSelected_FCOSAlwaysFalse(t *testing.T) {
+	w, _, _, _ := newTestWizard()
+	w.State.Config.OS = model.OSFCOS
+	w.State.Sysexts = []model.SysextEntry{{Name: "nvidia-runtime", Selected: true}}
+
+	if w.isNvidiaSelected() {
+		t.Error("isNvidiaSelected should return false for FCOS regardless of sysext selection")
+	}
+}
+


### PR DESCRIPTION
Closes #643

## Summary

Implements the full TUI FCOS/Flatcar split at every OS-sensitive step in the wizard.

### Changes

#### OS picker sub-view (StepWelcome)
- New `osSubView bool` on TUI `Model`: `true` = OS picker, `false` = channel/stream cards
- `initStepFields` sets `osSubView = true` for `StepWelcome`; two-phase `handleEnter` flow
- `viewOSPicker()` renders bordered cards for Flatcar Container Linux and Fedora CoreOS

#### FCOS stream cards
- `channelList()` returns `["stable","testing","next"]` for FCOS vs Flatcar's four channels
- `getChannelMeta()` branches on OS; populates version from `State.FCOSStreams`
- Community link switches to `discussion.fedoraproject.org/tag/coreos` for FCOS

#### StepUpdate — FCOS strategies
- `maxCursor()` returns 2 for FCOS (immediate/disabled), 3 for Flatcar
- `viewUpdate()` shows Fedora CoreOS header + zincati strategy descriptions for FCOS
- `handleEnter()` stores strategy in `UpdateStrategy.FCOSUpdateStrategy`

#### Per-step Flatcar string cleanup
- Hostname default: `"fcos"` for FCOS, `"flatcar"` for Flatcar in `initForm()`
- `buildReviewForm()` title: "Install Fedora CoreOS to disk?" for FCOS
- `reviewSummary()` now includes OS row
- `viewInstall()` / `viewDone()`: OS-aware titles and community links
- `applyFields()`: uses `validate.FCOSStream()` for FCOS channel validation

#### wizard.go / main.go
- `FCOSStreamInfo` type + `FCOSStreams []FCOSStreamInfo` field on `State`
- `FetchFCOSStreams(ctx)` — fetches FCOS stream metadata (stub for #641)
- `FetchSysexts()` returns nil for FCOS (FetchCatalogFCOS requires #641)
- `FetchFCOSStreams()` wired in `main.go` alongside `FetchChannels()`

### Tests
- 27 new FCOS TUI tests in `fcos_tui_test.go`
- Existing channel-card tests updated to set `m.osSubView = false` where needed
- All 17 packages pass: `ok` / no failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fedora CoreOS support in the installer flow, including OS-specific stream selection, update options, and install-complete messaging.
  * Displayed FCOS stream version information where available, with graceful fallback if version data can’t be loaded.

* **Bug Fixes**
  * Default hostnames now match the selected OS.
  * Improved welcome-step navigation so OS selection and channel selection are handled in separate steps.
  * FCOS installs now skip unsupported sysext and NVIDIA selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->