### PR TITLE
[sec-check] pin just install fallback with tarball + SHA256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,13 @@ jobs:
         id: setup-just-action
       - name: install just (fallback if setup-just action fails)
         if: steps.setup-just-action.outcome == 'failure'
-        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.58.0
+          JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
+          curl -fsSL -o /tmp/just.tar.gz "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${JUST_SHA256}  /tmp/just.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tar.gz -C /usr/local/bin just
+          rm /tmp/just.tar.gz
 
       - name: per-package coverage thresholds
         run: just cover-check
@@ -179,7 +185,13 @@ jobs:
         id: setup-just-action-e2e
       - name: install just (fallback if setup-just action fails)
         if: steps.setup-just-action-e2e.outcome == 'failure'
-        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.58.0
+          JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
+          curl -fsSL -o /tmp/just.tar.gz "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${JUST_SHA256}  /tmp/just.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tar.gz -C /usr/local/bin just
+          rm /tmp/just.tar.gz
 
       - name: headless dry-run
         run: just headless-test
@@ -206,7 +218,13 @@ jobs:
         id: setup-just-action-iso
       - name: install just (fallback if setup-just action fails)
         if: steps.setup-just-action-iso.outcome == 'failure'
-        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.58.0
+          JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
+          curl -fsSL -o /tmp/just.tar.gz "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${JUST_SHA256}  /tmp/just.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tar.gz -C /usr/local/bin just
+          rm /tmp/just.tar.gz
 
       - name: build knuckle binary (amd64)
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,13 @@ jobs:
         id: setup-just-action
       - name: install just (fallback)
         if: steps.setup-just-action.outcome == 'failure'
-        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.58.0
+          JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
+          curl -fsSL -o /tmp/just.tar.gz "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${JUST_SHA256}  /tmp/just.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tar.gz -C /usr/local/bin just
+          rm /tmp/just.tar.gz
 
       - name: per-package coverage gate
         run: just cover-check


### PR DESCRIPTION
Closes #879

Pins the four `install just` fallback steps (ci.yml x3: coverage/bats/vm-e2e-prep; nightly.yml x1) to a pinned 1.58.0 release tarball with SHA256 verification, replacing the unpinned `curl just.systems/install.sh | bash`.

— hive: backend=pi model=lemonade/Ornith-1.5-35B-A3B-GGUF-Q6_K
