### PR TITLE
feat(quality): extract knuckle coverage patterns as org-wide templates

### DIFF
--- a/org-templates/README.md
+++ b/org-templates/README.md
@@ -1,0 +1,84 @@
+# Org test-quality templates
+
+Reusable, copy-paste test-quality patterns **extracted from
+[`projectbluefin/knuckle`](https://github.com/projectbluefin/knuckle)**, which
+runs a per-package coverage gate, Codecov, and 5x flaky-test detection in CI.
+
+This exists because of [issue #746](https://github.com/projectbluefin/knuckle/issues/746):
+other org repos (bootc-installer, testsuite, …) have lower coverage floors and
+can adopt knuckle's patterns without re-deriving them. Each artifact below is
+self-contained — copy it into your repo and adjust the numbers.
+
+## Artifacts
+
+| Artifact | What it is | Copy to your repo as |
+| -------- | ---------- | -------------------- |
+| [`coverage-gate/`](coverage-gate/) | Per-package Go coverage gate (script + config) | `scripts/coverage-gate.sh` + `coverage-gate.toml` |
+| [`codecov.yml`](codecov.yml) | Standardized Codecov config (project ≥70%, patch ≥70%) | `codecov.yml` |
+| [`actions/flaky-test-detect`](actions/flaky-test-detect/) | Composite action: run suite 5x, fail on any flake | `.github/actions/flaky-test-detect/action.yml` |
+
+## 1. Per-package coverage gate
+
+`coverage-gate/coverage-gate.sh` is a dependency-free (just `bash` + `go`) port
+of knuckle's `just cover-check`. It reads a `package:threshold` config, runs
+`go test -cover` per package, and exits non-zero if any package is below its
+gate or reports no coverage.
+
+```bash
+chmod +x coverage-gate.sh
+./coverage-gate.sh --config coverage-gate.toml   # or: ./coverage-gate.sh
+```
+
+Start from `coverage-gate.example.toml` (knuckle's own thresholds) and lower the
+gates to your repo's current coverage — set them **below** your real numbers so
+CI fails on regression, not on aspirational drift. Run `go test -cover ./...`
+to see current numbers.
+
+CI usage:
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+- uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+  with:
+    go-version: "1.26"
+- run: ./scripts/coverage-gate.sh --config coverage-gate.toml
+```
+
+> **Ponytail note:** this intentionally re-implements ~60 lines of shell rather
+> than depending on knuckle's Justfile recipe, because other repos aren't Go
+> monorepos with `just`. If your repo *is* knuckle-like, you can skip the script
+> and call `just cover-check` directly.
+
+## 2. Codecov config
+
+`codecov.yml` is knuckle's Codecov config with thresholds relaxed to the org
+floor (project ≥70%, patch ≥70%) and both status checks marked
+non-informational (so they block/flag on miss). Knuckle's stricter 95%/85%
+values are fine for knuckle itself but unrealistic for repos starting lower.
+
+See the header comments in the file for the full schema explanation.
+
+## 3. Flaky test detection
+
+`actions/flaky-test-detect/action.yml` is a composite action wrapping knuckle's
+"run the suite 5x, fail CI if any run fails" step (from `ci.yml::build-test`).
+It's parameterized on run count and test command so it works for `go`, `pytest`,
+etc.
+
+```yaml
+- name: Detect flaky tests
+  uses: ./.github/actions/flaky-test-detect
+  with:
+    run_count: 5
+    test_cmd: "go test -count=1 ./..."
+```
+
+Set `fail_on_flake: false` to run it report-only while you build confidence.
+
+## Adopting across the org
+
+1. Copy the artifact(s) you want into your repo.
+2. Run the gate locally to capture current numbers, then set gates below them.
+3. Wire the gate + Codecov + flaky-detect into a CI job (pin every action by
+   version, set `contents: read`, `persist-credentials: false`).
+4. Raise gates over time as coverage improves.

--- a/org-templates/actions/flaky-test-detect/action.yml
+++ b/org-templates/actions/flaky-test-detect/action.yml
@@ -1,0 +1,49 @@
+name: "Flaky Test Detect"
+description: "Run the test suite N times and fail CI if any run fails, to catch flaky tests instead of silently ignoring them."
+author: "projectbluefin/knuckle"
+
+inputs:
+  run_count:
+    description: "How many times to run the suite. Knuckle uses 5."
+    required: false
+    default: "5"
+  test_cmd:
+    description: "The test command to run each pass. Knuckle uses 'go test -count=1 ./...'."
+    required: false
+    default: "go test -count=1 ./..."
+  fail_on_flake:
+    description: "Exit non-zero (fail CI) when a flake is detected. Set false to only warn."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect flaky tests
+      shell: bash
+      env:
+        RUN_COUNT: ${{ inputs.run_count }}
+        TEST_CMD: ${{ inputs.test_cmd }}
+        FAIL_ON_FLAKE: ${{ inputs.fail_on_flake }}
+      run: |
+        set -euo pipefail
+        flaky_detected=0
+        for i in $(seq 1 "$RUN_COUNT"); do
+          echo "────────────────────────────────────────"
+          echo "Run $i/$RUN_COUNT ..."
+          if ! eval "$TEST_CMD" > "/tmp/flake_run_$i.log" 2>&1; then
+            echo "::warning::Run $i failed — possible flaky test."
+            tail -n 20 "/tmp/flake_run_$i.log" || true
+            flaky_detected=1
+          fi
+        done
+        if [[ "$flaky_detected" -eq 1 ]]; then
+          if [[ "$FAIL_ON_FLAKE" == "true" ]]; then
+            echo "::error::Potential flaky tests detected — some runs failed. Check logs above."
+            echo "Failing CI so flaky tests are not silently ignored."
+            exit 1
+          fi
+          echo "::warning::Potential flaky tests detected (report-only mode)."
+          exit 0
+        fi
+        echo "✓ All $RUN_COUNT runs passed — no flaky tests detected"

--- a/org-templates/codecov.yml
+++ b/org-templates/codecov.yml
@@ -1,0 +1,44 @@
+# Standardized Codecov config template for org repos.
+#
+# Adopted from knuckle's codecov.yml. Thresholds are set to the org floor
+# (project >= 70%, patch >= 70%) rather than knuckle's stricter 95%/85% —
+# knuckle already meets those; other repos start at the floor and raise their
+# own gates over time. Keep both status checks NON-informational so Codecov
+# blocks/flags the check when the thresholds are missed.
+#
+# Copy to codecov.yml at your repo root. See
+# https://docs.codecov.com/docs/codecov-yaml for the full schema.
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    after_n_builds: 1
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    # Overall project coverage. informational: false => this is a required,
+    # blocking status check. Set to >=70% org floor; raise per repo.
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+        informational: false
+    # Coverage of changed lines in the diff. Blocks merges that add
+    # untested code.
+    patch:
+      default:
+        target: 70%
+        informational: false
+
+  # Per-file ceilings stop a tiny untested helper from tanking the project
+  # number; set informational: true to only warn, or remove entirely.
+  changes:
+    informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true

--- a/org-templates/coverage-gate/coverage-gate.example.toml
+++ b/org-templates/coverage-gate/coverage-gate.example.toml
@@ -1,0 +1,28 @@
+# Example per-package coverage gate config.
+# Copy to coverage-gate.toml (or pass --config) and adjust thresholds to your
+# repo. Format: one `package:threshold` per line. Package paths are passed to
+# `go test` verbatim as `<pkg>/...` (use "." for the module root). Thresholds
+# are whole percentages 0-100. Lines starting with # and blank lines are ignored.
+#
+# Gates are set conservatively BELOW current coverage so CI fails on
+# regression, not on aspirational drift (see knuckle docs/CI-AND-TESTING.md).
+#
+# This is knuckle's own gate, exported as a reusable template.
+internal/model:100
+internal/validate:99
+internal/ignition:100
+internal/github:96
+internal/bakery:100
+internal/probe:100
+internal/runner:100
+internal/install:100
+internal/headless:99
+internal/wizard:99
+internal/iso:100
+internal/tui:99
+internal/demo:100
+internal/fcos:100
+scripts/catalog_check:100
+cmd/knuckle:85
+cmd/compile-butane-fresh:100
+cmd/nvidia-check:95

--- a/org-templates/coverage-gate/coverage-gate.sh
+++ b/org-templates/coverage-gate/coverage-gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# coverage-gate.sh — per-package Go coverage gate, extracted from knuckle's
+# `just cover-check` so other org repos can adopt the same pattern without
+# depending on `just` or knuckle's exact package layout.
+#
+# Usage:
+#   coverage-gate.sh [--config FILE]
+#
+# Config format (one `package:threshold` per line, `#` starts a comment,
+# blank lines ignored). Package paths are passed to `go test` as `<pkg>/...`.
+# Thresholds are whole-percentage integers (0-100).
+#
+# Exit code is non-zero if any package reports no coverage or falls below its
+# threshold — the same "fail CI on regression" contract knuckle uses in CI.
+#
+# This uses statement-count coverage from `go test -cover` (not the
+# function-average Codecov reports), matching knuckle's gate.
+set -euo pipefail
+
+config=""
+args=("$@")
+i=0
+while (( i < ${#args[@]} )); do
+  arg="${args[$i]}"
+  case "$arg" in
+    --config)
+      i=$((i + 1))
+      config="${args[$i]:?--config requires a value}"
+      ;;
+    --config=*)
+      config="${arg#*=}"
+      ;;
+    *)
+      echo "usage: coverage-gate.sh [--config FILE]" >&2
+      exit 2
+      ;;
+  esac
+  i=$((i + 1))
+done
+
+if [[ -z "$config" ]]; then
+  for candidate in coverage-gate.toml coverage-gate.conf coverage-gate.cfg; do
+    if [[ -f "$candidate" ]]; then config="$candidate"; break; fi
+  done
+fi
+
+if [[ -z "$config" || ! -f "$config" ]]; then
+  echo "coverage-gate: no config found (looked for --config or coverage-gate.{toml,conf,cfg})" >&2
+  exit 2
+fi
+
+# Parse coverage percentage out of `go test` output. `go test` prints e.g.
+# "coverage: 95.5% of statements"; the value is the third field from the end.
+parse_pct() {
+  awk '/coverage:/ {gsub("%",""); print $(NF-2); exit}'
+}
+
+fail=0
+checked=0
+while IFS= read -r raw || [[ -n "$raw" ]]; do
+  # strip comments and surrounding whitespace
+  line="${raw%%#*}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  [[ -z "$line" ]] && continue
+
+  # split on the last ':' (package paths contain no colon; thresholds are numeric)
+  pkg="${line%:*}"
+  thr="${line#*:}"
+  # trim whitespace again after split
+  pkg="${pkg#"${pkg%%[![:space:]]*}"}"
+  pkg="${pkg%"${pkg##*[![:space:]]}"}"
+  thr="${thr#"${thr%%[![:space:]]*}"}"
+  thr="${thr%"${thr##*[![:space:]]}"}"
+
+  if [[ "$pkg" != *"/"* && "$pkg" != "." ]]; then
+    echo "coverage-gate: skipping malformed line (no package path): '$line'" >&2
+    fail=1
+    continue
+  fi
+  if ! [[ "$thr" =~ ^[0-9]+$ ]] || (( thr < 0 || thr > 100 )); then
+    echo "coverage-gate: skipping malformed threshold (not 0-100): '$line'" >&2
+    fail=1
+    continue
+  fi
+
+  pct="$(go test -count=1 -cover "./${pkg}/..." 2>/dev/null | parse_pct)"
+  pct="${pct%.*}"
+  checked=$((checked + 1))
+
+  if [[ -z "$pct" ]]; then
+    echo "FAIL  ${pkg}   no coverage reported (target ${thr}%)"
+    fail=1
+  elif (( pct < thr )); then
+    echo "FAIL  ${pkg}  ${pct}%  (target ${thr}%)"
+    fail=1
+  else
+    echo "ok    ${pkg}  ${pct}%  (target ${thr}%)"
+  fi
+done < "$config"
+
+echo "coverage-gate: ${checked} package(s) checked from ${config}"
+exit "$fail"


### PR DESCRIPTION
Resolves #746 — recommend adopting knuckle's coverage patterns across org repos.

This tracking/advisory issue asked for knuckle's test-quality patterns to be
extracted into reusable, org-wide templates. The artifacts below are
self-contained and copy-paste into any org repo (bootc-installer, testsuite, ...)
without depending on knuckle's `just` layout.

## What's shipped (under `org-templates/`)

1. **Per-module coverage gates** — `coverage-gate/coverage-gate.sh`, a
   dependency-free (bash + go) port of `just cover-check`. Reads a
   `package:threshold` config, runs `go test -cover` per package, and fails CI
   on regression or missing coverage. See `coverage-gate.example.toml` for
   knuckle's own thresholds as a starting point.
2. **Codecov config template** — `codecov.yml`, standardized at the org floor
   (project target >=70%, patch >=70%), both status checks non-informational so
   they block on miss.
3. **Flaky test detection** — `actions/flaky-test-detect/action.yml`, a
   composite action wrapping knuckle's 5x suite re-run that fails CI on any
   flake (parameterized on run count + test command).

Plus `org-templates/README.md` with adoption steps.

The coverage-gate script was verified locally against knuckle's real packages
(all 18 pass) and its failure/malformed-config paths.

— hive: backend=pi model=lemonade/Ornith-1.5-35B-A3B-GGUF-Q6_K
