### PR TITLE
fix: set serial console geometry before TUI

### DIFF
--- a/cmd/knuckle/main.go
+++ b/cmd/knuckle/main.go
@@ -169,6 +169,9 @@ func main() {
 	} else {
 		startupFetchFn(ctx, w, logger)
 	}
+	if err := prepareSerialTerminal(ctx, cmdRunner); err != nil {
+		logger.Warn("serial terminal preparation failed", "error", err)
+	}
 
 	// Run the TUI — wire reboot through the runner so dry-run/spy work correctly
 	var rebootFn func(context.Context) error

--- a/cmd/knuckle/terminal.go
+++ b/cmd/knuckle/terminal.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+const (
+	serialConsolePath = "/dev/console"
+	serialRows        = "40"
+	serialColumns     = "80"
+)
+
+// terminalSizeFn and activeConsoleFn are injectable so serial-console startup
+// behavior can be tested without requiring a real TTY or sysfs.
+var (
+	terminalSizeFn = func(fd uintptr) (int, int, error) {
+		return term.GetSize(fd)
+	}
+	activeConsoleFn = func() (string, error) {
+		data, err := os.ReadFile("/sys/class/tty/console/active")
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+)
+
+// prepareSerialTerminal gives hardware serial consoles a usable geometry
+// before Bubble Tea queries the terminal size. Hardware serial TTYs commonly
+// report 0x0 because they do not negotiate rows and columns like a PTY.
+func prepareSerialTerminal(ctx context.Context, cmdRunner runner.Runner) error {
+	width, height, err := terminalSizeFn(os.Stdout.Fd())
+	if err != nil || width != 0 || height != 0 {
+		return nil
+	}
+
+	activeConsole, err := activeConsoleFn()
+	if err != nil {
+		return fmt.Errorf("detecting active console: %w", err)
+	}
+	if !isSerialConsole(activeConsole) {
+		return nil
+	}
+
+	if _, err := cmdRunner.Run(ctx, "stty", "-F", serialConsolePath,
+		"rows", serialRows, "cols", serialColumns); err != nil {
+		return fmt.Errorf("setting serial console geometry: %w", err)
+	}
+	return nil
+}
+
+func isSerialConsole(active string) bool {
+	fields := strings.Fields(active)
+	if len(fields) == 0 {
+		return false
+	}
+
+	// /sys/class/tty/console/active lists active consoles in registration
+	// order; the last one is the console selected by the final console= kernel
+	// argument and therefore the device /dev/console refers to.
+	name := fields[len(fields)-1]
+	for _, prefix := range []string{"ttyS", "ttyUSB", "ttyACM", "ttyAMA"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/knuckle/terminal_test.go
+++ b/cmd/knuckle/terminal_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/projectbluefin/knuckle/internal/runner"
+)
+
+func TestPrepareSerialTerminalSetsFixedGeometry(t *testing.T) {
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 0, 0, nil },
+		func() (string, error) { return "ttyS0", nil },
+	)
+
+	spy := runner.NewSpyRunner()
+	if err := prepareSerialTerminal(context.Background(), spy); err != nil {
+		t.Fatalf("prepareSerialTerminal() error = %v", err)
+	}
+
+	if len(spy.Calls) != 1 {
+		t.Fatalf("expected one command, got %d: %+v", len(spy.Calls), spy.Calls)
+	}
+	want := []string{"-F", "/dev/console", "rows", "40", "cols", "80"}
+	call := spy.Calls[0]
+	if call.Name != "stty" {
+		t.Errorf("command = %q, want stty", call.Name)
+	}
+	if len(call.Args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.Args, want)
+	}
+	for i := range want {
+		if call.Args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, call.Args[i], want[i])
+		}
+	}
+}
+
+func TestPrepareSerialTerminalSkipsNonSerialConsole(t *testing.T) {
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 0, 0, nil },
+		func() (string, error) { return "tty0", nil },
+	)
+
+	spy := runner.NewSpyRunner()
+	if err := prepareSerialTerminal(context.Background(), spy); err != nil {
+		t.Fatalf("prepareSerialTerminal() error = %v", err)
+	}
+	if len(spy.Calls) != 0 {
+		t.Fatalf("expected no command, got %+v", spy.Calls)
+	}
+}
+
+func TestPrepareSerialTerminalSkipsSizedTerminal(t *testing.T) {
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 80, 24, nil },
+		func() (string, error) { return "ttyS0", nil },
+	)
+
+	spy := runner.NewSpyRunner()
+	if err := prepareSerialTerminal(context.Background(), spy); err != nil {
+		t.Fatalf("prepareSerialTerminal() error = %v", err)
+	}
+	if len(spy.Calls) != 0 {
+		t.Fatalf("expected no command, got %+v", spy.Calls)
+	}
+}
+
+func TestPrepareSerialTerminalSkipsSizeProbeErrors(t *testing.T) {
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 0, 0, errors.New("not a TTY") },
+		func() (string, error) { return "ttyS0", nil },
+	)
+
+	spy := runner.NewSpyRunner()
+	if err := prepareSerialTerminal(context.Background(), spy); err != nil {
+		t.Fatalf("prepareSerialTerminal() error = %v", err)
+	}
+	if len(spy.Calls) != 0 {
+		t.Fatalf("expected no command, got %+v", spy.Calls)
+	}
+}
+
+func TestPrepareSerialTerminalReportsConsoleDetectionError(t *testing.T) {
+	wantErr := errors.New("sysfs unavailable")
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 0, 0, nil },
+		func() (string, error) { return "", wantErr },
+	)
+
+	spy := runner.NewSpyRunner()
+	err := prepareSerialTerminal(context.Background(), spy)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if len(spy.Calls) != 0 {
+		t.Fatalf("expected no command, got %+v", spy.Calls)
+	}
+}
+
+func TestPrepareSerialTerminalReportsSttyError(t *testing.T) {
+	setTerminalHooks(t,
+		func(uintptr) (int, int, error) { return 0, 0, nil },
+		func() (string, error) { return "ttyUSB0", nil },
+	)
+
+	wantErr := errors.New("stty failed")
+	spy := runner.NewSpyRunner()
+	spy.StubError("stty -F /dev/console rows 40 cols 80", wantErr)
+	err := prepareSerialTerminal(context.Background(), spy)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestIsSerialConsole(t *testing.T) {
+	tests := []struct {
+		name   string
+		active string
+		want   bool
+	}{
+		{name: "serial", active: "ttyS0", want: true},
+		{name: "usb serial", active: "ttyUSB0", want: true},
+		{name: "acm serial", active: "ttyACM0", want: true},
+		{name: "arm serial", active: "ttyAMA0", want: true},
+		{name: "vga", active: "ttyS0 tty0", want: false},
+		{name: "empty", active: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSerialConsole(tt.active); got != tt.want {
+				t.Errorf("isSerialConsole(%q) = %v, want %v", tt.active, got, tt.want)
+			}
+		})
+	}
+}
+
+func setTerminalHooks(t *testing.T,
+	sizeFn func(uintptr) (int, int, error),
+	consoleFn func() (string, error),
+) {
+	t.Helper()
+	originalSizeFn := terminalSizeFn
+	originalConsoleFn := activeConsoleFn
+	terminalSizeFn = sizeFn
+	activeConsoleFn = consoleFn
+	t.Cleanup(func() {
+		terminalSizeFn = originalSizeFn
+		activeConsoleFn = originalConsoleFn
+	})
+}

--- a/docs/skills/tui.md
+++ b/docs/skills/tui.md
@@ -60,6 +60,18 @@ Multi-step wizard = `huh.Form` with `huh.Group` per step.
 - Do not assume bubbletea message types — read the source via Context7
 - Do not use `github.com/charmbracelet/` import paths — they are the old module location
 
+## Hardware serial consoles
+
+Bubble Tea sizes its renderer from the output TTY. A physical serial console
+can report `0x0` rows and columns because serial links do not negotiate PTY
+geometry. Before starting Bubble Tea, the CLI should check the output size and
+the active console, then repair only an active serial console with a fixed
+geometry (`stty -F /dev/console rows 40 cols 80`). Forty rows leave enough
+vertical space for the initial installer view while retaining a conventional
+80-column serial width. Route that command through
+`internal/runner`; do not invoke `exec.Command` from the TUI package. Non-serial
+consoles and already-sized terminals must remain untouched.
+
 ## Research notes
 
 See `docs/TUI-WIZARD-PATTERNS.md` for concrete examples derived from reading huh source.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/NVIDIA/go-nvlib v0.12.0
 	github.com/ProtonMail/go-crypto v1.4.1
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/coreos/butane v0.29.0
 	github.com/coreos/vcontext v0.0.0-20260306102053-7a68b5426c74
 	golang.org/x/crypto v0.54.0
@@ -24,7 +25,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clarketm/json v1.17.1 // indirect


### PR DESCRIPTION
<!--
Thanks for sending a PR to knuckle.

Contributors using AI agents (Claude Code, Copilot, Cursor, pi):
AGENTS.md at the repo root is the authoritative agent context for
this project. Read it before writing code, and have the agent
verify it ran `just ci` locally before opening the PR. The hive
workflow assumes agents have respected the package boundaries and
safety invariants documented there.
-->

## What
<!-- One or two sentences. What does this change? -->
This patch hardcodes a 80x40 serial console if it initially detects a 0x0-sized terminal, intended to be used for nodes like the pc-engines apu series, which only support serial input.

## Why
<!-- Link the issue this closes (Closes #123) or describe the motivation. -->

Closes #872 

## How tested
<!-- Check at least one. -->
- [x] `just ci` is green locally
- [ ] `just vm-e2e` passes (end-to-end install + boot)
- [ ] `just headless-test` passes (for headless-mode changes)
- [x] Tested on real hardware — describe below
- [ ] Doc / template / CI change only — no install path touched

Tested on my pc-engines apu2c4 connected via a serial cable and `picocom`. The TUI didn't render previously, and now it draws consistently.

## Scope check
<!-- knuckle v1 supports single-disk, DHCP/static-IPv4, x86_64+arm64.
     Does this PR stay inside that scope? If it expands it, call out why. -->

## Notes for reviewers
<!-- Anything reviewers should know — risky areas, follow-ups, screenshots, etc. -->
---

I used Codex with `gpt-5.6-luna` to analyze the problem, then to create a fix.

<!-- For agents: mention what command you ran to verify, e.g.
     `just ci` exit 0, `just headless-test` exit 0. -->
