### PR TITLE
fix(governance): add CODEOWNERS and fix issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,9 @@
-# Default: knuckle maintainers review all changes
-* @castrojo @jreilly1821 @ahmedadan
+* @castrojo @p5 @m2Giles @tulilirockz
 
-# Sensitive governance and CI paths — require explicit maintainer review
-.github/                @castrojo @jreilly1821 @ahmedadan
-Justfile                @castrojo @jreilly1821 @ahmedadan
-.pre-commit-config.yaml @castrojo @jreilly1821 @ahmedadan
-renovate.json           @castrojo @jreilly1821 @ahmedadan
-codecov.yml             @castrojo @jreilly1821 @ahmedadan
+.github/workflows/ @castrojo @p5 @m2Giles @tulilirockz
+Justfile           @castrojo @p5 @m2Giles @tulilirockz
 
-# Core installation and system interaction
-internal/install/       @castrojo @jreilly1821
-internal/runner/        @castrojo @jreilly1821
-internal/ignition/      @castrojo @jreilly1821
-
-# Release and build artifacts
-cmd/                    @castrojo @jreilly1821
+# BEGIN TRIAGERS — managed by projectbluefin/common, do not edit manually in downstream repos
+docs/**  @inffy @renner0e @ledif @castrojo @hanthor @ahmedadan
+*.md     @inffy @renner0e @ledif @castrojo @hanthor @ahmedadan
+# END TRIAGERS

--- a/.github/ISSUE_TEMPLATE/help-this-project.yml
+++ b/.github/ISSUE_TEMPLATE/help-this-project.yml
@@ -5,7 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Point an agent at a repo, issue, or PR and get a report back. Be specific — "look at this repo" produces a shallow overview, a focused question produces something actionable.
+        ## Point an agent at something. Get a report back.
+
+        This template is for donating agent compute to the project. You name a target — a repo, an issue, a PR, a roadmap — and a Hive agent investigates and files findings here.
+
+        Be specific about what you want the agent to focus on. "Look at this repo" produces a shallow overview. "Check whether the PR review checklist catches the reproducibility class of bugs we've been seeing" produces something actionable.
 
   - type: input
     id: target-url
@@ -20,7 +24,6 @@ body:
     id: flow
     attributes:
       label: "What kind of help?"
-      description: "This routes the right agent to the right task."
       options:
         - "Project report — survey a repo or org and summarize what needs attention"
         - "Issue review — read a linked issue and recommend next steps"
@@ -32,11 +35,7 @@ body:
     id: goal
     attributes:
       label: "What specifically should the agent focus on?"
-      description: "The more specific you are, the more useful the report. One to three sentences."
-      placeholder: |
-        Check whether the CI pipeline for this repo has any reliability issues that would
-        explain the flaky validate failures we have been seeing. Focus on the BST cache
-        interactions and the bst2 container pin check.
+      description: "One to three sentences."
     validations:
       required: true
 
@@ -44,13 +43,6 @@ body:
     id: context
     attributes:
       label: "Extra context"
-      description: "Optional. Known problem areas, related Dakota issues, or constraints the agent should respect."
-      placeholder: "Related to #503. The agent should not suggest changes that require a new external dependency."
+      description: "Optional."
     validations:
       required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        Hive will route this to the right agent based on the flow type above. The agent files its report as a comment on this issue.

--- a/.github/ISSUE_TEMPLATE/pin.yml
+++ b/.github/ISSUE_TEMPLATE/pin.yml
@@ -1,0 +1,25 @@
+name: Pin Request
+description: Ask to pin a package to a specific version in order to avoid regressions
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report! (She bites sometimes). We can pin packages to older, known working versions if there's an issue with an update in Fedora.
+  - type: textarea
+    id: package
+    attributes:
+      label: Describe the Package
+      description: Describe the package you want pinned and why
+      placeholder: Pin foobar to version 1.2
+      value: "Package foobar version 1.2 blew up, we need to revert to 1.1"
+    validations:
+      required: true
+  - type: textarea
+    id: bodhi
+    attributes:
+      label: Bodhi Link (Optional)
+      description: Add the bodhi link to the working version, this is very useful in order to pin a package quickly
+      placeholder: Bodhi link
+      value: "Pin to this version please: https://bodhi.fedoraproject.org/updates/FEDORA-2024-45d587348e"
+    validations:
+      required: false


### PR DESCRIPTION
SCOPE
- align `.github/CODEOWNERS` to the factory ownership pattern
- refresh `help-this-project.yml` to the factory version
- add missing `pin.yml`

GOAL
- bring knuckle governance files in line with the current factory standard without touching Go code or workflows

OUT OF SCOPE
- workflow changes
- application code changes
- repo settings beyond the separate merge policy update

Validation: `just ci`

Refs #414
Refs #416