### PR TITLE
chore(ci): correct codecov-action comment from v6 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           retention-days: 14
 
       - name: upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./cover.out
           fail_ci_if_error: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,7 @@ jobs:
           retention-days: 30
 
       - name: upload to Codecov (nightly flag)
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./cover.out
           flags: nightly


### PR DESCRIPTION
## What

PR #755 updated the codecov-action digest to `fb8b358` (the v7 hash) but left the inline comment as `# v6`. The action is already running v7 code — this corrects the comment to match.

## Why now

Closes Renovate PR #756 which tried to make the same change but has a merge conflict because it was based on the pre-#755 state.

Closes #758

---
Assisted-by: claude-sonnet-4-5 via pi