### PR TITLE
fix(ci): correct misleading comment on bonedigger SHA pin

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bonedigger:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # main
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
     with:
       brand_name: "Bluefin"
       brand_emoji: "🦖"


### PR DESCRIPTION
The SHA d53076732c is v1, not main. The comment said # main which was misleading for anyone reading the workflow.