### PR TITLE
chore(workflow): pin bonedigger lifecycle to clanker-queue rollout

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bonedigger:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@aa3185566171de43106976cd5a0ac72ee3106868 # clanker-queue-rollout
     with:
       brand_name: "Bluefin"
       brand_emoji: "🦖"


### PR DESCRIPTION
Pins knuckle's bonedigger caller to the new bonedigger rollout SHA so it can consume the clanker-queue migration workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated lifecycle workflow to use the latest implementation, improving workflow maintenance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->