### PR TITLE
fix(ci): bump Go to 1.26.5 and restore internal/install coverage to 100%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - name: go mod tidy (must be clean)
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
         continue-on-error: true
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -198,7 +198,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -259,7 +259,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - name: build arm64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - name: extended flaky detection (10 iterations)
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - name: run integration tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         if: steps.release-check.outputs.skip_upload != 'true'
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         if: steps.release-check.outputs.skip_upload != 'true'
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbluefin/knuckle
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/install/ddi.go
+++ b/internal/install/ddi.go
@@ -31,6 +31,7 @@ type BluefinDDIInstaller struct {
 	readFile  func(name string) ([]byte, error)
 	readDir   func(name string) ([]os.DirEntry, error)
 	mkdirTemp func(dir, pattern string) (string, error)
+	statFile  func(name string) (os.FileInfo, error)
 }
 
 // NewBluefinDDIInstaller creates a BluefinDDIInstaller with the given runner and logger.
@@ -43,6 +44,7 @@ func NewBluefinDDIInstaller(r runner.Runner, logger *slog.Logger) *BluefinDDIIns
 		readFile:  os.ReadFile,
 		readDir:   os.ReadDir,
 		mkdirTemp: os.MkdirTemp,
+		statFile:  os.Stat,
 	}
 }
 
@@ -155,7 +157,7 @@ func (i *BluefinDDIInstaller) prepareDDI(ctx context.Context, progress func(stri
 	// containing the DDI filesystem image as a raw block copy. systemd-repart's
 	// CopyBlocks= can copy directly from the device without mounting it.
 	const installerDataPartlabel = "/dev/disk/by-partlabel/bluefin-installer-data"
-	if _, statErr := os.Stat(installerDataPartlabel); statErr == nil {
+	if _, statErr := i.statFile(installerDataPartlabel); statErr == nil {
 		progress("Embedded DDI detected on installer media")
 		i.Logger.Info("embedded DDI source", "device", installerDataPartlabel)
 

--- a/internal/install/ddi_test.go
+++ b/internal/install/ddi_test.go
@@ -24,6 +24,9 @@ func noopDDIInstaller(spy *runner.SpyRunner) *BluefinDDIInstaller {
 	i.readFile = func(string) ([]byte, error) { return []byte{}, nil }
 	i.readDir = func(string) ([]os.DirEntry, error) { return nil, nil }
 	i.mkdirTemp = func(string, string) (string, error) { return "/tmp/fake-repart-dir", nil }
+	// Default: no embedded installer-media partition, so tests exercise the
+	// blkid / sysupdate paths unless they opt into the embedded-DDI branch.
+	i.statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	return i
 }
 
@@ -558,6 +561,61 @@ func TestInstall_WriteBootEntry_Error(t *testing.T) {
 	// writeBootEntry failure is non-fatal: Install should return nil
 	if err := i.Install(context.Background(), cfg, func(string) {}); err != nil {
 		t.Errorf("writeBootEntry failure should be non-fatal, got: %v", err)
+	}
+}
+
+// ── prepareDDI: embedded DDI on installer media ───────────────────────────────
+
+func TestPrepareDDI_EmbeddedInstallerMedia(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	i := noopDDIInstaller(spy)
+	i.statFile = func(name string) (os.FileInfo, error) {
+		if name == "/dev/disk/by-partlabel/bluefin-installer-data" {
+			return nil, nil // partition present
+		}
+		return nil, os.ErrNotExist
+	}
+	var progressed []string
+	defs, cleanup, err := i.prepareDDI(context.Background(), func(m string) { progressed = append(progressed, m) })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defs != "/tmp/fake-repart-dir" {
+		t.Errorf("want embedded repart.d dir, got %q", defs)
+	}
+	if cleanup == nil {
+		t.Error("expected a cleanup func for the temp repart.d dir")
+	} else {
+		cleanup()
+	}
+	if len(progressed) == 0 || !strings.Contains(progressed[0], "Embedded DDI") {
+		t.Errorf("want 'Embedded DDI' progress message, got %v", progressed)
+	}
+	// Detection short-circuits before blkid / sysupdate.
+	if len(spy.Calls) != 0 {
+		t.Errorf("embedded-DDI path must not fall through to blkid/sysupdate, got calls: %v", spy.Calls)
+	}
+}
+
+func TestPrepareDDI_EmbeddedInstallerMedia_MkdirTempFails(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	i := noopDDIInstaller(spy)
+	i.statFile = func(string) (os.FileInfo, error) { return nil, nil }
+	i.mkdirTemp = func(string, string) (string, error) { return "", os.ErrPermission }
+	_, _, err := i.prepareDDI(context.Background(), func(string) {})
+	if err == nil || !strings.Contains(err.Error(), "repart.d") {
+		t.Errorf("want 'repart.d' error, got %v", err)
+	}
+}
+
+func TestPrepareDDI_EmbeddedInstallerMedia_WriteRepartDefsFails(t *testing.T) {
+	spy := runner.NewSpyRunner()
+	i := noopDDIInstaller(spy)
+	i.statFile = func(string) (os.FileInfo, error) { return nil, nil }
+	i.readDir = func(string) ([]os.DirEntry, error) { return nil, os.ErrPermission }
+	_, _, err := i.prepareDDI(context.Background(), func(string) {})
+	if err == nil {
+		t.Error("expected writeLocalRepartDefs error to be propagated")
 	}
 }
 


### PR DESCRIPTION
## What

Two **systemic** CI failures were red on `main` and therefore blocking *every* open knuckle PR (the `govulncheck` and `coverage gate` checks). This fixes both.

### 1. `govulncheck` — `GO-2026-5856`
`govulncheck ./...` fails on the stdlib advisory **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`), reachable via `bakery.HTTPClient.FetchCatalogFCOS`. It's **fixed in go1.26.5**, but CI pinned `1.26.4`.

- Bumped the pinned toolchain `1.26.4 → 1.26.5` in `go.mod` and every `setup-go` step (`ci.yml`, `nightly.yml`, `release.yml`, `security.yml`). The floating `"1.26"` entries in `vm-e2e.yml` already resolve to ≥ 1.26.5 and were left alone.
- **Verified locally:** `govulncheck ./...` → *0 vulnerabilities* on 1.26.5.

### 2. `coverage gate` — `internal/install` at 97% (target 100%)
The embedded-DDI detection branch added in 7e463fc calls `os.Stat` on a hardcoded `/dev/disk/by-partlabel/bluefin-installer-data` path with **no test seam**, so that branch was never exercised — dropping `internal/install` to 97%.

- Added a `statFile` seam on `BluefinDDIInstaller` (mirrors the existing `mkdirTemp`/`readDir`/`writeFile`/… injection pattern), defaulting to `os.Stat`.
- Added tests covering all three branch paths: success (short-circuits before blkid/sysupdate), `mkdirTemp` failure, and `writeLocalRepartDefs` failure.
- **Verified locally:** `just cover-check` passes end-to-end — `internal/install` now `100% (target 100%)`, full test suite green.

## Impact
Unblocks the `govulncheck` + `coverage gate` checks across all open knuckle PRs. Scope is knuckle only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s Go toolchain to version 1.26.5 across development, security, nightly, and release workflows.
  - Builds, validations, coverage checks, and releases now consistently use the updated Go version.

- **Tests**
  - Expanded installer media validation coverage, including embedded DDI detection and error handling for temporary directory and definition-writing failures.
  - Improved test configurability for installer partition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->