### PR TITLE
fix(drive-demo): use -x not -f for binary discovery + trap to clean FIFO

### DIFF
--- a/scripts/drive-demo.sh
+++ b/scripts/drive-demo.sh
@@ -17,7 +17,7 @@ set -u
 
 BINARY=""
 for candidate in "bin/knuckle" "./knuckle"; do
-    if [[ -f "$candidate" ]]; then
+    if [[ -x "$candidate" ]]; then
         BINARY="$candidate"
         break
     fi
@@ -29,6 +29,7 @@ fi
 
 FIFO=$(mktemp -u)
 mkfifo "$FIFO"
+trap 'rm -f "$FIFO"' EXIT
 
 # --demo: mock hardware/catalog, implies --dry-run (no real writes)
 "$BINARY" --demo < "$FIFO" &


### PR DESCRIPTION
## Problem

The discovery loop in `scripts/drive-demo.sh` tested `-f` (existence) instead of `-x` (executable). An unexecutable `bin/knuckle` (stale artifact, partial copy, checkout with lost permission bits) was still selected, so the subsequent `"$BINARY" --demo < "$FIFO" &` failed with `Permission denied`. Nothing opened the read end of the FIFO, the first `send` died on SIGPIPE, and the script exited 141 before reaching `rm -f "$FIFO"`. Each such run leaked a stale FIFO in \`TMPDIR\`.

## Fix

1. Use `[[ -x "$candidate" ]]` in the discovery loop so an unexecutable candidate falls through to the existing not-found message and exit 1.
2. Install `trap 'rm -f "$FIFO"' EXIT` right after `mkfifo` so the FIFO is removed on every exit path, not just the happy one.

Fixes #884

---

— hive: backend=pi model=lemonade/Ornith-1.5-35B-A3B-GGUF-Q6_K
---
🐝 **Hive Agent**: `contributor` | **SHA:** `3cfe9fa`