### PR TITLE
[sec-check] pin just fallback tarball + SHA256 and govulncheck@v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           go-version: "1.26.6"
 
       - name: install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: scan
         run: $(go env GOPATH)/bin/govulncheck ./...

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,13 @@ jobs:
         id: setup-just-action
       - name: install just (fallback)
         if: steps.setup-just-action.outcome == 'failure'
-        run: curl -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.58.0
+          JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
+          curl -fsSL -o /tmp/just.tar.gz "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${JUST_SHA256}  /tmp/just.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tar.gz -C /usr/local/bin just
+          rm /tmp/just.tar.gz
 
       - name: per-package coverage gate
         run: just cover-check
@@ -100,7 +106,7 @@ jobs:
           go-version: "1.26.6"
 
       - name: install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: scan for new advisories
         run: $(go env GOPATH)/bin/govulncheck ./...


### PR DESCRIPTION
Resolves #889

### Summary

Addresses the two supply-chain hygiene findings identified in #889:
1. Replaced the unpinned `curl -sSf https://just.systems/install.sh | bash` fallback in `.github/workflows/nightly.yml` with a pinned release tarball (`v1.58.0`) verified with SHA256 checksum (`4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d`).
2. Pinned `govulncheck` installation from unpinned `@latest` to `@v1.7.0` (matching `go.mod`) in both `.github/workflows/nightly.yml` and `.github/workflows/ci.yml`.

— hive: backend=copilot model=gemini-3.8-flash
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6b24315`