### PR TITLE
fix(ci): block floating GitHub Action tags in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,11 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: no-floating-action-tags
+        name: Block floating GitHub Action tags
+        language: pygrep
+        entry: 'uses:(?!.*projectbluefin/).*@(main|master|latest|v[0-9])'
+        types: [yaml]
+        files: '(^\.github/workflows/.*\.yml$|action\.yml$)'


### PR DESCRIPTION
Part of projectbluefin/common#477 (org-wide rollout).

Adds a `no-floating-action-tags` pre-commit hook that blocks third-party GitHub Action floating tags (`@main`, `@master`, `@latest`, `@v1`, `@v1.2.3`, etc.) at commit time.

**Exemption**: `projectbluefin/` refs are excluded — `@v1` on `projectbluefin/actions` and `@main` on `projectbluefin/bonedigger` are intentional managed floating tags.

Covers both `.github/workflows/*.yml` and composite `action.yml` files.