### PR TITLE
test(tui): add coverage for form validator closures in forms.go

### DIFF
--- a/internal/tui/forms.go
+++ b/internal/tui/forms.go
@@ -11,6 +11,45 @@ import (
 	"github.com/projectbluefin/knuckle/internal/validate"
 )
 
+func validateOptionalCIDR(s string) error {
+	if s == "" {
+		return nil
+	}
+	return validate.CIDR(s)
+}
+
+func validateOptionalIPAddress(s string) error {
+	if s == "" {
+		return nil
+	}
+	return validate.IPAddress(s)
+}
+
+func validateOptionalHostname(s string) error {
+	if s == "" {
+		return nil
+	}
+	return validate.Hostname(s)
+}
+
+func validateTimezoneInput(s string) error {
+	return validate.Timezone(s)
+}
+
+func validateOptionalUsername(s string) error {
+	if s == "" {
+		return nil
+	}
+	return validate.Username(s)
+}
+
+func validateOptionalTailscaleAuthKey(s string) error {
+	if s == "" {
+		return nil
+	}
+	return validate.TailscaleAuthKey(s)
+}
+
 // buildNetworkForm creates the huh form for the Network step.
 func (m *Model) buildNetworkForm() *huh.Form {
 	// Build interface options from detected interfaces
@@ -51,22 +90,12 @@ func (m *Model) buildNetworkForm() *huh.Form {
 			Description("With subnet mask, e.g. 192.168.1.100/24").
 			Placeholder("192.168.1.100/24").
 			Value(&m.Wizard.State.Config.Network.Address).
-			Validate(func(s string) error {
-				if s == "" {
-					return nil
-				}
-				return validate.CIDR(s)
-			}),
+			Validate(validateOptionalCIDR),
 		huh.NewInput().
 			Title("Gateway").
 			Placeholder("192.168.1.1").
 			Value(&m.Wizard.State.Config.Network.Gateway).
-			Validate(func(s string) error {
-				if s == "" {
-					return nil
-				}
-				return validate.IPAddress(s)
-			}),
+			Validate(validateOptionalIPAddress),
 		huh.NewInput().
 			Title("DNS Servers").
 			Description("Comma-separated, e.g. 1.1.1.1,8.8.8.8").
@@ -93,30 +122,18 @@ func (m *Model) buildUserForm() *huh.Form {
 				Title("Hostname").
 				Placeholder("flatcar-node01").
 				Value(&m.Wizard.State.Config.Hostname).
-				Validate(func(s string) error {
-					if s == "" {
-						return nil
-					}
-					return validate.Hostname(s)
-				}),
+				Validate(validateOptionalHostname),
 			huh.NewInput().
 				Title("Timezone").
 				Placeholder("UTC").
 				Description("e.g. America/New_York, Europe/Berlin").
 				Value(&m.Wizard.State.Config.Timezone).
-				Validate(func(s string) error {
-					return validate.Timezone(s)
-				}),
+				Validate(validateTimezoneInput),
 			huh.NewInput().
 				Title("Username").
 				Description("Primary user account").
 				Value(&m.usernameInput).
-				Validate(func(s string) error {
-					if s == "" {
-						return nil
-					}
-					return validate.Username(s)
-				}),
+				Validate(validateOptionalUsername),
 			huh.NewInput().
 				Title("Password").
 				Description("Optional — leave blank for key-only auth").
@@ -172,12 +189,7 @@ func (m *Model) buildTailscaleForm() *huh.Form {
 				Placeholder("tskey-auth-...").
 				EchoMode(huh.EchoModePassword).
 				Value(&m.tailscaleAuthKeyIn).
-				Validate(func(s string) error {
-					if s == "" {
-						return nil
-					}
-					return validate.TailscaleAuthKey(s)
-				}),
+				Validate(validateOptionalTailscaleAuthKey),
 			huh.NewSelect[string]().
 				Title("Mode").
 				Options(modeOptions...).

--- a/internal/tui/forms_validator_test.go
+++ b/internal/tui/forms_validator_test.go
@@ -1,0 +1,127 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateOptionalCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid cidr", input: "192.168.1.10/24", wantErr: false},
+		{name: "invalid cidr", input: "192.168.1.10", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateOptionalCIDR(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateOptionalCIDR(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOptionalIPAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid ipv4", input: "192.168.1.1", wantErr: false},
+		{name: "invalid ipv4", input: "gateway", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateOptionalIPAddress(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateOptionalIPAddress(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOptionalHostname(t *testing.T) {
+	tooLong := strings.Repeat("a", 64)
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid hostname", input: "flatcar-node01", wantErr: false},
+		{name: "invalid hostname", input: tooLong, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateOptionalHostname(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateOptionalHostname(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTimezoneInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid timezone", input: "America/New_York", wantErr: false},
+		{name: "invalid timezone", input: "Bad Timezone", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateTimezoneInput(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateTimezoneInput(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOptionalUsername(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid username", input: "core", wantErr: false},
+		{name: "invalid username", input: "Core", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateOptionalUsername(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateOptionalUsername(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateOptionalTailscaleAuthKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "valid auth key", input: "tskey-auth-1234567890-abcdefghijklmnopqrstuvwxyz123456", wantErr: false},
+		{name: "invalid auth key", input: "tskey-auth-short", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErr := validateOptionalTailscaleAuthKey(tt.input) != nil; gotErr != tt.wantErr {
+				t.Fatalf("validateOptionalTailscaleAuthKey(%q) error = %v, wantErr %v", tt.input, gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- extract form validator closures in `internal/tui/forms.go` into named package-level validators
- add direct table-driven tests for the optional CIDR, IP, hostname, timezone, username, and Tailscale auth key validators
- keep form wiring unchanged while making validator coverage explicit and stable

## Testing
- just cover-check
- just ci