### PR TITLE
ci(cover-check): add cmd/nvidia-check coverage gate at 95%

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -182,6 +182,22 @@ cover-check:
     else
         echo "ok    ${cbf_pkg}  ${cbf_pct}%  (target ${cbf_target}%)"
     fi
+    # cmd/nvidia-check — gated at 95% (run() is covered; main() wrapper is not).
+    # Depends on the run() refactor landing in #760. Gate prevents regression.
+    nvidia_pkg=cmd/nvidia-check
+    nvidia_target=95
+    nvidia_pct=$(go test -count=1 -cover ./${nvidia_pkg}/... 2>/dev/null \
+        | awk '/coverage:/ {gsub("%",""); print $(NF-2); exit}')
+    nvidia_pct=${nvidia_pct%.*}
+    if [[ -z "$nvidia_pct" ]]; then
+        echo "FAIL  ${nvidia_pkg}   no coverage reported"
+        fail=1
+    elif (( nvidia_pct < nvidia_target )); then
+        echo "FAIL  ${nvidia_pkg}  ${nvidia_pct}%  (target ${nvidia_target}%)"
+        fail=1
+    else
+        echo "ok    ${nvidia_pkg}  ${nvidia_pct}%  (target ${nvidia_target}%)"
+    fi
     exit $fail
 
 # Quick headless dry-run test (no VM needed)

--- a/docs/CI-AND-TESTING.md
+++ b/docs/CI-AND-TESTING.md
@@ -54,6 +54,9 @@
 | `internal/headless`          |  99%   |  99% | (n/a)                     |
 | `internal/tui`               |  98.7% |  98% | ≥ 85%                     |
 | `internal/github`            |  97%   |  96% | (n/a)                     |
+| `cmd/knuckle`                |  ~85%  |  85% | (n/a)                     |
+| `cmd/compile-butane-fresh`   |  100%  | 100% | (n/a)                     |
+| `cmd/nvidia-check`           |  98.9% |  95% | (n/a) — depends on #760   |
 
 Gates are set conservatively below current numbers so CI fails on
 **regression**, not on aspirational drift. When a package's actual coverage


### PR DESCRIPTION
## Problem

`cmd/nvidia-check` was the only `cmd/` package without a coverage gate in `just cover-check`. The `run()` refactor in #760 brings the package from ~40% to 98.9%, but without a gate this coverage could silently regress.

## Changes

### `Justfile`
- Add `cmd/nvidia-check` to `cover-check` with threshold 95%
- 95% leaves room for the one-line `main()` wrapper that cannot be covered without a re-invocation harness, while preventing any regression in the `run()` path

### `docs/CI-AND-TESTING.md`
- Add the three `cmd/` packages to the coverage table:
  - `cmd/knuckle` — gated at 85%
  - `cmd/compile-butane-fresh` — gated at 100%
  - `cmd/nvidia-check` — gated at 95% (**new**)

## Dependency

**This PR requires #760 to merge first.** On the current `main` branch (without the `run()` refactor), `cmd/nvidia-check` is at ~40% and the gate would fail. Once #760 merges, the gate will pass at 98.9%.

Closes #776
Closes #767

---
Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented stricter code coverage thresholds for additional components to ensure code quality standards.

* **Documentation**
  * Updated CI and testing documentation with current coverage gate configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->