### PR TITLE
fix(deps): bump Go toolchain pin to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: go mod tidy (must be clean)
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
@@ -113,7 +113,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
         continue-on-error: true
@@ -171,7 +171,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -198,7 +198,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -259,7 +259,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: build arm64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: extended flaky detection (10 iterations)
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: run integration tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         if: steps.release-check.outputs.skip_upload != 'true'
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         if: steps.release-check.outputs.skip_upload != 'true'
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbluefin/knuckle
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Why

The required `govulncheck` check fails on four Go 1.26.5 standard-library vulnerabilities, all fixed in go1.26.6:

| ID | Package | Found | Fixed |
|---|---|---|---|
| GO-2026-6218 | net/url (quadratic resolvePath) | go1.26.5 | go1.26.6 |
| GO-2026-6090 | crypto/tls (post-handshake messages) | go1.26.5 | go1.26.6 |
| GO-2026-5972 | encoding/asn1 (recursion depth) | go1.26.5 | go1.26.6 |
| GO-2026-5026 | net/http (Punycode label rejection) | go1.26.5 | go1.26.6 |

This blocks every open dependency PR (#860, #861, #863, #864, #865, #866), none of which can repair it without changing their purpose.

## What

Smallest toil-only repair: move every exact Go patch pin from 1.26.5 to 1.26.6, the first patched release.

- `.github/workflows/ci.yml` — 7 setup-go pins
- `.github/workflows/nightly.yml` — 4 setup-go pins
- `.github/workflows/release.yml` — 2 setup-go pins
- `.github/workflows/security.yml` — 1 setup-go pin
- `go.mod` — `go 1.26.5` → `go 1.26.6`

`vm-e2e.yml` pins only `go-version: "1.26"` and already resolves to the latest patch; untouched.

## Local validation (GOTOOLCHAIN=go1.26.6)

- `go mod tidy` clean, `gofmt -l` clean, `go vet ./...` clean
- `go build ./...` ok
- `go test -race ./...` — all 18 packages ok
- `bats scripts/tests/*.bats` — 80/80 ok
- `govulncheck ./...` — **No vulnerabilities found** (was: 4 stdlib findings on go1.26.5)