### PR TITLE
docs: update AGENTS.md for FCOS dual-OS architecture; fix release-preflight Justfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@
 
 ## What This Repo Is
 
-A TUI installer for [Flatcar Container Linux](https://www.flatcar.org/), targeting bare-metal.
+A TUI installer for [Flatcar Container Linux](https://www.flatcar.org/) and [FCOS](https://fedoraproject.org/coreos/), targeting bare-metal.
 Built in Go on charm.sh (Bubble Tea v2, Lip Gloss v2, Huh v2). Assembles an Ignition config
-and hands off to `flatcar-install` — knuckle never writes partitions itself.
+and dispatches to `flatcar-install` (Flatcar) or `coreos-installer` (FCOS) via `DispatchingInstaller` — knuckle never writes partitions itself.
 
 - **Module:** `github.com/projectbluefin/knuckle` (Go 1.26+)
 - **License:** Apache-2.0
@@ -87,10 +87,10 @@ Coverage gates are authoritative in [`docs/CI-AND-TESTING.md`](docs/CI-AND-TESTI
 | `internal/runner`   | `Runner` interface: `RealRunner`, `DryRunner`, `SpyRunner`        |
 | `internal/probe`    | `lsblk` + `ip addr` JSON parsing, `/dev/disk/by-id` resolution   |
 | `internal/validate` | Hostname, CIDR, gateway, SSH key, timezone, disk path validators  |
-| `internal/bakery`   | sysext catalog + Flatcar release/SBOM fetchers, SHA512 + GPG check|
+| `internal/bakery`   | `DispatchingClient` routing to Flatcar or FCOS bakery clients; sysext catalog + release/SBOM fetchers, SHA512 + GPG check|
 | `internal/github`   | SSH key fetch + GitHub Releases API client                        |
 | `internal/ignition` | Butane assembly + in-process Butane→Ignition compilation          |
-| `internal/install`  | `flatcar-install` orchestration via runner                        |
+| `internal/install`  | `DispatchingInstaller` routing to `FlatcarInstaller` or `FCOSInstaller` via runner |
 | `internal/iso`      | Installer ISO builder helpers                                     |
 | `internal/headless` | `--headless --config` JSON-driven install path                    |
 | `internal/wizard`   | Step state machine, navigation, validation gates                  |

--- a/Justfile
+++ b/Justfile
@@ -1109,11 +1109,24 @@ nvidia-check:
         -o bin/nvidia-check ./cmd/nvidia-check
     ./bin/nvidia-check
 
-# Full pre-release preflight: catalog coverage + nvidia versions + CI gate.
+# Full pre-release preflight: catalog coverage + nvidia versions + CI gate + CHANGELOG reminder.
 # Run this before tagging any release.
 release-preflight: ci
     #!/usr/bin/env bash
     set -euo pipefail
+    echo ""
+    echo "[2/3] Checking sysext catalog coverage against live bakery..."
+    go run ./scripts/catalog_check/ --strict
+    echo ""
+    echo "[3/3] Checking NVIDIA driver series against Flatcar docs..."
+    ./scripts/nvidia_check.sh
+    echo ""
+    echo "✓ release-preflight complete"
+    echo ""
+    echo "Pre-tag checklist (manual steps):"
+    echo "  - [ ] Promote CHANGELOG.md [Unreleased] to ## [vX.Y.Z] - $(date +%Y-%m-%d)"
+    echo "  - [ ] Update compare links in CHANGELOG.md footer"
+    echo "  - [ ] Run 'just vm-e2e' for final VM verification before publishing"
 
 # QA: full PR test — build + unit tests + Flatcar VM install + boot + domain assertions.
 # Artifacts saved to .qa/runs/pr-N-TIMESTAMP/. Failed runs generate an issue body.


### PR DESCRIPTION
Addresses hive advisory findings from [projectbluefin/common#557](https://github.com/projectbluefin/common/issues/557).

### AGENTS.md — FCOS dual-OS architecture
- Updated description from Flatcar-only to Flatcar + FCOS
- `internal/install`: updated to reflect `DispatchingInstaller` routing to `FlatcarInstaller` or `FCOSInstaller`
- `internal/bakery`: updated to reflect `DispatchingClient` routing to Flatcar or FCOS bakery clients

### Justfile — release-preflight
- Added `catalog-check-strict` and `nvidia-check` calls (were only in `qa-pr`, not `release-preflight`)
- Added CHANGELOG.md promotion reminder — v0.7.0 was tagged without a CHANGELOG update due to this gap