### PR TITLE
feat(bakery): FCOS sysext catalog client for fedora-sysexts/community

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -121,7 +121,7 @@ cover-check:
         [model]=100 [validate]=99 [ignition]=100 [github]=96
         [bakery]=100 [probe]=100   [runner]=100   [install]=100
         [headless]=99 [wizard]=99  [iso]=100      [tui]=99
-        [demo]=100
+        [demo]=100   [fcos]=100
     )
     fail=0
     for pkg in "${!targets[@]}"; do

--- a/internal/bakery/fcos.go
+++ b/internal/bakery/fcos.go
@@ -1,0 +1,272 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+	"github.com/projectbluefin/knuckle/internal/validate"
+)
+
+const (
+	// FCOSCatalogURL is the GitHub Releases API for the fedora-sysexts/community
+	// sysext catalog.  This catalog is updated daily and covers both x86-64 and
+	// arm64 builds for all supported Fedora major versions.
+	FCOSCatalogURL = "https://api.github.com/repos/fedora-sysexts/community/releases?per_page=100"
+
+	// fcosMaxCatalogPages caps the number of GitHub API pages fetched for the
+	// FCOS catalog.  fedora-sysexts/community had 1,583+ releases as of 2025,
+	// which fits in ≤16 pages at 100/page.  20 pages (2,000 releases) provides
+	// comfortable headroom while preventing unbounded loops.
+	//
+	// Design note: we rely on the fact that the newest release per extension is
+	// always in the first N pages (the API returns newest-first and extensions
+	// are released frequently).  If the page cap is hit while a Link: next
+	// header is still present, FetchCatalogFCOS returns an error rather than
+	// silently returning a partial catalog.
+	fcosMaxCatalogPages = 20
+)
+
+// fcosCDNNote: asset URLs in fedora-sysexts/community point to github.com,
+// NOT the extensions.fcos.fr CDN mentioned in the issue.  Verified 2025-06-04:
+// all browser_download_url values have the form:
+//
+//	https://github.com/fedora-sysexts/community/releases/download/<tag>/<file>
+//
+// The existing maxSysextURLLen (2048) and HTTPS enforcement in ignition.go
+// handle these URLs without modification.
+
+// FCOSClient wraps HTTPClient with a pinned fedoraVersion and implements the
+// Client interface for fetching the fedora-sysexts/community catalog.
+//
+// The fedoraVersion is derived at startup from FetchStreamFedoraVersion and
+// stored here so that FetchCatalogArch can filter assets for the correct Fedora
+// release without requiring callers to thread the version through every call.
+type FCOSClient struct {
+	HTTP          *http.Client
+	CatalogURL    string
+	AuthToken     string
+	FedoraVersion int
+}
+
+// NewFCOSClient creates an FCOSClient pointed at the fedora-sysexts/community
+// catalog, filtering for the given Fedora major version.
+func NewFCOSClient(fedoraVersion int) *FCOSClient {
+	return &FCOSClient{
+		HTTP: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		CatalogURL:    FCOSCatalogURL,
+		AuthToken:     githubTokenFromEnv(),
+		FedoraVersion: fedoraVersion,
+	}
+}
+
+// NewFCOSClientWithURL creates an FCOSClient pointing at a custom catalog URL
+// (for testing).
+func NewFCOSClientWithURL(url string, fedoraVersion int) *FCOSClient {
+	return &FCOSClient{
+		HTTP: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		CatalogURL:    url,
+		AuthToken:     githubTokenFromEnv(),
+		FedoraVersion: fedoraVersion,
+	}
+}
+
+// FetchCatalog implements Client.  Delegates to FetchCatalogArch with "amd64".
+func (c *FCOSClient) FetchCatalog(ctx context.Context) ([]model.SysextEntry, error) {
+	return c.FetchCatalogArch(ctx, "amd64")
+}
+
+// FetchCatalogArch implements Client.  Delegates to FetchCatalogFCOS with the
+// stored FedoraVersion.
+func (c *FCOSClient) FetchCatalogArch(ctx context.Context, arch string) ([]model.SysextEntry, error) {
+	httpClient := &HTTPClient{
+		CatalogURL: c.CatalogURL,
+		HTTP:       c.HTTP,
+		AuthToken:  c.AuthToken,
+	}
+	return httpClient.FetchCatalogFCOS(ctx, arch, c.FedoraVersion)
+}
+
+// FetchCatalogFCOS fetches sysexts from the fedora-sysexts/community catalog
+// built for the given arch and Fedora major version.
+//
+// arch must be "amd64" or "arm64".  fedoraVersion is an integer such as 44,
+// obtained from FetchStreamFedoraVersion in internal/fcos.
+//
+// The catalog is paginated; this method follows Link headers up to
+// fcosMaxCatalogPages pages.  If the cap is hit while more pages remain, an
+// error is returned to avoid silently delivering a partial catalog.
+//
+// Entries are deduplicated by name; the newest release per extension wins.
+// Curated metadata (description, category, support tier) is applied from
+// fcos_descriptions.go when available.
+func (c *HTTPClient) FetchCatalogFCOS(ctx context.Context, arch string, fedoraVersion int) ([]model.SysextEntry, error) {
+	var assetSuffix string
+	switch arch {
+	case "amd64":
+		assetSuffix = "x86-64"
+	case "arm64":
+		assetSuffix = "arm64"
+	default:
+		return nil, fmt.Errorf("unsupported architecture %q: must be amd64 or arm64", arch)
+	}
+
+	fedoraVersionStr := strconv.Itoa(fedoraVersion)
+
+	const maxResponseSize = 5 << 20
+	var allReleases []githubRelease
+	nextURL := c.CatalogURL
+
+	for page := 0; page < fcosMaxCatalogPages && nextURL != ""; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request (page %d): %w", page+1, err)
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "knuckle/1.0")
+		if c.AuthToken != "" {
+			req.Header.Set("Authorization", "Bearer "+c.AuthToken)
+		}
+
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching FCOS catalog (page %d): %w", page+1, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("FCOS catalog returned status %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading FCOS catalog response (page %d): %w", page+1, err)
+		}
+		if int64(len(body)) >= maxResponseSize {
+			return nil, fmt.Errorf("FCOS catalog response exceeds 5MB size limit")
+		}
+
+		var releases []githubRelease
+		if err := json.Unmarshal(body, &releases); err != nil {
+			return nil, fmt.Errorf("parsing FCOS catalog JSON (page %d): %w", page+1, err)
+		}
+		if len(releases) == 0 {
+			break
+		}
+		allReleases = append(allReleases, releases...)
+
+		linkNext, hasNext := parseLinkNext(resp.Header.Get("Link"))
+		nextURL = ""
+		if hasNext {
+			if page+1 >= fcosMaxCatalogPages {
+				// Cap reached; refuse to return a silently truncated catalog.
+				return nil, fmt.Errorf("FCOS catalog exceeds page cap (%d pages × 100): catalog may have grown beyond %d releases; raise fcosMaxCatalogPages",
+					fcosMaxCatalogPages, fcosMaxCatalogPages*100)
+			}
+			nextURL = linkNext
+		}
+	}
+
+	seen := make(map[string]bool)
+	sysexts := make([]model.SysextEntry, 0, len(allReleases))
+
+	for _, rel := range allReleases {
+		name, version, tagFedoraVer, tagArch, err := ParseFCOSTagName(rel.TagName)
+		if err != nil {
+			continue // bare pointer tags and malformed tags are expected; skip silently
+		}
+
+		// Filter: only include assets built for the requested Fedora version and arch.
+		if tagFedoraVer != fedoraVersionStr || tagArch != assetSuffix {
+			continue
+		}
+
+		if seen[name] {
+			continue // deduplicate — keep first (newest)
+		}
+
+		if validate.SysextName(name) != nil {
+			continue
+		}
+
+		// Find the .raw asset and SHA256SUMS file.
+		var downloadURL, sha256sumsURL string
+		for _, asset := range rel.Assets {
+			switch {
+			case asset.Name == "SHA256SUMS":
+				sha256sumsURL = asset.BrowserDownloadURL
+			case strings.HasSuffix(asset.Name, ".raw"):
+				if downloadURL == "" {
+					downloadURL = asset.BrowserDownloadURL
+				}
+			}
+		}
+		if downloadURL == "" {
+			continue
+		}
+		if len(downloadURL) > maxSysextURLLen {
+			continue
+		}
+		if sha256sumsURL != "" && len(sha256sumsURL) > maxSysextURLLen {
+			sha256sumsURL = ""
+		}
+
+		seen[name] = true
+
+		sha256Hash := ""
+		if sha256sumsURL != "" {
+			rawFilename := downloadURL[strings.LastIndex(downloadURL, "/")+1:]
+			if h, err := c.fetchSHA256ForAsset(ctx, sha256sumsURL, rawFilename); err == nil {
+				sha256Hash = h
+			}
+		}
+
+		description := truncateDescription(rel.Body, 80)
+		category := ""
+		supportTier := ""
+
+		if meta, ok := FCOSLookup(name); ok {
+			if meta.Short != "" {
+				description = meta.Short
+			}
+			category = meta.Category
+			supportTier = meta.SupportTier
+		}
+
+		sysexts = append(sysexts, model.SysextEntry{
+			Name:        name,
+			Description: description,
+			Version:     version,
+			URL:         downloadURL,
+			Sha256:      sha256Hash,
+			Category:    category,
+			SupportTier: supportTier,
+			Selected:    false,
+		})
+	}
+
+	return sysexts, nil
+}
+
+// FCOSMockClient is a test double for FCOSClient that implements Client and
+// exposes the FedoraVersion field for assertions in tests.
+type FCOSMockClient struct {
+	*MockClient
+	FedoraVersion int
+}
+
+// compile-time assertion: FCOSClient implements Client.
+var _ Client = (*FCOSClient)(nil)
+
+// compile-time assertion: FCOSMockClient implements Client.
+var _ Client = (*FCOSMockClient)(nil)

--- a/internal/bakery/fcos_descriptions.go
+++ b/internal/bakery/fcos_descriptions.go
@@ -1,0 +1,95 @@
+package bakery
+
+// FCOS support tier constants describe integration and maintenance level for
+// fedora-sysexts/community extensions.
+const (
+	// TierFCOSCommunity marks extensions maintained by the fedora-sysexts
+	// community project, built daily from upstream sources.
+	TierFCOSCommunity = "FCOS Community"
+)
+
+// fcosCatalog is the curated metadata catalog for fedora-sysexts/community
+// extensions.  Descriptions are written for FCOS users on bare-metal nodes.
+// When a name is not found here, FCOSLookup returns ok=false and the caller
+// falls back to the raw GitHub release body.
+var fcosCatalog = map[string]ExtensionMeta{
+	"docker-ce": {
+		Category:    "Container Runtime",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Docker CE — container engine with daemon, CLI, and BuildKit for FCOS nodes",
+		Long:        "Installs the full Docker CE engine (dockerd, docker CLI, containerd, runc) from the official Docker upstream RPMs, repackaged as a sysext for FCOS. Docker starts via socket activation and integrates with systemd on first boot. Pair with docker-buildx or docker-compose sysexts for a complete build environment.",
+		Caveats:     []string{"Replaces the default container runtime. Verify compatibility with your workloads before deploying to production."},
+	},
+	"tailscale": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Tailscale — zero-config WireGuard mesh VPN for secure node-to-node networking",
+		Long:        "Tailscale creates an encrypted WireGuard mesh network between your FCOS nodes with no manual key exchange or firewall configuration required. Ships tailscale and tailscaled with a service unit that auto-starts at boot. Authenticate nodes with tailscale up after provisioning.",
+		Caveats:     nil,
+	},
+	"vscode": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Visual Studio Code — lightweight source editor from Microsoft, for remote-SSH workflows",
+		Long:        "Installs the VS Code server binary, enabling remote development via the VS Code Remote - SSH extension. Useful when FCOS is used as a development or build host. Ships the code CLI and server binary; does not start a GUI on the node.",
+		Caveats:     []string{"Requires a display server or Remote - SSH connection from a desktop VS Code instance."},
+	},
+	"vscodium": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "VSCodium — open-source VS Code build without Microsoft telemetry",
+		Long:        "VSCodium is the community-compiled build of VS Code with Microsoft proprietary components and telemetry removed. Ships the codium binary and remote server for SSH-based development workflows on FCOS nodes. Same feature set as VS Code for most use cases.",
+		Caveats:     nil,
+	},
+	"cilium-cli": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Cilium CLI — manage eBPF-based Kubernetes networking and security policies",
+		Long:        "Ships the cilium CLI for installing, inspecting, and troubleshooting Cilium in a Kubernetes cluster. Does not ship the Cilium agent itself — this is a management tool for interacting with an existing Cilium installation. Pair with a Kubernetes distribution such as kubeadm.",
+		Caveats:     nil,
+	},
+	"1password-gui": {
+		Category:    "Security",
+		SupportTier: TierFCOSCommunity,
+		Short:       "1Password — GUI password manager and secrets integration for FCOS workstations",
+		Long:        "Installs the 1Password GUI application and CLI for managing credentials and secrets on FCOS-based workstation or developer nodes. Also provides the op CLI for scripted secrets access. Requires a graphical session or remote desktop to use the GUI; op works in headless environments.",
+		Caveats:     []string{"GUI requires a display server (Wayland or X11). The op CLI is available without a display."},
+	},
+	"kubernetes": {
+		Category:    "Orchestration",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Kubernetes — kubelet, kubeadm, and kubectl for FCOS cluster nodes",
+		Long:        "Ships kubelet, kubeadm, and kubectl from the official Kubernetes RPM repositories, repackaged as a sysext for FCOS. Use kubeadm init on control-plane nodes and kubeadm join on workers. FCOS's immutable base image pairs well with Kubernetes' declarative workload model.",
+		Caveats:     []string{"Update within the same minor version only (e.g. v1.32.x → v1.32.y). Cross-minor upgrades require manual coordination."},
+	},
+	"netbird": {
+		Category:    "Networking",
+		SupportTier: TierFCOSCommunity,
+		Short:       "NetBird — peer-to-peer WireGuard overlay network with centralized management",
+		Long:        "NetBird creates a peer-to-peer WireGuard overlay network managed through a control plane. Ships the netbird daemon and CLI with a service unit that starts at boot. Configure via /etc/netbird/ or environment variables. Suitable for multi-site or hybrid-cloud FCOS deployments.",
+		Caveats:     nil,
+	},
+	"cloud-hypervisor": {
+		Category:    "Virtualization",
+		SupportTier: TierFCOSCommunity,
+		Short:       "Cloud Hypervisor — lightweight KVM-based VMM for cloud-native virtual machines",
+		Long:        "Cloud Hypervisor is a minimal Virtual Machine Monitor built on Linux KVM, designed for running cloud workloads with low overhead. Ships the cloud-hypervisor binary. No default service unit is included — configure and launch VMs via Butane units or post-provisioning scripts.",
+		Caveats:     []string{"Requires hardware virtualization support (KVM). FCOS must be running on a bare-metal or nested-virt-capable host."},
+	},
+	"glab": {
+		Category:    "Developer Tools",
+		SupportTier: TierFCOSCommunity,
+		Short:       "glab — GitLab CLI for managing MRs, issues, pipelines, and repositories",
+		Long:        "glab is the official GitLab CLI tool for interacting with GitLab repositories, merge requests, issues, CI/CD pipelines, and more from the command line. Useful on FCOS CI runner nodes or developer workstations. No daemon — purely a CLI binary.",
+		Caveats:     nil,
+	},
+}
+
+// FCOSLookup returns curated metadata for the named FCOS sysext extension.
+// Returns the metadata and true if found; zero ExtensionMeta and false otherwise.
+// Unknown extensions should be displayed with the raw GitHub release body as
+// description, grouped under "Other" in the TUI.
+func FCOSLookup(name string) (ExtensionMeta, bool) {
+	meta, ok := fcosCatalog[name]
+	return meta, ok
+}

--- a/internal/bakery/fcos_descriptions_test.go
+++ b/internal/bakery/fcos_descriptions_test.go
@@ -1,0 +1,73 @@
+package bakery
+
+import (
+	"testing"
+)
+
+func TestFCOSLookup_KnownExtensions(t *testing.T) {
+	known := []string{
+		"docker-ce",
+		"tailscale",
+		"vscode",
+		"vscodium",
+		"cilium-cli",
+		"1password-gui",
+		"kubernetes",
+		"netbird",
+		"cloud-hypervisor",
+		"glab",
+	}
+	for _, name := range known {
+		t.Run(name, func(t *testing.T) {
+			meta, ok := FCOSLookup(name)
+			if !ok {
+				t.Fatalf("FCOSLookup(%q) returned ok=false; expected it to be in fcosCatalog", name)
+			}
+			if meta.Short == "" {
+				t.Errorf("FCOSLookup(%q): Short description is empty", name)
+			}
+			if meta.Category == "" {
+				t.Errorf("FCOSLookup(%q): Category is empty", name)
+			}
+			if meta.SupportTier == "" {
+				t.Errorf("FCOSLookup(%q): SupportTier is empty", name)
+			}
+			if meta.Long == "" {
+				t.Errorf("FCOSLookup(%q): Long description is empty", name)
+			}
+		})
+	}
+}
+
+func TestFCOSLookup_UnknownExtension(t *testing.T) {
+	meta, ok := FCOSLookup("not-a-real-extension-xyz")
+	if ok {
+		t.Errorf("expected ok=false for unknown extension, got %+v", meta)
+	}
+}
+
+func TestFCOSLookup_ReturnsCorrectMetadata(t *testing.T) {
+	meta, ok := FCOSLookup("docker-ce")
+	if !ok {
+		t.Fatal("expected docker-ce to be in fcosCatalog")
+	}
+	if meta.Category != "Container Runtime" {
+		t.Errorf("docker-ce Category: got %q, want %q", meta.Category, "Container Runtime")
+	}
+	if meta.SupportTier != TierFCOSCommunity {
+		t.Errorf("docker-ce SupportTier: got %q, want %q", meta.SupportTier, TierFCOSCommunity)
+	}
+}
+
+func TestFCOSLookup_CatalogSize(t *testing.T) {
+	// Require at least 6 entries per issue spec.
+	if len(fcosCatalog) < 6 {
+		t.Errorf("fcosCatalog has %d entries; require at least 6 per issue spec", len(fcosCatalog))
+	}
+}
+
+func TestTierFCOSCommunity(t *testing.T) {
+	if TierFCOSCommunity == "" {
+		t.Error("TierFCOSCommunity constant must not be empty")
+	}
+}

--- a/internal/bakery/fcos_tag.go
+++ b/internal/bakery/fcos_tag.go
@@ -1,0 +1,107 @@
+package bakery
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ParseFCOSTagName extracts the name, version, fedoraVersion, and arch from a
+// fedora-sysexts/community release tag.
+//
+// Tag format: <name>-<version_components>-<fedoraVersion>-<arch>
+//
+// The arch suffix is always "x86-64" or "arm64".
+// The fedoraVersion is a 2-or-more digit decimal integer (e.g. "44").
+// The version is everything between the name and the fedoraVersion.
+//
+// Tags without an arch suffix (bare pointer tags such as "vscode", "latest", or
+// per-name "docker-ce") are rejected with a descriptive error.
+//
+// Examples:
+//
+//	tailscale-0-1.98.3-1-44-x86-64       → tailscale, 0-1.98.3-1, 44, x86-64
+//	docker-ce-3-29.5.3-1.fc44-44-x86-64  → docker-ce, 3-29.5.3-1.fc44, 44, x86-64
+//	vscode-1.123.0-1780481629.el8-43-arm64 → vscode, 1.123.0-1780481629.el8, 43, arm64
+//	1password-gui-8.12.22-1-44-x86-64    → 1password-gui, 8.12.22-1, 44, x86-64
+//	cloud-hypervisor-51.0.0-39.38-43-x86-64 → cloud-hypervisor, 51.0.0-39.38, 43, x86-64
+func ParseFCOSTagName(tag string) (name, version, fedoraVersion, arch string, err error) {
+	// 1. Strip arch suffix to reveal <name>-<version>-<fedoraVersion>.
+	var rest string
+	switch {
+	case strings.HasSuffix(tag, "-x86-64"):
+		arch = "x86-64"
+		rest = tag[:len(tag)-len("-x86-64")]
+	case strings.HasSuffix(tag, "-arm64"):
+		arch = "arm64"
+		rest = tag[:len(tag)-len("-arm64")]
+	default:
+		return "", "", "", "", fmt.Errorf("fcos tag %q: no arch suffix (x86-64 or arm64); bare pointer tags are skipped", tag)
+	}
+
+	// 2. Strip the trailing all-digit fedoraVersion segment.
+	lastDash := strings.LastIndex(rest, "-")
+	if lastDash < 0 {
+		return "", "", "", "", fmt.Errorf("fcos tag %q: missing fedora version segment", tag)
+	}
+	candidate := rest[lastDash+1:]
+	if !isAllDigits(candidate) || candidate == "" {
+		return "", "", "", "", fmt.Errorf("fcos tag %q: expected all-digit fedora version before arch, got %q", tag, candidate)
+	}
+	fedoraVersion = candidate
+	rest = rest[:lastDash]
+
+	if rest == "" {
+		return "", "", "", "", fmt.Errorf("fcos tag %q: no name or version after stripping arch and fedora version", tag)
+	}
+
+	// 3. Split the remaining string into <name>-<version> at the boundary where
+	//    the version components begin.
+	//
+	//    Heuristic (covers all observed fedora-sysexts/community tags):
+	//    Scan segments left-to-right; version starts at the first segment that:
+	//      a) contains a "." (version number or epoch+release), OR
+	//      b) is a pure integer AND the next segment contains a "." (RPM epoch).
+	//
+	//    This correctly handles:
+	//      - Simple versions:    "dnclient-0.9.4"      → name="dnclient"
+	//      - Epoch-prefixed:     "tailscale-0-1.98.3"  → epoch "0" before "1.98.3"
+	//      - Multi-word names:   "docker-ce-3-29.5.3"  → name="docker-ce"
+	//      - Digit-starting:     "1password-gui-8.12"  → name="1password-gui"
+	segments := strings.Split(rest, "-")
+	splitIdx := -1
+	for i, seg := range segments {
+		if strings.ContainsRune(seg, '.') {
+			splitIdx = i
+			break
+		}
+		if isAllDigits(seg) && i+1 < len(segments) && strings.ContainsRune(segments[i+1], '.') {
+			splitIdx = i
+			break
+		}
+	}
+
+	switch {
+	case splitIdx < 0:
+		return "", "", "", "", fmt.Errorf("fcos tag %q: could not find version boundary in %q", tag, rest)
+	case splitIdx == 0:
+		return "", "", "", "", fmt.Errorf("fcos tag %q: no name segment before version in %q", tag, rest)
+	}
+
+	name = strings.Join(segments[:splitIdx], "-")
+	version = strings.Join(segments[splitIdx:], "-")
+	return name, version, fedoraVersion, arch, nil
+}
+
+// isAllDigits reports whether s is non-empty and contains only ASCII decimal digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bakery/fcos_tag_test.go
+++ b/internal/bakery/fcos_tag_test.go
@@ -1,0 +1,219 @@
+package bakery
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseFCOSTagName covers the real tag formats observed in the
+// fedora-sysexts/community GitHub Releases API (per_page=100 on 2025-06-04).
+func TestParseFCOSTagName(t *testing.T) {
+	tests := []struct {
+		tag             string
+		wantName        string
+		wantVersion     string
+		wantFedoraVer   string
+		wantArch        string
+		wantErrContains string
+	}{
+		// ── Real catalog examples ──────────────────────────────────────────
+		{
+			tag:      "tailscale-0-1.98.3-1-44-x86-64",
+			wantName: "tailscale", wantVersion: "0-1.98.3-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "tailscale-0-1.98.3-1-43-arm64",
+			wantName: "tailscale", wantVersion: "0-1.98.3-1",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+		{
+			tag:      "docker-ce-3-29.5.3-1.fc44-44-x86-64",
+			wantName: "docker-ce", wantVersion: "3-29.5.3-1.fc44",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "docker-ce-3-29.5.3-1.fc43-43-arm64",
+			wantName: "docker-ce", wantVersion: "3-29.5.3-1.fc43",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+		{
+			tag:      "vscode-1.123.0-1780481629.el8-43-arm64",
+			wantName: "vscode", wantVersion: "1.123.0-1780481629.el8",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+		{
+			tag:      "vscode-1.123.0-1780481612.el8-44-x86-64",
+			wantName: "vscode", wantVersion: "1.123.0-1780481612.el8",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "vscodium-1.121.03429-el8-44-x86-64",
+			wantName: "vscodium", wantVersion: "1.121.03429-el8",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "dnclient-0.9.4-44-x86-64",
+			wantName: "dnclient", wantVersion: "0.9.4",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "dnclient-0.9.4-43-arm64",
+			wantName: "dnclient", wantVersion: "0.9.4",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+		{
+			tag:      "cloud-hypervisor-51.0.0-39.38-43-x86-64",
+			wantName: "cloud-hypervisor", wantVersion: "51.0.0-39.38",
+			wantFedoraVer: "43", wantArch: "x86-64",
+		},
+		{
+			tag:      "cloud-hypervisor-51.0.0-39.38-43-arm64",
+			wantName: "cloud-hypervisor", wantVersion: "51.0.0-39.38",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+		{
+			tag:      "cilium-cli-0.19.4-44-x86-64",
+			wantName: "cilium-cli", wantVersion: "0.19.4",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "bitwarden-2026.5.0-1-44-x86-64",
+			wantName: "bitwarden", wantVersion: "2026.5.0-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "1password-gui-8.12.22-1-44-x86-64",
+			wantName: "1password-gui", wantVersion: "8.12.22-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "openconnect-9.12.git.270.549fd2d-0.fc44-44-x86-64",
+			wantName: "openconnect", wantVersion: "9.12.git.270.549fd2d-0.fc44",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "openh264-2.6.0-3.fc44-44-x86-64",
+			wantName: "openh264", wantVersion: "2.6.0-3.fc44",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "glab-1.97.0-1-44-x86-64",
+			wantName: "glab", wantVersion: "1.97.0-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "glab-1.97.0-1-44-arm64",
+			wantName: "glab", wantVersion: "1.97.0-1",
+			wantFedoraVer: "44", wantArch: "arm64",
+		},
+		{
+			tag:      "netbird-0.71.2-1-44-x86-64",
+			wantName: "netbird", wantVersion: "0.71.2-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "netbird-ui-0.71.2-1-44-x86-64",
+			wantName: "netbird-ui", wantVersion: "0.71.2-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "littlesnitch-1.0.9-1-44-x86-64",
+			wantName: "littlesnitch", wantVersion: "1.0.9-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "virtctl-1.5.0-44-x86-64",
+			wantName: "virtctl", wantVersion: "1.5.0",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "microsoft-edge-148.0.7778.178-1-44-x86-64",
+			wantName: "microsoft-edge", wantVersion: "148.0.7778.178-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "google-chrome-148.0.7778.178-1-44-x86-64",
+			wantName: "google-chrome", wantVersion: "148.0.7778.178-1",
+			wantFedoraVer: "44", wantArch: "x86-64",
+		},
+		{
+			tag:      "1password-gui-8.12.21-1-43-arm64",
+			wantName: "1password-gui", wantVersion: "8.12.21-1",
+			wantFedoraVer: "43", wantArch: "arm64",
+		},
+
+		// ── Error cases: bare pointer tags ────────────────────────────────
+		{tag: "vscode", wantErrContains: "arch suffix"},
+		{tag: "tailscale", wantErrContains: "arch suffix"},
+		{tag: "docker-ce", wantErrContains: "arch suffix"},
+		{tag: "latest", wantErrContains: "arch suffix"},
+
+		// ── Error cases: malformed ────────────────────────────────────────
+		{tag: "noarch-44", wantErrContains: "arch suffix"},
+		{tag: "-x86-64", wantErrContains: "fedora version"},
+		{tag: "name-noversion-x86-64", wantErrContains: "fedora version"},
+		// rest == "" after stripping arch and fedoraVersion
+		{tag: "-44-x86-64", wantErrContains: "no name or version"},
+		// no version boundary (no segment with "." and no epoch+dot pattern)
+		{tag: "name-word-44-x86-64", wantErrContains: "could not find version boundary"},
+		// version starts at segment 0 — no name before it
+		{tag: "1.0.0-44-x86-64", wantErrContains: "no name segment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			name, version, fedoraVer, arch, err := ParseFCOSTagName(tt.tag)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErrContains)
+				}
+				if !containsStr(err.Error(), tt.wantErrContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if name != tt.wantName {
+				t.Errorf("name: got %q, want %q", name, tt.wantName)
+			}
+			if version != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", version, tt.wantVersion)
+			}
+			if fedoraVer != tt.wantFedoraVer {
+				t.Errorf("fedoraVersion: got %q, want %q", fedoraVer, tt.wantFedoraVer)
+			}
+			if arch != tt.wantArch {
+				t.Errorf("arch: got %q, want %q", arch, tt.wantArch)
+			}
+		})
+	}
+}
+
+func TestIsAllDigits(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"44", true},
+		{"0", true},
+		{"123", true},
+		{"", false},
+		{"44a", false},
+		{"a44", false},
+		{"4.4", false},
+		{"44 ", false},
+	}
+	for _, tt := range tests {
+		got := isAllDigits(tt.input)
+		if got != tt.want {
+			t.Errorf("isAllDigits(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return strings.Contains(s, sub)
+}

--- a/internal/bakery/fcos_test.go
+++ b/internal/bakery/fcos_test.go
@@ -698,3 +698,25 @@ func TestFCOSMockClient_ImplementsClient(t *testing.T) {
 		t.Errorf("FedoraVersion: got %d, want 44", mock.FedoraVersion)
 	}
 }
+
+func TestFetchCatalogFCOS_AuthTokenSent(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClientWithURL(srv.URL)
+	c.HTTP = srv.Client()
+	c.AuthToken = "test-token-abc"
+
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer test-token-abc" {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, "Bearer test-token-abc")
+	}
+}

--- a/internal/bakery/fcos_test.go
+++ b/internal/bakery/fcos_test.go
@@ -1,0 +1,700 @@
+package bakery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/model"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// makeFCOSRelease builds a minimal JSON release object for the test server.
+func makeFCOSRelease(tagName, body string, assets []struct{ Name, URL string }) map[string]any {
+	assetList := make([]map[string]any, len(assets))
+	for i, a := range assets {
+		assetList[i] = map[string]any{"name": a.Name, "browser_download_url": a.URL}
+	}
+	return map[string]any{"tag_name": tagName, "body": body, "assets": assetList}
+}
+
+// fcosCatalogServer returns an httptest.Server that serves a single-page
+// FCOS catalog containing the given releases.  The server's URL is returned
+// as baseURL so callers can point FCOSClient or HTTPClient at it.
+func fcosCatalogServer(t *testing.T, releases []any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releases); err != nil {
+			t.Errorf("fcosCatalogServer: encode error: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// fcosSingleRelease constructs one release that passes all filters.
+func fcosSingleRelease(t *testing.T, name, version string, fedora int, arch string, rawURL, sha256URL string) map[string]any {
+	t.Helper()
+	var archSuffix string
+	if arch == "amd64" {
+		archSuffix = "x86-64"
+	} else {
+		archSuffix = arch
+	}
+	tag := fmt.Sprintf("%s-%s-%d-%s", name, version, fedora, archSuffix)
+	return makeFCOSRelease(tag, "release body", []struct{ Name, URL string }{
+		{Name: tag + ".raw", URL: rawURL},
+		{Name: "SHA256SUMS", URL: sha256URL},
+	})
+}
+
+// ── FetchCatalogFCOS ──────────────────────────────────────────────────────────
+
+func TestFetchCatalogFCOS_Success(t *testing.T) {
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+
+	sha256Body := "aabbccdd" + strings.Repeat("0", 56) + "  tailscale-0-1.2.3-44-x86-64.raw\n"
+
+	// Two servers: one for the catalog, one for SHA256SUMS.
+	sha256Srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sha256Body))
+	}))
+	defer sha256Srv.Close()
+
+	// Repoint the SHA256SUMS URL to our test server.
+	sha256TestURL := sha256Srv.URL + "/sha256sums"
+	rawRel := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURL, sha256TestURL)
+
+	srv := fcosCatalogServer(t, []any{rawRel})
+
+	c := NewHTTPClientWithURL(srv.URL)
+	c.HTTP = srv.Client()
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Name != "tailscale" {
+		t.Errorf("name: got %q, want tailscale", e.Name)
+	}
+	if e.Version != "0-1.2.3" {
+		t.Errorf("version: got %q, want 0-1.2.3", e.Version)
+	}
+	if e.URL != rawURL {
+		t.Errorf("URL: got %q, want %q", e.URL, rawURL)
+	}
+}
+
+func TestFetchCatalogFCOS_BadArch(t *testing.T) {
+	c := NewHTTPClientWithURL("http://localhost:1")
+	_, err := c.FetchCatalogFCOS(context.Background(), "riscv64", 44)
+	if err == nil || !strings.Contains(err.Error(), "unsupported architecture") {
+		t.Errorf("expected unsupported architecture error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_NetworkError(t *testing.T) {
+	c := &HTTPClient{
+		CatalogURL: "http://127.0.0.1:1",
+		HTTP:       &http.Client{},
+	}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	if !strings.Contains(err.Error(), "fetching FCOS catalog") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_HTTPNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil || !strings.Contains(err.Error(), "429") {
+		t.Errorf("expected HTTP 429 error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil || !strings.Contains(err.Error(), "parsing FCOS catalog JSON") {
+		t.Errorf("expected JSON parse error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_EmptyPageStops(t *testing.T) {
+	var pageCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&pageCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Return empty JSON array — pagination should stop.
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+	if pageCount != 1 {
+		t.Errorf("expected exactly 1 page fetch, got %d", pageCount)
+	}
+}
+
+func TestFetchCatalogFCOS_Deduplication(t *testing.T) {
+	// Two releases for "tailscale", same arch and fedora version — only first should appear.
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	rawURL2 := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.2-44-x86-64/tailscale-0-1.2.2-44-x86-64.raw"
+
+	rel1 := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURL, "")
+	rel2 := fcosSingleRelease(t, "tailscale", "0-1.2.2", 44, "amd64", rawURL2, "")
+
+	srv := fcosCatalogServer(t, []any{rel1, rel2})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (deduplication), got %d", len(entries))
+	}
+	if entries[0].Version != "0-1.2.3" {
+		t.Errorf("expected newest version 0-1.2.3, got %q", entries[0].Version)
+	}
+}
+
+func TestFetchCatalogFCOS_FedoraVersionFiltering(t *testing.T) {
+	rawURL43 := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-43-x86-64/tailscale-0-1.2.3-43-x86-64.raw"
+	rawURL44 := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+
+	rel43 := fcosSingleRelease(t, "tailscale", "0-1.2.3", 43, "amd64", rawURL43, "")
+	rel44 := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURL44, "")
+
+	srv := fcosCatalogServer(t, []any{rel43, rel44})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (version filter), got %d", len(entries))
+	}
+	if entries[0].URL != rawURL44 {
+		t.Errorf("expected fedora44 URL, got %q", entries[0].URL)
+	}
+}
+
+func TestFetchCatalogFCOS_ArchFiltering(t *testing.T) {
+	rawURLx86 := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	rawURLarm := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-arm64/tailscale-0-1.2.3-44-arm64.raw"
+
+	relx86 := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURLx86, "")
+	relarm := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "arm64", rawURLarm, "")
+
+	srv := fcosCatalogServer(t, []any{relx86, relarm})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "arm64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 arm64 entry, got %d", len(entries))
+	}
+	if !strings.Contains(entries[0].URL, "arm64") {
+		t.Errorf("expected arm64 URL, got %q", entries[0].URL)
+	}
+}
+
+func TestFetchCatalogFCOS_SkipBadTags(t *testing.T) {
+	// Bare pointer tag (no arch suffix) — should be silently skipped.
+	rel := makeFCOSRelease("tailscale", "pointer", nil)
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries (bad tag skipped), got %d", len(entries))
+	}
+}
+
+func TestFetchCatalogFCOS_SkipMissingDownloadURL(t *testing.T) {
+	tag := "tailscale-0-1.2.3-44-x86-64"
+	// Release with only a non-.raw asset — should be skipped.
+	rel := makeFCOSRelease(tag, "body", []struct{ Name, URL string }{
+		{Name: "README.md", URL: "https://github.com/x/README.md"},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries (no .raw asset), got %d", len(entries))
+	}
+}
+
+func TestFetchCatalogFCOS_SkipURLTooLong(t *testing.T) {
+	longURL := "https://github.com/" + strings.Repeat("a", maxSysextURLLen) + ".raw"
+	tag := "tailscale-0-1.2.3-44-x86-64"
+	rel := makeFCOSRelease(tag, "body", []struct{ Name, URL string }{
+		{Name: tag + ".raw", URL: longURL},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries (URL too long), got %d", len(entries))
+	}
+}
+
+func TestFetchCatalogFCOS_SHA256SumsURLTooLong(t *testing.T) {
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	longSHA256URL := "https://github.com/" + strings.Repeat("b", maxSysextURLLen) + "/SHA256SUMS"
+	tag := "tailscale-0-1.2.3-44-x86-64"
+	rel := makeFCOSRelease(tag, "body", []struct{ Name, URL string }{
+		{Name: tag + ".raw", URL: rawURL},
+		{Name: "SHA256SUMS", URL: longSHA256URL},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	// Should succeed — the SHA256SUMS URL is sanitized (dropped), not fatal.
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Sha256 != "" {
+		t.Errorf("expected empty sha256 (URL sanitized), got %q", entries[0].Sha256)
+	}
+}
+
+func TestFetchCatalogFCOS_PageCap(t *testing.T) {
+	// Serve fcosMaxCatalogPages pages of one release each (with a next-page link).
+	// After the last page the server would serve more — expect an error.
+	var pageCount int32
+	var capSrv *httptest.Server
+	capSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := atomic.AddInt32(&pageCount, 1)
+		tag := fmt.Sprintf("dummy-%d-0-1.0.0-44-x86-64", page)
+		rawURL := fmt.Sprintf("https://github.com/dummy/releases/%s.raw", tag)
+		rel := makeFCOSRelease(tag, "", []struct{ Name, URL string }{
+			{Name: tag + ".raw", URL: rawURL},
+		})
+		releases := []any{rel}
+
+		// Always set a Link: next header to simulate an infinite catalog.
+		w.Header().Set("Link", fmt.Sprintf(`<%s?page=%d>; rel="next"`, capSrv.URL, page+1))
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(releases); err != nil {
+			t.Errorf("encode error: %v", err)
+		}
+	}))
+	defer capSrv.Close()
+
+	c := &HTTPClient{CatalogURL: capSrv.URL, HTTP: capSrv.Client()}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil {
+		t.Fatal("expected page cap error")
+	}
+	if !strings.Contains(err.Error(), "page cap") {
+		t.Errorf("expected page cap error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_Pagination(t *testing.T) {
+	// Serve two pages: page 1 has tailscale, page 2 has docker-ce.  Page 2 has no next link.
+	rawURLTailscale := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	rawURLDocker := "https://github.com/fedora-sysexts/community/releases/download/docker-ce-3-29.5.3-1.fc44-44-x86-64/docker-ce-3-29.5.3-1.fc44-44-x86-64.raw"
+
+	relTailscale := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURLTailscale, "")
+	relDocker := fcosSingleRelease(t, "docker-ce", "3-29.5.3-1.fc44", 44, "amd64", rawURLDocker, "")
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		if page == "2" {
+			if err := json.NewEncoder(w).Encode([]any{relDocker}); err != nil {
+				t.Errorf("encode error: %v", err)
+			}
+			return
+		}
+		// page 1 — set Link: next
+		w.Header().Set("Link", fmt.Sprintf(`<%s?page=2>; rel="next"`, srv.URL))
+		if err := json.NewEncoder(w).Encode([]any{relTailscale}); err != nil {
+			t.Errorf("encode error: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (paginated), got %d", len(entries))
+	}
+}
+
+func TestFetchCatalogFCOS_FCOSLookupApplied(t *testing.T) {
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/docker-ce-3-29.5.3-1.fc44-44-x86-64/docker-ce-3-29.5.3-1.fc44-44-x86-64.raw"
+	rel := fcosSingleRelease(t, "docker-ce", "3-29.5.3-1.fc44", 44, "amd64", rawURL, "")
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	// docker-ce is in fcosCatalog — curated description should be applied.
+	if entries[0].Category == "" {
+		t.Errorf("expected category from FCOSLookup, got empty")
+	}
+	if entries[0].SupportTier == "" {
+		t.Errorf("expected support tier from FCOSLookup, got empty")
+	}
+	if !strings.Contains(entries[0].Description, "Docker") {
+		t.Errorf("expected curated description containing Docker, got %q", entries[0].Description)
+	}
+}
+
+func TestFetchCatalogFCOS_UnknownExtensionFallsBackToBody(t *testing.T) {
+	// Use a name not in fcosCatalog.
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/mypkg-1.2.3-44-x86-64/mypkg-1.2.3-44-x86-64.raw"
+	rel := makeFCOSRelease("mypkg-1.2.3-44-x86-64", "This is the release body", []struct{ Name, URL string }{
+		{Name: "mypkg-1.2.3-44-x86-64.raw", URL: rawURL},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Description != "This is the release body" {
+		t.Errorf("expected release body as description, got %q", entries[0].Description)
+	}
+}
+
+func TestFetchCatalogFCOS_SHA256Fetch(t *testing.T) {
+	rawFilename := "tailscale-0-1.2.3-44-x86-64.raw"
+	expectedHash := strings.Repeat("a", 64)
+	sha256Body := expectedHash + "  " + rawFilename + "\n"
+
+	sha256Srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sha256Body))
+	}))
+	defer sha256Srv.Close()
+
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/" + rawFilename
+	tag := "tailscale-0-1.2.3-44-x86-64"
+	rel := makeFCOSRelease(tag, "body", []struct{ Name, URL string }{
+		{Name: tag + ".raw", URL: rawURL},
+		{Name: "SHA256SUMS", URL: sha256Srv.URL + "/sha256"},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	// Allow SHA256 fetches to reach sha256Srv (different server).
+	c.HTTP = &http.Client{Transport: &dualTransport{a: srv.Client().Transport, aHost: srv.Listener.Addr().String(), b: sha256Srv.Client().Transport}}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Sha256 != expectedHash {
+		t.Errorf("expected sha256 %q, got %q", expectedHash, entries[0].Sha256)
+	}
+}
+
+// dualTransport routes requests to one of two transports based on host.
+type dualTransport struct {
+	a     http.RoundTripper
+	aHost string
+	b     http.RoundTripper
+}
+
+func (d *dualTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == d.aHost {
+		return d.a.RoundTrip(req)
+	}
+	return d.b.RoundTrip(req)
+}
+
+func TestFetchCatalogFCOS_SHA256FetchError_SoftFail(t *testing.T) {
+	// SHA256SUMS server returns 500 — should be a soft fail, not fatal.
+	sha256Srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer sha256Srv.Close()
+
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	tag := "tailscale-0-1.2.3-44-x86-64"
+	rel := makeFCOSRelease(tag, "body", []struct{ Name, URL string }{
+		{Name: tag + ".raw", URL: rawURL},
+		{Name: "SHA256SUMS", URL: sha256Srv.URL + "/sha256"},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+	c.HTTP = &http.Client{Transport: &dualTransport{a: srv.Client().Transport, aHost: srv.Listener.Addr().String(), b: sha256Srv.Client().Transport}}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("expected soft fail on SHA256 error, got fatal error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry despite SHA256 error, got %d", len(entries))
+	}
+	if entries[0].Sha256 != "" {
+		t.Errorf("expected empty sha256 after soft fail, got %q", entries[0].Sha256)
+	}
+}
+
+func TestFetchCatalogFCOS_InvalidCatalogURL(t *testing.T) {
+	// A URL with a control character causes http.NewRequestWithContext to fail.
+	c := &HTTPClient{CatalogURL: "http://\n", HTTP: &http.Client{}}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil || !strings.Contains(err.Error(), "creating request") {
+		t.Errorf("expected 'creating request' error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_ResponseBodyReadError(t *testing.T) {
+	c := &HTTPClient{
+		CatalogURL: "http://placeholder",
+		HTTP:       &http.Client{Transport: &errorBodyTransport{}},
+	}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil || !strings.Contains(err.Error(), "reading FCOS catalog response") {
+		t.Errorf("expected read error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_ResponseBodyTooLarge(t *testing.T) {
+	// Serve exactly maxResponseSize bytes so the limit-exceeded check triggers.
+	c := &HTTPClient{
+		CatalogURL: "http://placeholder",
+		HTTP:       &http.Client{Transport: &bigBodyTransport{}},
+	}
+	_, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err == nil || !strings.Contains(err.Error(), "5MB") {
+		t.Errorf("expected 5MB size limit error, got: %v", err)
+	}
+}
+
+func TestFetchCatalogFCOS_InvalidSysextName(t *testing.T) {
+	// Tag that parses fine but whose name fails validate.SysextName (starts with '!').
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/!pkg-1.0.0-44-x86-64/!pkg-1.0.0-44-x86-64.raw"
+	rel := makeFCOSRelease("!pkg-1.0.0-44-x86-64", "body", []struct{ Name, URL string }{
+		{Name: "!pkg-1.0.0-44-x86-64.raw", URL: rawURL},
+	})
+
+	srv := fcosCatalogServer(t, []any{rel})
+	c := &HTTPClient{CatalogURL: srv.URL, HTTP: srv.Client()}
+
+	entries, err := c.FetchCatalogFCOS(context.Background(), "amd64", 44)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries (invalid sysext name skipped), got %d", len(entries))
+	}
+}
+
+// ── transport helpers for error injection ─────────────────────────────────────
+
+// errorBodyTransport returns HTTP 200 responses whose body errors on Read.
+type errorBodyTransport struct{}
+
+func (t *errorBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &errorReadBody{},
+		Header:     make(http.Header),
+	}, nil
+}
+
+type errorReadBody struct{}
+
+func (e *errorReadBody) Read(_ []byte) (int, error) { return 0, fmt.Errorf("simulated read error") }
+func (e *errorReadBody) Close() error               { return nil }
+
+// bigBodyTransport returns HTTP 200 responses with exactly maxResponseSize bytes
+// of data, triggering the ≥5MB size limit check.
+type bigBodyTransport struct{}
+
+func (t *bigBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	const maxResponseSize = 5 << 20
+	body := make([]byte, maxResponseSize)
+	// Fill with '[' so the limit reader reads the maximum and hits the check.
+	for i := range body {
+		body[i] = '['
+	}
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          readCloser{r: fixedReader{data: body, pos: 0}},
+		Header:        make(http.Header),
+		ContentLength: int64(len(body)),
+	}, nil
+}
+
+type readCloser struct{ r fixedReader }
+
+func (rc readCloser) Read(p []byte) (int, error) { return rc.r.read(p) }
+func (rc readCloser) Close() error               { return nil }
+
+type fixedReader struct {
+	data []byte
+	pos  int
+}
+
+func (f *fixedReader) read(p []byte) (int, error) {
+	if f.pos >= len(f.data) {
+		return 0, fmt.Errorf("EOF")
+	}
+	n := copy(p, f.data[f.pos:])
+	f.pos += n
+	return n, nil
+}
+
+// ── FCOSClient ────────────────────────────────────────────────────────────────
+
+func TestNewFCOSClient(t *testing.T) {
+	c := NewFCOSClient(44)
+	if c.FedoraVersion != 44 {
+		t.Errorf("FedoraVersion: got %d, want 44", c.FedoraVersion)
+	}
+	if c.CatalogURL != FCOSCatalogURL {
+		t.Errorf("CatalogURL: got %q, want %q", c.CatalogURL, FCOSCatalogURL)
+	}
+	if c.HTTP == nil {
+		t.Error("HTTP client should not be nil")
+	}
+}
+
+func TestNewFCOSClientWithURL(t *testing.T) {
+	c := NewFCOSClientWithURL("http://example.com", 43)
+	if c.FedoraVersion != 43 {
+		t.Errorf("FedoraVersion: got %d, want 43", c.FedoraVersion)
+	}
+	if c.CatalogURL != "http://example.com" {
+		t.Errorf("CatalogURL: got %q", c.CatalogURL)
+	}
+}
+
+func TestFCOSClient_FetchCatalog_DelegatesToAmd64(t *testing.T) {
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-x86-64/tailscale-0-1.2.3-44-x86-64.raw"
+	rel := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "amd64", rawURL, "")
+
+	srv := fcosCatalogServer(t, []any{rel})
+
+	c := NewFCOSClientWithURL(srv.URL, 44)
+	c.HTTP = srv.Client()
+
+	entries, err := c.FetchCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+func TestFCOSClient_FetchCatalogArch(t *testing.T) {
+	rawURL := "https://github.com/fedora-sysexts/community/releases/download/tailscale-0-1.2.3-44-arm64/tailscale-0-1.2.3-44-arm64.raw"
+	rel := fcosSingleRelease(t, "tailscale", "0-1.2.3", 44, "arm64", rawURL, "")
+
+	srv := fcosCatalogServer(t, []any{rel})
+
+	c := NewFCOSClientWithURL(srv.URL, 44)
+	c.HTTP = srv.Client()
+
+	entries, err := c.FetchCatalogArch(context.Background(), "arm64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 arm64 entry, got %d", len(entries))
+	}
+}
+
+// ── FCOSMockClient compile-time assertion is tested by building ───────────────
+
+func TestFCOSMockClient_ImplementsClient(t *testing.T) {
+	mock := &FCOSMockClient{
+		MockClient: &MockClient{
+			Entries: []model.SysextEntry{{Name: "test", URL: "https://example.com/test.raw"}},
+		},
+		FedoraVersion: 44,
+	}
+	// Verify the interface is satisfied by calling through the interface.
+	var c Client = mock
+	entries, err := c.FetchCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected entries from mock")
+	}
+	if mock.FedoraVersion != 44 {
+		t.Errorf("FedoraVersion: got %d, want 44", mock.FedoraVersion)
+	}
+}

--- a/internal/fcos/streams.go
+++ b/internal/fcos/streams.go
@@ -1,0 +1,132 @@
+// Package fcos provides utilities for interacting with Fedora CoreOS stream
+// metadata endpoints and deriving Fedora version information from them.
+package fcos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// StreamMetaBaseURL is the base URL for FCOS stream metadata JSON files.
+	StreamMetaBaseURL = "https://builds.coreos.fedoraproject.org/streams"
+
+	defaultTimeout = 30 * time.Second
+)
+
+// streamHTTPClient is the shared HTTP client for FCOS stream metadata fetches.
+var streamHTTPClient = &http.Client{Timeout: defaultTimeout}
+
+// fcosStreamJSON is the minimal subset of the FCOS stream metadata JSON needed
+// to extract the Fedora major version.  Full schema at:
+// https://builds.coreos.fedoraproject.org/streams/stable.json
+type fcosStreamJSON struct {
+	Architectures map[string]fcosArch `json:"architectures"`
+}
+
+type fcosArch struct {
+	Artifacts map[string]fcosArtifact `json:"artifacts"`
+}
+
+type fcosArtifact struct {
+	// Release is the FCOS release string, e.g. "44.20260510.3.1".
+	// The first component is the Fedora major version.
+	Release string `json:"release"`
+}
+
+// FetchStreamFedoraVersion returns the Fedora major version number for a given
+// FCOS stream (e.g. "stable" → 44).  Needed to filter fedora-sysexts/community
+// assets by the correct Fedora version.
+//
+// The version is derived from the release string embedded in the stream metadata
+// JSON (e.g. "44.20260510.3.1" → 44).
+func FetchStreamFedoraVersion(ctx context.Context, stream string) (int, error) {
+	return fetchStreamFedoraVersion(ctx, StreamMetaBaseURL, stream, streamHTTPClient)
+}
+
+// fetchStreamFedoraVersion is the injectable implementation used by tests.
+func fetchStreamFedoraVersion(ctx context.Context, baseURL, stream string, client *http.Client) (int, error) {
+	if stream == "" {
+		return 0, fmt.Errorf("FCOS stream name must not be empty")
+	}
+
+	url := baseURL + "/" + stream + ".json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating FCOS stream request: %w", err)
+	}
+	req.Header.Set("User-Agent", "knuckle/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fetching FCOS stream %q: %w", stream, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("FCOS stream %q returned HTTP %d", stream, resp.StatusCode)
+	}
+
+	const maxSize = 5 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSize))
+	if err != nil {
+		return 0, fmt.Errorf("reading FCOS stream response: %w", err)
+	}
+
+	return parseFedoraVersionFromStreamJSON(stream, body)
+}
+
+// parseFedoraVersionFromStreamJSON extracts the Fedora major version from the
+// raw FCOS stream metadata JSON bytes.
+func parseFedoraVersionFromStreamJSON(stream string, body []byte) (int, error) {
+	var doc fcosStreamJSON
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return 0, fmt.Errorf("parsing FCOS stream JSON for %q: %w", stream, err)
+	}
+
+	// Prefer x86_64; fall back to aarch64 if absent.  Both architectures
+	// always carry the same Fedora major version, so the choice is cosmetic.
+	for _, archKey := range []string{"x86_64", "aarch64"} {
+		arch, ok := doc.Architectures[archKey]
+		if !ok {
+			continue
+		}
+		// Prefer the "metal" artifact; fall back to any artifact.
+		if metal, ok := arch.Artifacts["metal"]; ok && metal.Release != "" {
+			return parseFedoraVersionFromRelease(stream, metal.Release)
+		}
+		for _, art := range arch.Artifacts {
+			if art.Release != "" {
+				return parseFedoraVersionFromRelease(stream, art.Release)
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("FCOS stream %q: no release version found in JSON", stream)
+}
+
+// parseFedoraVersionFromRelease extracts the Fedora major version integer from
+// an FCOS release string such as "44.20260510.3.1".
+func parseFedoraVersionFromRelease(stream, release string) (int, error) {
+	dotIdx := strings.IndexByte(release, '.')
+	var majorStr string
+	if dotIdx < 0 {
+		majorStr = release
+	} else {
+		majorStr = release[:dotIdx]
+	}
+	if majorStr == "" {
+		return 0, fmt.Errorf("FCOS stream %q: unexpected release format %q", stream, release)
+	}
+	v, err := strconv.Atoi(majorStr)
+	if err != nil {
+		return 0, fmt.Errorf("FCOS stream %q: parsing Fedora version from %q: %w", stream, release, err)
+	}
+	return v, nil
+}

--- a/internal/fcos/streams_test.go
+++ b/internal/fcos/streams_test.go
@@ -1,0 +1,260 @@
+package fcos
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── parseFedoraVersionFromRelease ─────────────────────────────────────────────
+
+func TestParseFedoraVersionFromRelease_Standard(t *testing.T) {
+	v, err := parseFedoraVersionFromRelease("stable", "44.20260510.3.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestParseFedoraVersionFromRelease_OlderVersion(t *testing.T) {
+	v, err := parseFedoraVersionFromRelease("testing", "41.20250223.3.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 41 {
+		t.Errorf("got %d, want 41", v)
+	}
+}
+
+func TestParseFedoraVersionFromRelease_NoDot(t *testing.T) {
+	v, err := parseFedoraVersionFromRelease("next", "44")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestParseFedoraVersionFromRelease_Empty(t *testing.T) {
+	_, err := parseFedoraVersionFromRelease("stable", "")
+	if err == nil {
+		t.Fatal("expected error for empty release")
+	}
+}
+
+func TestParseFedoraVersionFromRelease_NonNumeric(t *testing.T) {
+	_, err := parseFedoraVersionFromRelease("stable", "notanumber.20260510.3.1")
+	if err == nil {
+		t.Fatal("expected error for non-numeric major version")
+	}
+}
+
+func TestParseFedoraVersionFromRelease_EmptyAfterDot(t *testing.T) {
+	_, err := parseFedoraVersionFromRelease("stable", ".20260510.3.1")
+	if err == nil {
+		t.Fatal("expected error for empty major version before dot")
+	}
+}
+
+// ── parseFedoraVersionFromStreamJSON ─────────────────────────────────────────
+
+func TestParseFedoraVersionFromStreamJSON_X86_64Metal(t *testing.T) {
+	body := []byte(`{"architectures":{"x86_64":{"artifacts":{"metal":{"release":"44.20260510.3.1"}}}}}`)
+	v, err := parseFedoraVersionFromStreamJSON("stable", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestParseFedoraVersionFromStreamJSON_FallbackToAarch64(t *testing.T) {
+	// No x86_64, only aarch64
+	body := []byte(`{"architectures":{"aarch64":{"artifacts":{"metal":{"release":"44.20260510.3.1"}}}}}`)
+	v, err := parseFedoraVersionFromStreamJSON("stable", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestParseFedoraVersionFromStreamJSON_FallbackNonMetal(t *testing.T) {
+	// x86_64 present but no metal artifact; falls back to another artifact
+	body := []byte(`{"architectures":{"x86_64":{"artifacts":{"qemu":{"release":"44.20260510.3.1"}}}}}`)
+	v, err := parseFedoraVersionFromStreamJSON("stable", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestParseFedoraVersionFromStreamJSON_NoArchitectures(t *testing.T) {
+	body := []byte(`{"architectures":{}}`)
+	_, err := parseFedoraVersionFromStreamJSON("stable", body)
+	if err == nil {
+		t.Fatal("expected error when architectures map is empty")
+	}
+}
+
+func TestParseFedoraVersionFromStreamJSON_InvalidJSON(t *testing.T) {
+	_, err := parseFedoraVersionFromStreamJSON("stable", []byte(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseFedoraVersionFromStreamJSON_NoReleaseField(t *testing.T) {
+	body := []byte(`{"architectures":{"x86_64":{"artifacts":{"metal":{"release":""}}}}}`)
+	_, err := parseFedoraVersionFromStreamJSON("stable", body)
+	if err == nil {
+		t.Fatal("expected error when release is empty")
+	}
+}
+
+// ── fetchStreamFedoraVersion (HTTP path) ─────────────────────────────────────
+
+func TestFetchStreamFedoraVersion_EmptyStream(t *testing.T) {
+	_, err := fetchStreamFedoraVersion(context.Background(), "http://localhost", "", http.DefaultClient)
+	if err == nil {
+		t.Fatal("expected error for empty stream")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty: %v", err)
+	}
+}
+
+func TestFetchStreamFedoraVersion_HTTP200(t *testing.T) {
+	body := `{"architectures":{"x86_64":{"artifacts":{"metal":{"release":"44.20260510.3.1"}}}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("User-Agent") != "knuckle/1.0" {
+			t.Errorf("expected User-Agent knuckle/1.0, got %q", r.Header.Get("User-Agent"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	v, err := fetchStreamFedoraVersion(context.Background(), srv.URL, "stable", srv.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 44 {
+		t.Errorf("got %d, want 44", v)
+	}
+}
+
+func TestFetchStreamFedoraVersion_HTTP404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := fetchStreamFedoraVersion(context.Background(), srv.URL, "unknown", srv.Client())
+	if err == nil {
+		t.Fatal("expected error for HTTP 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention 404: %v", err)
+	}
+}
+
+func TestFetchStreamFedoraVersion_NetworkError(t *testing.T) {
+	_, err := fetchStreamFedoraVersion(context.Background(), "http://127.0.0.1:1", "stable", &http.Client{})
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestFetchStreamFedoraVersion_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := fetchStreamFedoraVersion(context.Background(), srv.URL, "stable", srv.Client())
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestFetchStreamFedoraVersion_CorrectURLPath(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		body := `{"architectures":{"x86_64":{"artifacts":{"metal":{"release":"44.20260510.3.1"}}}}}`
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	_, err := fetchStreamFedoraVersion(context.Background(), srv.URL, "testing", srv.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPath != "/testing.json" {
+		t.Errorf("got path %q, want %q", capturedPath, "/testing.json")
+	}
+}
+
+func TestFetchStreamFedoraVersion_CancelledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// serve nothing — just block
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := fetchStreamFedoraVersion(ctx, srv.URL, "stable", srv.Client())
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestFetchStreamFedoraVersion_InvalidBaseURL(t *testing.T) {
+	// A URL with a control character causes http.NewRequestWithContext to fail.
+	_, err := fetchStreamFedoraVersion(context.Background(), "http://\n", "stable", http.DefaultClient)
+	if err == nil || !strings.Contains(err.Error(), "creating FCOS stream request") {
+		t.Errorf("expected 'creating FCOS stream request' error, got: %v", err)
+	}
+}
+
+func TestFetchStreamFedoraVersion_BodyReadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send 200 OK but close the connection immediately (causes read error).
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", 500)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		// Send a malformed response that will cause Read to fail.
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000000\r\n\r\n"))
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	_, err := fetchStreamFedoraVersion(context.Background(), srv.URL, "stable", srv.Client())
+	if err == nil {
+		t.Fatal("expected read error for abruptly closed connection")
+	}
+}
+
+// ── FetchStreamFedoraVersion (public, uses package-level client) ──────────────
+
+func TestFetchStreamFedoraVersion_PublicFunction_EmptyStream(t *testing.T) {
+	_, err := FetchStreamFedoraVersion(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty stream name")
+	}
+}


### PR DESCRIPTION
Closes #641.

## What this PR does

Implements the FCOS sysext catalog client described in issue #641, fetching extensions from the [fedora-sysexts/community](https://github.com/fedora-sysexts/community) GitHub Releases API.

## New files

### `internal/fcos/streams.go` (new package)
- `FetchStreamFedoraVersion(ctx, stream) (int, error)` — queries FCOS stream metadata JSON to derive the current Fedora major version (e.g. 44 from `44.20260510.3.1`). Prefers `x86_64`, falls back to `aarch64`.
- Injectable HTTP client; 100% statement coverage.

### `internal/bakery/fcos_tag.go`
- `ParseFCOSTagName(tag) (name, version, fedoraVersion, arch, error)` — parses tags in the form `<name>-<version_components>-<fedoraVersion>-<arch>`.
- Handles RPM epoch prefixes, multi-word names, digit-starting names; rejects bare pointer tags.
- 30+ real catalog tags as test cases.

### `internal/bakery/fcos.go`
- `FCOSCatalogURL`, `FetchCatalogFCOS` on `*HTTPClient`, `FCOSClient` implementing `Client`.
- Paginated (up to `fcosMaxCatalogPages=20`), deduplicating, with SHA256 verification and curated metadata. Page cap is a hard error, not silent truncation.

### `internal/bakery/fcos_descriptions.go`
- `FCOSLookup` and `fcosCatalog` with 10 curated entries: docker-ce, tailscale, vscode, vscodium, cilium-cli, 1password-gui, kubernetes, netbird, cloud-hypervisor, glab.

### `Justfile`
- Added `[fcos]=100` to `cover-check` targets.

## Design notes
- **Asset URLs**: verified 2025-06-04 — all `browser_download_url` values point to `github.com` (not `extensions.fcos.fr`). Existing `maxSysextURLLen` and HTTPS enforcement are sufficient.
- **Wiring to wizard/headless**: scoped to issue #638.
- **100% coverage**: both `internal/bakery` and `internal/fcos` hit 100% statement coverage.