### PR TITLE
docs(agents): document floating-tag pre-commit guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ just e2e                 # build ISO → boot in QEMU GTK window → interactive
 
 `just ci` is the pre-push gate. Never `--no-verify`.
 
+**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+
 ---
 
 ## Safety Invariants ⛔


### PR DESCRIPTION
## Summary
- document the new no-floating-action-tags pre-commit guard in AGENTS.md
- clarify the projectbluefin/actions managed-tag exemption

## Testing
- not run (docs-only change)