### PR TITLE
test(bakery): wire bakery_catalog.json fixture into catalog test

### DIFF
--- a/internal/bakery/bakery_catalog_fixture_test.go
+++ b/internal/bakery/bakery_catalog_fixture_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/projectbluefin/knuckle/internal/bakery"
 	"github.com/projectbluefin/knuckle/internal/model"
 )
 
-func TestMockClientFetchCatalogArch_UsesRepositoryFixture(t *testing.T) {
+func loadBakeryCatalogFixture(t *testing.T) []model.SysextEntry {
+	t.Helper()
+
 	fixturePath := filepath.Join("..", "..", "testdata", "bakery_catalog.json")
 	fixture, err := os.ReadFile(fixturePath)
 	if err != nil {
@@ -23,33 +26,22 @@ func TestMockClientFetchCatalogArch_UsesRepositoryFixture(t *testing.T) {
 		t.Fatalf("Unmarshal(%q): %v", fixturePath, err)
 	}
 
-	client := &bakery.MockClient{Entries: entries}
-	got, err := client.FetchCatalogArch(context.Background(), "amd64")
-	if err != nil {
-		t.Fatalf("FetchCatalogArch: %v", err)
-	}
-	if len(got) != 3 {
-		t.Fatalf("expected 3 entries from fixture, got %d", len(got))
-	}
+	return entries
+}
 
-	wants := []struct {
-		name    string
-		version string
-		url     string
-	}{
-		{name: "docker", version: "24.0.7", url: "https://bakery.flatcar.org/sysext/docker-24.0.7.raw"},
-		{name: "wasmcloud", version: "0.82.0", url: "https://bakery.flatcar.org/sysext/wasmcloud-0.82.0.raw"},
-		{name: "tailscale", version: "1.56.1", url: "https://bakery.flatcar.org/sysext/tailscale-1.56.1.raw"},
-	}
-	for i, want := range wants {
-		if got[i].Name != want.name {
-			t.Fatalf("entry %d name = %q, want %q", i, got[i].Name, want.name)
-		}
-		if got[i].Version != want.version {
-			t.Fatalf("entry %d version = %q, want %q", i, got[i].Version, want.version)
-		}
-		if got[i].URL != want.url {
-			t.Fatalf("entry %d url = %q, want %q", i, got[i].URL, want.url)
-		}
+func TestMockClientFetchCatalogArch_UsesRepositoryFixture(t *testing.T) {
+	entries := loadBakeryCatalogFixture(t)
+	client := &bakery.MockClient{Entries: entries}
+
+	for _, arch := range []string{"amd64", "arm64"} {
+		t.Run(arch, func(t *testing.T) {
+			got, err := client.FetchCatalogArch(context.Background(), arch)
+			if err != nil {
+				t.Fatalf("FetchCatalogArch(%q): %v", arch, err)
+			}
+			if !reflect.DeepEqual(got, entries) {
+				t.Fatalf("FetchCatalogArch(%q) = %#v, want %#v", arch, got, entries)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- keep `testdata/bakery_catalog.json` as a repository-backed bakery fixture
- load the fixture through a shared helper in bakery tests
- assert `MockClient.FetchCatalogArch` returns the fixture unchanged for both amd64 and arm64 when URLs are arch-neutral

## Testing
- just ci