### PR TITLE
docs: fix doc advisory follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ These docs live in `docs/` and improve continuously. Load the relevant one for y
 | Troubleshooting runbook, first-boot diagnostics | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
 | Butane-as-library rationale | [`docs/BUTANE-DEPENDENCY.md`](docs/BUTANE-DEPENDENCY.md) |
 
+## Release Checklist
+
+Before tagging any release, use [`docs/RELEASE.md`](docs/RELEASE.md) as the canonical pre-release gate for required checks, VM verification, and blocker history.
+
 ---
 
 ## Routine Maintenance

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -349,4 +349,3 @@ Tracked in `docs/REVIEW-2026-05-19.md` (passes 1-2) and session notes from
 - Verify `ens3` vs `eth0` interface name in static-network vm-e2e pass.
 - Add fixture gaps: `lsblk-empty.json`, `lsblk-all-removable.json`,
   `ip_addr-ipv6-only.json`, `bakery-malformed-digests` (from QA review).
-- ~~Raise `tui` coverage (currently 52%)~~ **Done** — `internal/tui` reached 95.6% (gate: 94%). PR #521 adds form-state and render branch tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,3 +29,17 @@ These files are mainly useful for maintainers, reviewers, and agent-assisted dev
 | [internal/REVIEW-2026-05-19.md](internal/REVIEW-2026-05-19.md) | Agent-authored principal-engineer review notes from 2026-05-19. |
 | [internal/REVIEW-2026-05-19b.md](internal/REVIEW-2026-05-19b.md) | Agent-authored follow-up review notes from 2026-05-19. |
 | [internal/REVIEW-2026-05-20.md](internal/REVIEW-2026-05-20.md) | Agent-authored principal-engineer review notes from 2026-05-20. |
+
+## Demo assets
+
+The top-level `demo/` directory contains the recorded installer demo used in the project docs:
+
+- `demo/knuckle-demo.tape` — [VHS](https://github.com/charmbracelet/vhs) script/source
+- `demo/knuckle-install.cast` — generated [asciinema](https://asciinema.org/) cast
+- `demo/knuckle-install.gif` — rendered GIF artifact
+
+Regenerate the cast and GIF with:
+
+```bash
+vhs demo/knuckle-demo.tape
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -59,11 +59,6 @@ This document covers each.
   `SignedDigest` is set to `false` and a warning is logged. This is separate
   from knuckle's own release artifact signing (cosign keyless via Sigstore).
 
-- **Flatcar release GPG signatures.** `channels.go` downloads `.DIGESTS.asc`
-  and `verify.go` validates the signature against the embedded Flatcar signing
-  key (`internal/bakery/keys/flatcar-signing.asc`). If verification fails,
-  `SignedDigest` is set to false and a warning is logged. This is separate
-  from knuckle's own release artifact signing (cosign keyless via Sigstore).
 
 ### Verifying a release (users)
 


### PR DESCRIPTION
## Summary
- remove the stale completed TUI coverage roadmap item from CI/testing docs
- add a release checklist heading in AGENTS that points to the canonical release doc
- keep the Flatcar GPG verification note in the verified section and drop the duplicate copy
- document the top-level demo/ assets and how to regenerate them in docs/README.md

## Testing
- just ci