### PR TITLE
fix(knuckle): pin @v1 floating tag to SHA and add automerge to renovate.json

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   skill-drift:
-    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
       code-paths: '[".github/workflows/**", "cmd/**", "internal/**", "Justfile", "scripts/**"]'
       skill-paths: '["docs/**/*.md", "AGENTS.md"]'

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
     {
       "matchManagers": ["github-actions"],
       "pinDigests": true
+    },
+    {
+      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two factory convergence fixes batched together:

### 1. Pin `@v1` floating tag to SHA — closes projectbluefin/common#610

`skill-drift.yml` was using `projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1` — a floating tag that can silently drift. Pin to full SHA with version comment per factory standard.

**SHA**: `5f3cabacecd1a7b95b7f64b03aa4c298ff73f918` (current v1 tag)

### 2. Add automerge to renovate.json — closes projectbluefin/common#615

`renovate.json` already extended `local>projectbluefin/renovate-config` and had `pinDigests: true` for GitHub Actions, but was missing the automerge rule for `digest/pin/patch/minor` updates. Adds the standard `matchUpdateTypes` automerge packageRule matching the factory pattern.

## Verification

- [ ] `actionlint .github/workflows/*.yml` passes
- Changes are additive / safe; no logic changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for more reliable automated processes
  * Enhanced automated dependency update rules to streamline dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->